### PR TITLE
Update .licenserc.yaml

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -26,4 +26,4 @@ header:
   paths:
     - '**/*.rs'
 
-comment: on-failure
+  comment: on-failure

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -1,30 +1,29 @@
 header:
   license:
-    spdx-id: AGPL-3.0-or-later
-    copyright-owner: Quickwit Inc.
+    content: | # <4>
+      Copyright (C) 2021 Quickwit Inc.
 
-  content: | # <4>
-    Copyright (C) 2021 Quickwit Inc.
+      Quickwit is offered under the AGPL v3.0 and as commercial software.
+      For commercial licensing, contact us at hello@quickwit.io.
 
-    Quickwit is offered under the AGPL v3.0 and as commercial software.
-    For commercial licensing, contact us at hello@quickwit.io.
+      AGPL:
+      This program is free software: you can redistribute it and/or modify
+      it under the terms of the GNU Affero General Public License as
+      published by the Free Software Foundation, either version 3 of the
+      License, or (at your option) any later version.
 
-    AGPL:
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation, either version 3 of the
-    License, or (at your option) any later version.
+      This program is distributed in the hope that it will be useful,
+      but WITHOUT ANY WARRANTY; without even the implied warranty of
+      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+      GNU Affero General Public License for more details.
 
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
+      You should have received a copy of the GNU Affero General Public License
+      along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-    You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
-  pattern: |
+    pattern: |
       Copyright \(C\) 2021 Quickwit Inc\..*commercial.*AGPL
+
   paths:
     - '**/*.rs'
-  comment: on-failure
+
+comment: on-failure


### PR DESCRIPTION
Fix `licensers.yaml`, some indentations are not correct, and the spdx-id is not needed if you have customized license header.