### PR TITLE
Add `exists` method to `Storage` trait

### DIFF
--- a/storage/src/error.rs
+++ b/storage/src/error.rs
@@ -26,13 +26,13 @@ use thiserror::Error;
 /// Storage error kind.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum StorageErrorKind {
-    /// The target index does not exists
+    /// The target index does not exist.
     DoesNotExist,
     /// The request credentials do not allow for this operation.
     Unauthorized,
     /// A third-party service forbids this operation.
     Service,
-    /// Any generic internal error
+    /// Any generic internal error.
     InternalError,
     /// Io error.
     Io,

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -123,6 +123,16 @@ pub(crate) mod tests {
         Ok(())
     }
 
+    async fn test_exists(storage: &mut dyn Storage) -> anyhow::Result<()> {
+        let test_path = Path::new("exists");
+        assert!(matches!(storage.exists(test_path).await, Ok(false)));
+        storage
+            .put(test_path, PutPayload::from(b"".as_ref()))
+            .await?;
+        assert!(matches!(storage.exists(test_path).await, Ok(true)));
+        Ok(())
+    }
+
     pub async fn storage_test_suite(storage: &mut dyn Storage) -> anyhow::Result<()> {
         test_get_inexistent_file(storage)
             .await
@@ -139,6 +149,7 @@ pub(crate) mod tests {
         test_write_and_delete(storage)
             .await
             .with_context(|| "write_and_delete")?;
+        test_exists(storage).await.with_context(|| "exists")?;
         Ok(())
     }
 }

--- a/storage/src/object_storage/error.rs
+++ b/storage/src/object_storage/error.rs
@@ -27,13 +27,14 @@ use std::io;
 use rusoto_core::RusotoError;
 use rusoto_s3::{
     AbortMultipartUploadError, CompleteMultipartUploadError, CreateMultipartUploadError,
-    DeleteObjectError, GetObjectError, PutObjectError, UploadPartError,
+    DeleteObjectError, GetObjectError, HeadObjectError, PutObjectError, UploadPartError,
 };
 
 use crate::retry::IsRetryable;
 use crate::{StorageError, StorageErrorKind};
 
-pub struct RusotoErrorWrapper<T: StdError>(RusotoError<T>);
+pub struct RusotoErrorWrapper<T: StdError>(pub RusotoError<T>);
+
 impl<T: StdError> From<RusotoError<T>> for RusotoErrorWrapper<T> {
     fn from(err: RusotoError<T>) -> Self {
         RusotoErrorWrapper(err)
@@ -144,6 +145,12 @@ impl ToStorageErrorKind for CreateMultipartUploadError {
 }
 
 impl ToStorageErrorKind for PutObjectError {
+    fn to_storage_error_kind(&self) -> StorageErrorKind {
+        StorageErrorKind::Service
+    }
+}
+
+impl ToStorageErrorKind for HeadObjectError {
     fn to_storage_error_kind(&self) -> StorageErrorKind {
         StorageErrorKind::Service
     }

--- a/storage/src/object_storage/s3_compatible_storage.rs
+++ b/storage/src/object_storage/s3_compatible_storage.rs
@@ -132,7 +132,7 @@ pub fn parse_split_uri(split_uri: &str) -> Option<(String, PathBuf)> {
     static SPLIT_URI_PTN: OnceCell<Regex> = OnceCell::new();
     SPLIT_URI_PTN
         .get_or_init(|| {
-            // s3://quickwit-dev/quickwit/quickwit-dev-stream/02fba1b7-8344-44b3-bd9f-019c57021dd7
+            // s3://bucket/path/to/split
             Regex::new(r"s3://(?P<bucket>[^/]+)/(?P<path>.*)").unwrap()
         })
         .captures(split_uri)
@@ -600,8 +600,8 @@ mod tests {
     #[test]
     fn test_parse_split_uri() {
         assert_eq!(
-            parse_split_uri("s3://quickwit-dev/quickwit/quickwit-dev-stream/02fba1b7-8344-44b3-bd9f-019c57021dd7"),
-            Some(("quickwit-dev".to_string(), PathBuf::from("quickwit/quickwit-dev-stream/02fba1b7-8344-44b3-bd9f-019c57021dd7") ))
+            parse_split_uri("s3://bucket/path/to/object"),
+            Some(("bucket".to_string(), PathBuf::from("path/to/object")))
         );
     }
 }

--- a/storage/src/ram_storage.rs
+++ b/storage/src/ram_storage.rs
@@ -109,6 +109,10 @@ impl Storage for RamStorage {
         Ok(payload_bytes.to_vec())
     }
 
+    async fn exists(&self, path: &Path) -> StorageResult<bool> {
+        Ok(self.files.read().await.contains_key(path))
+    }
+
     fn uri(&self) -> String {
         "ram://".to_string()
     }

--- a/storage/src/storage.rs
+++ b/storage/src/storage.rs
@@ -88,7 +88,7 @@ pub trait Storage: Send + Sync + 'static {
     /// For large files prefer `copy_to_file`.
     async fn get_all(&self, path: &Path) -> StorageResult<Vec<u8>>;
 
-    /// Delete file
+    /// Deletes a file.
     async fn delete(&self, path: &Path) -> StorageResult<()>;
 
     /// Returns whether a file exists or not.

--- a/storage/src/storage.rs
+++ b/storage/src/storage.rs
@@ -91,6 +91,9 @@ pub trait Storage: Send + Sync + 'static {
     /// Delete file
     async fn delete(&self, path: &Path) -> StorageResult<()>;
 
+    /// Returns whether a file exists or not.
+    async fn exists(&self, path: &Path) -> StorageResult<bool>;
+
     /// Returns an URI identifying the storage
     fn uri(&self) -> String;
 }


### PR DESCRIPTION
### Context / purpose
Backporting this patch from the Common Crawl repo. I fixed a few things while I was at it (doc, missing retries).

### Description
The implementation is trivial for ram storage. For S3, we issue a head object request. A `404` or `NoSuchKey` response means that the object does not exist.

It is used in CommonCrawl to check for the presence of a success file.

### How was this PR tested?
The patch was tested while I was building the Common Crawl index. That's how I found out about the Rusoto bug.

### Checklist
- [x] tested locally
- [x] added unit tests
- [x] included documentation
