### PR TITLE
Restrict CI to Rust files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,10 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'Cargo.lock'
+      - 'Cargo.toml'
+      - 'quickwit-*/**'
 
 name: CI
 


### PR DESCRIPTION
### Description
Restrict CI to Rust files so that CI does not run unnecessarily.