### PR TITLE
Add hot-directory module from barrel

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "quickwit-cli",
   "quickwit-core",
   "quickwit-doc-mapping",
+  "quickwit-hot-directory",
   "quickwit-metastore",
   "quickwit-storage",
 ]

--- a/quickwit-cli/src/main.rs
+++ b/quickwit-cli/src/main.rs
@@ -22,7 +22,7 @@
 
 use anyhow::bail;
 use byte_unit::Byte;
-use clap::{load_yaml, value_t, App, ArgMatches};
+use clap::{load_yaml, value_t, App, AppSettings, ArgMatches};
 use std::path::PathBuf;
 use tracing::debug;
 
@@ -215,7 +215,9 @@ async fn main() {
     tracing_subscriber::fmt::init();
 
     let yaml = load_yaml!("cli.yaml");
-    let app = App::from(yaml).version(env!("CARGO_PKG_VERSION"));
+    let app = App::from(yaml)
+        .setting(AppSettings::ArgRequiredElseHelp)
+        .version(env!("CARGO_PKG_VERSION"));
     let matches = app.get_matches();
 
     let command = match CliCommand::parse_cli_args(&matches) {

--- a/quickwit-cli/src/main.rs
+++ b/quickwit-cli/src/main.rs
@@ -68,7 +68,8 @@ enum CliCommand {
 impl CliCommand {
     fn parse_cli_args(matches: &ArgMatches) -> anyhow::Result<Self> {
         let (subcommand, submatches_opt) = matches.subcommand();
-        let submatches = submatches_opt.unwrap();
+        let submatches =
+            submatches_opt.ok_or_else(|| anyhow::anyhow!("Unable to parse sub matches"))?;
 
         match subcommand {
             "new" => Self::parse_new_args(submatches),

--- a/quickwit-hot-directory/Cargo.toml
+++ b/quickwit-hot-directory/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "quickwit-hot-directory"
+version = "0.1.0"
+authors = ["Quickwit, Inc. <hello@quickwit.io>"]
+edition = "2018"
+license = "AGPL-3.0-or-later" # For a commercial, license, contact hello@quickwit.io
+
+[dependencies]
+attohttpc = { version = "0.16", default-features = false, features = ["json"] }
+crossbeam = "0.8"
+futures = "0.3"
+iobuffer = "0.2"
+rusoto_s3 = { version = "0.46", default-features = false, features = [
+  "rustls"
+] }
+rusoto_core = { version = "0.46", default-features = false, features = [
+  "rustls"
+] }
+serde = "1"
+serde_cbor = "0.11"
+serde_json = "1"
+structopt = "0.3"
+tantivy = { git= "https://github.com/quickwit-inc/tantivy", branch = "async", features = ["lz4-compression"] }
+quickwit-storage = { version = "0.1.0", path = "../quickwit-storage" }
+uuid = "0.8"
+once_cell = "1"
+lru = "0.6"
+tokio = { version = "1", features = ["sync"] }
+tracing = "0.1"
+tracing-subscriber = "0.2"
+thiserror = "1"
+flume = "0.10"
+anyhow = "1"
+async-trait = "0.1"
+chrono = "0.4"
+
+[dev-dependencies]
+tracing-subscriber = "0.2"

--- a/quickwit-hot-directory/src/caching_directory.rs
+++ b/quickwit-hot-directory/src/caching_directory.rs
@@ -1,0 +1,336 @@
+/*
+    Quickwit
+    Copyright (C) 2021 Quickwit Inc.
+
+    Quickwit is offered under the AGPL v3.0 and as commercial software.
+    For commercial licensing, contact us at hello@quickwit.io.
+
+    AGPL:
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+use async_trait::async_trait;
+use lru::LruCache;
+use std::fmt;
+use std::io;
+use std::ops::Range;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use tantivy::directory::error::{DeleteError, OpenReadError, OpenWriteError};
+use tantivy::directory::{FileHandle, OwnedBytes, WatchHandle, WritePtr};
+use tantivy::{AsyncIoResult, Directory, HasLen};
+use tracing::warn;
+
+#[derive(Hash, Debug, Clone, PartialEq, Eq)]
+struct SliceAddress {
+    path: PathBuf,
+    byte_range: Range<usize>,
+}
+
+struct NeedMutCache {
+    lru_cache: LruCache<SliceAddress, OwnedBytes>,
+    num_bytes: usize,
+    capacity_in_bytes: usize,
+}
+
+impl NeedMutCache {
+    pub fn with_capacity_in_bytes(capacity_in_bytes: usize) -> Self {
+        NeedMutCache {
+            // The limit will be decided by the amount of memory in the cache,
+            // not the number of items in the cache.
+            // Enforcing this limit is done in the `NeedMutCache` impl.
+            lru_cache: LruCache::unbounded(),
+            num_bytes: 0,
+            capacity_in_bytes,
+        }
+    }
+
+    fn get(&mut self, cache_key: &SliceAddress) -> Option<OwnedBytes> {
+        self.lru_cache.get(cache_key).cloned()
+    }
+
+    /// Attempt to put the given amount of data in the cache.
+    /// This may fail silently if the owned_bytes slice is larger than the cache
+    /// capacity.
+    fn put(&mut self, slice_addr: SliceAddress, owned_bytes: OwnedBytes) {
+        if owned_bytes.len() > self.capacity_in_bytes {
+            // The value does not fit in the cache. We simply don't store it.
+            warn!(
+                capacity_in_bytes = self.capacity_in_bytes,
+                len = owned_bytes.len(),
+                "Downloaded a byte slice larger than the cache capacity."
+            );
+            return;
+        }
+        if let Some(previous_data) = self.lru_cache.pop(&slice_addr) {
+            self.num_bytes -= previous_data.len();
+        }
+        while self.num_bytes + owned_bytes.len() >= self.capacity_in_bytes {
+            if let Some((_, bytes)) = self.lru_cache.pop_lru() {
+                self.num_bytes -= bytes.len();
+            } else {
+                return;
+            }
+        }
+        self.num_bytes += owned_bytes.len();
+        self.lru_cache.put(slice_addr, owned_bytes);
+    }
+}
+
+pub struct Cache {
+    inner: Mutex<NeedMutCache>,
+}
+
+impl Cache {
+    pub fn with_capacity_in_bytes(capacity_in_bytes: usize) -> Self {
+        Cache {
+            inner: Mutex::new(NeedMutCache::with_capacity_in_bytes(capacity_in_bytes)),
+        }
+    }
+
+    fn get(&self, cache_key: &SliceAddress) -> Option<OwnedBytes> {
+        self.inner.lock().unwrap().get(cache_key)
+    }
+
+    /// Attempt to put the given amount of data in the cache.
+    /// This may fail silently if the owned_bytes slice is larger than the cache
+    /// capacity.
+    fn put(&self, slice_addr: SliceAddress, owned_bytes: OwnedBytes) {
+        self.inner.lock().unwrap().put(slice_addr, owned_bytes);
+    }
+}
+
+/// The caching directory is a simple cache that wraps another directory.
+#[derive(Clone)]
+pub struct CachingDirectory {
+    underlying: Arc<dyn Directory>,
+    // TODO fixme: that's a pretty ugly cache we have here.
+    cache: Arc<Cache>,
+    filter_suffix: String,
+}
+
+impl CachingDirectory {
+    /// Creates a new  CachingDirectory.
+    /// `capacity_in_bytes` acts as a memory budget for the directory.
+    ///
+    /// The implementation is voluntarily very naive as it was design solely to
+    /// address Quickwit's requirements.
+    /// Most notably, if two reads targetting the same read on the same path
+    /// happen concurrently, the read will be executed twice.
+    ///
+    /// The overall number of bytes held in memory may exceed the capacity at one point
+    /// if a read request is large than `capacity_in_bytes`.
+    /// In that case, the read payload will not be saved in the cache.
+    pub fn new_with_capacity_in_bytes(
+        underlying: Arc<dyn Directory>,
+        capacity_in_bytes: usize,
+        filter_suffix: String,
+    ) -> CachingDirectory {
+        CachingDirectory {
+            underlying,
+            cache: Arc::new(Cache::with_capacity_in_bytes(capacity_in_bytes)),
+            filter_suffix,
+        }
+    }
+
+    pub fn new_with_cache(
+        underlying: Arc<dyn Directory>,
+        cache: Arc<Cache>,
+        filter_suffix: String,
+    ) -> CachingDirectory {
+        CachingDirectory {
+            underlying,
+            cache,
+            filter_suffix,
+        }
+    }
+}
+
+impl fmt::Debug for CachingDirectory {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "CachingDirectory({:?})", self.underlying)
+    }
+}
+
+struct CachingFileHandle {
+    path: PathBuf,
+    cache: Arc<Cache>,
+    underlying_filehandle: Box<dyn FileHandle>,
+}
+
+impl fmt::Debug for CachingFileHandle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "CachingFileHandle(path={:?}, underlying={:?})",
+            &self.path,
+            self.underlying_filehandle.as_ref()
+        )
+    }
+}
+
+#[async_trait]
+impl FileHandle for CachingFileHandle {
+    fn read_bytes(&self, byte_range: Range<usize>) -> io::Result<OwnedBytes> {
+        let cache_key = SliceAddress {
+            path: self.path.clone(),
+            byte_range: byte_range.clone(),
+        };
+        if let Some(owned_bytes) = self.cache.get(&cache_key) {
+            return Ok(owned_bytes);
+        }
+        let owned_bytes = self.underlying_filehandle.read_bytes(byte_range)?;
+        self.cache.put(cache_key, owned_bytes.clone());
+        Ok(owned_bytes)
+    }
+
+    fn get_physical_address(&self, range: Range<usize>) -> Option<String> {
+        self.underlying_filehandle.get_physical_address(range)
+    }
+
+    async fn read_bytes_async(&self, byte_range: Range<usize>) -> AsyncIoResult<OwnedBytes> {
+        let cache_key = SliceAddress {
+            path: self.path.clone(),
+            byte_range: byte_range.clone(),
+        };
+        if let Some(owned_bytes) = self.cache.get(&cache_key) {
+            return Ok(owned_bytes);
+        }
+        let read_bytes = self
+            .underlying_filehandle
+            .read_bytes_async(byte_range)
+            .await?;
+        self.cache.put(cache_key, read_bytes.clone());
+        Ok(read_bytes)
+    }
+}
+
+impl HasLen for CachingFileHandle {
+    fn len(&self) -> usize {
+        self.underlying_filehandle.len()
+    }
+}
+
+impl Directory for CachingDirectory {
+    fn exists(&self, path: &Path) -> std::result::Result<bool, OpenReadError> {
+        self.underlying.exists(path)
+    }
+
+    fn get_file_handle(
+        &self,
+        path: &Path,
+    ) -> std::result::Result<Box<dyn FileHandle>, OpenReadError> {
+        let underlying_filehandle = self.underlying.get_file_handle(path)?;
+        if !path.to_string_lossy().ends_with(&self.filter_suffix) {
+            return Ok(underlying_filehandle);
+        }
+        let caching_file_handle = CachingFileHandle {
+            path: path.to_path_buf(),
+            cache: self.cache.clone(),
+            underlying_filehandle,
+        };
+        Ok(Box::new(caching_file_handle))
+    }
+
+    fn delete(&self, _path: &Path) -> std::result::Result<(), DeleteError> {
+        unimplemented!("read only");
+    }
+
+    fn open_write(&self, _path: &Path) -> std::result::Result<WritePtr, OpenWriteError> {
+        unimplemented!("read only");
+    }
+
+    fn atomic_read(&self, path: &Path) -> std::result::Result<Vec<u8>, OpenReadError> {
+        let file_handle = self.get_file_handle(path)?;
+        let len = file_handle.len();
+        let owned_bytes = file_handle
+            .read_bytes(0..len)
+            .map_err(|io_error| OpenReadError::wrap_io_error(io_error, path.to_path_buf()))?;
+        Ok(owned_bytes.as_slice().to_vec())
+    }
+
+    fn atomic_write(&self, _path: &Path, _data: &[u8]) -> io::Result<()> {
+        unimplemented!("read only");
+    }
+
+    fn watch(
+        &self,
+        _watch_callback: tantivy::directory::WatchCallback,
+    ) -> tantivy::Result<WatchHandle> {
+        Ok(WatchHandle::empty())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::{Cache, CachingDirectory};
+    use crate::caching_directory::SliceAddress;
+    use crate::DebugProxyDirectory;
+    use std::path::{Path, PathBuf};
+    use std::sync::Arc;
+    use tantivy::directory::{OwnedBytes, RAMDirectory};
+    use tantivy::Directory;
+
+    #[test]
+    fn test_cache() {
+        let cache = Cache::with_capacity_in_bytes(10_000);
+        let slice_address = SliceAddress {
+            path: PathBuf::from("hello.seg"),
+            byte_range: 1..3,
+        };
+        assert!(cache.get(&slice_address).is_none());
+        let data = OwnedBytes::new(&b"werwer"[..]);
+        cache.put(slice_address.clone(), data);
+        assert_eq!(
+            cache.get(&slice_address).unwrap().as_slice(),
+            &b"werwer"[..]
+        );
+    }
+
+    #[test]
+    fn test_cache_different_slice() {
+        let cache = Cache::with_capacity_in_bytes(10_000);
+        let mut slice_address = SliceAddress {
+            path: PathBuf::from("hello.seg"),
+            byte_range: 1..3,
+        };
+        assert!(cache.get(&slice_address).is_none());
+        let data = OwnedBytes::new(&b"werwer"[..]);
+        cache.put(slice_address.clone(), data);
+        slice_address.byte_range = 2..3;
+        assert!(cache.get(&slice_address).is_none());
+    }
+
+    #[test]
+    fn test_caching_directory() -> tantivy::Result<()> {
+        let ram_directory = RAMDirectory::default();
+        let test_path = Path::new("test");
+        ram_directory.atomic_write(test_path, &b"test"[..])?;
+        let debug_proxy_directory = Arc::new(DebugProxyDirectory::wrap(ram_directory));
+        let caching_directory = CachingDirectory::new_with_capacity_in_bytes(
+            debug_proxy_directory.clone(),
+            10_000,
+            "".to_string(),
+        );
+        caching_directory.atomic_read(test_path)?;
+        caching_directory.atomic_read(test_path)?;
+        let records: Vec<crate::ReadOperation> =
+            debug_proxy_directory.drain_read_operations().collect();
+        assert_eq!(records.len(), 1);
+        Ok(())
+    }
+
+    // TODO test eviction
+}

--- a/quickwit-hot-directory/src/debug_proxy_directory.rs
+++ b/quickwit-hot-directory/src/debug_proxy_directory.rs
@@ -1,0 +1,328 @@
+/*
+    Quickwit
+    Copyright (C) 2021 Quickwit Inc.
+
+    Quickwit is offered under the AGPL v3.0 and as commercial software.
+    For commercial licensing, contact us at hello@quickwit.io.
+
+    AGPL:
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+use crate::StorageDirectory;
+use async_trait::async_trait;
+use std::ops::Range;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use std::{fmt, io};
+use tantivy::chrono::{DateTime, Utc};
+use tantivy::directory::error::{DeleteError, LockError, OpenReadError, OpenWriteError};
+use tantivy::directory::{
+    DirectoryLock, FileHandle, OwnedBytes, WatchCallback, WatchHandle, WritePtr,
+};
+use tantivy::Directory;
+use tantivy::HasLen;
+
+/// A ReadOperation records meta data about a read operation.
+/// It is recorded by the `DebugProxyDirectory`.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct ReadOperation {
+    /// Path that was read
+    pub path: PathBuf,
+    /// If fetching a range of data, the start offset, else 0.
+    pub offset: usize,
+    /// The number of bytes fetched
+    pub num_bytes: usize,
+    /// The date at which the operation was performed.
+    pub start_date: DateTime<Utc>,
+    /// The elapsed time to run the read operatioon.
+    pub duration: Duration,
+}
+
+struct ReadOperationBuilder {
+    start_date: DateTime<Utc>,
+    start_instant: Instant,
+    path: PathBuf,
+    offset: usize,
+}
+
+impl ReadOperationBuilder {
+    pub fn new(path: &Path) -> Self {
+        let start_instant = Instant::now();
+        let start_date = Utc::now();
+        ReadOperationBuilder {
+            start_date,
+            start_instant,
+            path: path.to_path_buf(),
+            offset: 0,
+        }
+    }
+
+    pub fn with_offset(self, offset: usize) -> Self {
+        ReadOperationBuilder {
+            start_date: self.start_date,
+            start_instant: self.start_instant,
+            path: self.path,
+            offset,
+        }
+    }
+
+    fn terminate(self, num_bytes: usize) -> ReadOperation {
+        let duration = self.start_instant.elapsed();
+        ReadOperation {
+            path: self.path.clone(),
+            offset: self.offset,
+            num_bytes,
+            start_date: self.start_date,
+            duration,
+        }
+    }
+}
+
+/// The debug proxy wraps another directory and simply acts as a proxy
+/// recording all of its read operations.
+///
+/// It has two purpose
+/// - It is used when building our hotcache, to identify the file sections that
+/// should be in the hotcache.
+/// - It is used in the search-api to provide debugging/performance information.
+#[derive(Debug)]
+pub struct DebugProxyDirectory<D: Directory> {
+    underlying: Arc<D>,
+    operations_tx: flume::Sender<ReadOperation>,
+    operations_rx: flume::Receiver<ReadOperation>,
+}
+
+impl<D: Directory> Clone for DebugProxyDirectory<D> {
+    fn clone(&self) -> Self {
+        DebugProxyDirectory {
+            underlying: self.underlying.clone(),
+            operations_tx: self.operations_tx.clone(),
+            operations_rx: self.operations_rx.clone(),
+        }
+    }
+}
+
+impl<D: Directory> DebugProxyDirectory<D> {
+    /// Wraps another directory to log all of its read operations.
+    pub fn wrap(directory: D) -> Self {
+        let (operations_tx, operations_rx) = flume::unbounded();
+        DebugProxyDirectory {
+            underlying: Arc::new(directory),
+            operations_tx,
+            operations_rx,
+        }
+    }
+
+    /// Returns all of the existing read operations.
+    ///
+    /// Calling this "drains" the existing queue of operations.
+    pub fn drain_read_operations(&self) -> impl Iterator<Item = ReadOperation> + '_ {
+        self.operations_rx.drain()
+    }
+
+    /// Adds a new operation
+    fn register(&self, read_op: ReadOperation) {
+        let _ = self.operations_tx.send(read_op);
+    }
+
+    /// Adds a new operation in an async fashion.
+    async fn register_async(&self, read_op: ReadOperation) {
+        let _ = self.operations_tx.send_async(read_op).await;
+    }
+}
+
+struct DebugProxyFileHandle<D: Directory> {
+    directory: DebugProxyDirectory<D>,
+    underlying: Box<dyn FileHandle>,
+    path: PathBuf,
+}
+
+#[async_trait]
+impl<D: Directory> FileHandle for DebugProxyFileHandle<D> {
+    fn read_bytes(&self, byte_range: Range<usize>) -> io::Result<OwnedBytes> {
+        let read_operation_builder =
+            ReadOperationBuilder::new(&self.path).with_offset(byte_range.start);
+        let payload = self.underlying.read_bytes(byte_range)?;
+        let read_operation = read_operation_builder.terminate(payload.len());
+        self.directory.register(read_operation);
+        Ok(payload)
+    }
+
+    fn get_physical_address(&self, range: Range<usize>) -> Option<String> {
+        self.underlying.get_physical_address(range)
+    }
+
+    async fn read_bytes_async(
+        &self,
+        byte_range: Range<usize>,
+    ) -> tantivy::AsyncIoResult<OwnedBytes> {
+        let read_operation_builder =
+            ReadOperationBuilder::new(&self.path).with_offset(byte_range.start);
+        let payload = self.underlying.read_bytes_async(byte_range).await?;
+        let read_operation = read_operation_builder.terminate(payload.len());
+        self.directory.register_async(read_operation).await;
+        Ok(payload)
+    }
+}
+
+impl<D: Directory> fmt::Debug for DebugProxyFileHandle<D> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "DebugProxyFileHandle({:?})", &self.underlying)
+    }
+}
+
+impl<D: Directory> HasLen for DebugProxyFileHandle<D> {
+    fn len(&self) -> usize {
+        self.underlying.len()
+    }
+}
+
+impl<D: Directory> Directory for DebugProxyDirectory<D> {
+    fn get_file_handle(&self, path: &Path) -> Result<Box<dyn FileHandle>, OpenReadError> {
+        let underlying = self.underlying.get_file_handle(path)?;
+        Ok(Box::new(DebugProxyFileHandle {
+            underlying,
+            directory: self.clone(),
+            path: path.to_owned(),
+        }))
+    }
+
+    fn delete(&self, path: &Path) -> Result<(), DeleteError> {
+        self.underlying.delete(path)
+    }
+
+    fn exists(&self, path: &Path) -> Result<bool, OpenReadError> {
+        self.underlying.exists(path)
+    }
+
+    fn open_write(&self, path: &Path) -> Result<WritePtr, OpenWriteError> {
+        self.underlying.open_write(path)
+    }
+
+    fn atomic_read(&self, path: &Path) -> Result<Vec<u8>, OpenReadError> {
+        let read_operation_builder = ReadOperationBuilder::new(path);
+        let payload = self.underlying.atomic_read(path)?;
+        let read_operation = read_operation_builder.terminate(payload.len());
+        self.register(read_operation);
+        Ok(payload.to_vec())
+    }
+
+    fn atomic_write(&self, _path: &Path, _data: &[u8]) -> io::Result<()> {
+        unimplemented!()
+    }
+
+    fn watch(&self, _watch_callback: WatchCallback) -> tantivy::Result<WatchHandle> {
+        Ok(WatchHandle::empty())
+    }
+
+    fn acquire_lock(&self, _lock: &tantivy::directory::Lock) -> Result<DirectoryLock, LockError> {
+        Ok(DirectoryLock::from(Box::new(|| {})))
+    }
+}
+
+impl DebugProxyDirectory<StorageDirectory> {
+    /// Fetches a slice of byte from a file asynchronously.
+    pub async fn get_slice(&self, path: &Path, range: Range<usize>) -> io::Result<Vec<u8>> {
+        let read_operation_builder = ReadOperationBuilder::new(path);
+        let payload: Vec<u8> = self.underlying.get_slice(path, range).await?;
+        let read_operation = read_operation_builder.terminate(payload.len());
+        self.register_async(read_operation).await;
+        Ok(payload)
+    }
+
+    /// Fetches an entire file asynchronously.
+    pub async fn get_all(&self, path: &Path) -> io::Result<Vec<u8>> {
+        let read_operation_builder = ReadOperationBuilder::new(path);
+        let payload: Vec<u8> = self.underlying.get_all(path).await?;
+        let read_operation = read_operation_builder.terminate(payload.len());
+        self.register_async(read_operation).await;
+        Ok(payload)
+    }
+
+    pub fn underlying(&self) -> &StorageDirectory {
+        &self.underlying
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DebugProxyDirectory;
+    use std::io::Write;
+    use std::path::Path;
+    use tantivy::directory::{RAMDirectory, TerminatingWrite};
+    use tantivy::Directory;
+
+    const TEST_PATH: &str = "test.file";
+    const TEST_PAYLOAD: &[u8] = b"hello happy tax payer";
+
+    fn make_test_directory() -> tantivy::Result<RAMDirectory> {
+        let ram_directory = RAMDirectory::create();
+        let mut wrt = ram_directory.open_write(Path::new(TEST_PATH))?;
+        wrt.write_all(TEST_PAYLOAD)?;
+        wrt.flush()?;
+        wrt.terminate()?;
+        Ok(ram_directory)
+    }
+
+    #[test]
+    fn test_debug_proxy_atomic_read() -> tantivy::Result<()> {
+        let debug_proxy = DebugProxyDirectory::wrap(make_test_directory()?);
+        let test_path = Path::new(TEST_PATH);
+        let read_data = debug_proxy.atomic_read(test_path)?;
+        assert_eq!(&read_data[..], TEST_PAYLOAD);
+        let operations: Vec<crate::ReadOperation> = debug_proxy.drain_read_operations().collect();
+        println!("operations {:?}", operations);
+        assert_eq!(operations.len(), 1);
+        let op0 = &operations[0];
+        assert_eq!(op0.offset, 0);
+        assert_eq!(op0.num_bytes, 21);
+        assert_eq!(op0.path, test_path);
+        Ok(())
+    }
+
+    #[test]
+    fn test_debug_proxy_open_read_read_sync() -> tantivy::Result<()> {
+        let test_path = Path::new(TEST_PATH);
+        let debug_proxy = DebugProxyDirectory::wrap(make_test_directory()?);
+        let read_data = debug_proxy.open_read(test_path)?;
+        assert_eq!(read_data.read_bytes_slice(1..3)?.as_slice(), b"el");
+        let operations: Vec<crate::ReadOperation> = debug_proxy.drain_read_operations().collect();
+        assert_eq!(operations.len(), 1);
+        let op = &operations[0];
+        assert_eq!(op.path, test_path);
+        assert_eq!(op.offset, 1);
+        assert_eq!(op.num_bytes, 2);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_debug_proxy_open_read_read_async() -> tantivy::Result<()> {
+        let test_path = Path::new(TEST_PATH);
+        let debug_proxy = DebugProxyDirectory::wrap(make_test_directory()?);
+        let read_data = debug_proxy.open_read(test_path)?;
+        assert_eq!(
+            read_data.read_bytes_slice_async(1..3).await?.as_slice(),
+            b"el"
+        );
+        let operations: Vec<crate::ReadOperation> = debug_proxy.drain_read_operations().collect();
+        assert_eq!(operations.len(), 1);
+        let op = &operations[0];
+        assert_eq!(op.path, test_path);
+        assert_eq!(op.offset, 1);
+        assert_eq!(op.num_bytes, 2);
+        Ok(())
+    }
+}

--- a/quickwit-hot-directory/src/hot_directory.rs
+++ b/quickwit-hot-directory/src/hot_directory.rs
@@ -1,0 +1,706 @@
+/*
+    Quickwit
+    Copyright (C) 2021 Quickwit Inc.
+
+    Quickwit is offered under the AGPL v3.0 and as commercial software.
+    For commercial licensing, contact us at hello@quickwit.io.
+
+    AGPL:
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
+use std::fmt;
+use std::io;
+use std::ops::Range;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use tantivy::directory::error::{LockError, OpenReadError};
+use tantivy::directory::DirectoryLock;
+use tantivy::directory::{FileSlice, OwnedBytes, WatchCallback};
+use tantivy::error::DataCorruption;
+use tantivy::{directory::FileHandle, directory::WatchHandle, HasLen};
+use tantivy::{AsyncIoResult, Directory, Index, IndexReader, ReloadPolicy};
+
+use crate::{CachingDirectory, DebugProxyDirectory};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct SliceCacheIndexEntry {
+    start: usize, //< legacy. We keep this instead of range due to existing indices.
+    stop: usize,
+    addr: usize,
+}
+
+impl SliceCacheIndexEntry {
+    pub fn len(&self) -> usize {
+        self.range().len()
+    }
+
+    pub fn range(&self) -> Range<usize> {
+        self.start..self.stop
+    }
+}
+
+#[derive(Serialize, Deserialize, Default)]
+pub struct SliceCacheIndex {
+    total_len: u64,
+    slices: Vec<SliceCacheIndexEntry>,
+}
+impl SliceCacheIndex {
+    pub fn is_complete(&self) -> bool {
+        if self.slices.len() != 1 {
+            return false;
+        }
+        self.slices[0].len() as u64 == self.total_len
+    }
+
+    pub fn get(&self, byte_range: Range<usize>) -> Option<usize> {
+        let entry_idx = match self
+            .slices
+            .binary_search_by_key(&byte_range.start, |entry| entry.range().start)
+        {
+            Ok(idx) => idx,
+            Err(0) => {
+                return None;
+            }
+            Err(idx_after) => (idx_after - 1),
+        };
+        let entry = &self.slices[entry_idx];
+        if entry.range().start > byte_range.start || entry.range().end < byte_range.end {
+            return None;
+        }
+        Some(entry.addr + byte_range.start - entry.range().start)
+    }
+}
+
+#[derive(Default)]
+struct StaticDirectoryCacheBuilder {
+    file_cache_builder: HashMap<PathBuf, StaticSliceCacheBuilder>,
+    file_lengths: HashMap<PathBuf, u64>, // a mapping from file path to file size in bytes
+}
+
+impl StaticDirectoryCacheBuilder {
+    pub fn add_file(&mut self, path: &Path, file_len: u64) -> &mut StaticSliceCacheBuilder {
+        self.file_lengths.insert(path.to_owned(), file_len);
+        self.file_cache_builder
+            .entry(path.to_owned())
+            .or_insert_with(|| StaticSliceCacheBuilder::new(file_len))
+    }
+
+    /// Flush needs to be called afterwards.
+    pub fn write(self, wrt: &mut dyn io::Write) -> tantivy::Result<()> {
+        // Write format version
+        wrt.write_all(b"\x00")?;
+
+        let file_lengths_bytes = serde_cbor::to_vec(&self.file_lengths).unwrap();
+        wrt.write_all(&(file_lengths_bytes.len() as u64).to_le_bytes())?;
+        wrt.write_all(&file_lengths_bytes[..])?;
+
+        let mut data_buffer = Vec::new();
+        let mut data_idx: Vec<(PathBuf, u64)> = Vec::new();
+        let mut offset = 0u64;
+        for (path, cache) in self.file_cache_builder {
+            let buf = cache.flush()?;
+            data_idx.push((path, offset));
+            offset += buf.len() as u64;
+            data_buffer.extend_from_slice(&buf);
+        }
+        let idx_bytes = serde_cbor::to_vec(&data_idx).unwrap();
+        wrt.write_all(&(idx_bytes.len() as u64).to_le_bytes())?;
+        wrt.write_all(&idx_bytes[..])?;
+        wrt.write_all(&data_buffer[..])?;
+
+        Ok(())
+    }
+}
+
+fn deserialize_cbor<T>(bytes: &mut OwnedBytes) -> serde_cbor::Result<T>
+where
+    T: serde::de::DeserializeOwned,
+{
+    let len = bytes.read_u64();
+    let value = serde_cbor::from_reader(&bytes.as_slice()[..len as usize]);
+    bytes.advance(len as usize);
+    value
+}
+
+#[derive(Debug)]
+struct StaticDirectoryCache {
+    file_lengths: HashMap<PathBuf, u64>,
+    slices: HashMap<PathBuf, Arc<StaticSliceCache>>,
+}
+
+impl StaticDirectoryCache {
+    pub fn open(mut bytes: OwnedBytes) -> tantivy::Result<StaticDirectoryCache> {
+        let format_version = bytes.read_u8();
+
+        if format_version != 0 {
+            return Err(tantivy::TantivyError::DataCorruption(
+                DataCorruption::comment_only(format!(
+                    "Format version not supported: `{}`",
+                    format_version
+                )),
+            ));
+        }
+
+        let file_lengths: HashMap<PathBuf, u64> = deserialize_cbor(&mut bytes).unwrap();
+
+        let mut slice_offsets: Vec<(PathBuf, u64)> = deserialize_cbor(&mut bytes).unwrap();
+        slice_offsets.push((PathBuf::default(), bytes.len() as u64));
+
+        let slices = slice_offsets
+            .windows(2)
+            .map(|w| {
+                let path = w[0].0.clone();
+                let start = w[0].1 as usize;
+                let end = w[1].1 as usize;
+                StaticSliceCache::open(bytes.slice(start..end)).map(|s| (path, Arc::new(s)))
+            })
+            .collect::<tantivy::Result<_>>()?;
+
+        Ok(StaticDirectoryCache {
+            file_lengths,
+            slices,
+        })
+    }
+
+    pub fn get_slice(&self, path: &Path) -> Arc<StaticSliceCache> {
+        self.slices.get(path).cloned().unwrap_or_default()
+    }
+
+    pub fn get_file_length(&self, path: &Path) -> Option<u64> {
+        self.file_lengths.get(path).map(u64::clone)
+    }
+}
+
+/// A SliceCache is a static toring
+pub struct StaticSliceCache {
+    bytes: OwnedBytes,
+    index: SliceCacheIndex,
+}
+
+impl Default for StaticSliceCache {
+    fn default() -> StaticSliceCache {
+        StaticSliceCache {
+            bytes: OwnedBytes::empty(),
+            index: SliceCacheIndex::default(),
+        }
+    }
+}
+
+impl StaticSliceCache {
+    pub fn open(owned_bytes: OwnedBytes) -> tantivy::Result<Self> {
+        let owned_bytes_len = owned_bytes.len();
+        assert!(owned_bytes_len >= 8);
+        let (body, len_bytes) = owned_bytes.split(owned_bytes_len - 8);
+        let mut body_len_bytes = [0u8; 8];
+        body_len_bytes.copy_from_slice(len_bytes.as_slice());
+        let body_len = u64::from_le_bytes(body_len_bytes);
+        let (body, idx) = body.split(body_len as usize);
+        let mut idx_bytes = idx.as_slice();
+        let index: SliceCacheIndex = serde_cbor::from_reader(&mut idx_bytes).map_err(|err| {
+            DataCorruption::comment_only(format!(
+                "Failed to deserialize the slice index: {:?}",
+                err
+            ))
+        })?;
+        Ok(StaticSliceCache { bytes: body, index })
+    }
+
+    pub fn try_read_all(&self) -> Option<OwnedBytes> {
+        if !self.index.is_complete() {
+            return None;
+        }
+        Some(self.bytes.clone())
+    }
+
+    pub fn try_read_bytes(&self, byte_range: Range<usize>) -> Option<OwnedBytes> {
+        if byte_range.is_empty() {
+            return Some(OwnedBytes::empty());
+        }
+        if let Some(start) = self.index.get(byte_range.clone()) {
+            return Some(self.bytes.slice(start..start + byte_range.len()));
+        }
+        None
+    }
+}
+
+struct StaticSliceCacheBuilder {
+    wrt: Vec<u8>,
+    slices: Vec<SliceCacheIndexEntry>,
+    offset: u64,
+    total_len: u64,
+}
+
+impl StaticSliceCacheBuilder {
+    pub fn new(total_len: u64) -> StaticSliceCacheBuilder {
+        StaticSliceCacheBuilder {
+            wrt: Vec::new(),
+            slices: Vec::new(),
+            offset: 0u64,
+            total_len,
+        }
+    }
+
+    pub fn add_bytes(&mut self, bytes: &[u8], start: usize) {
+        self.wrt.extend_from_slice(bytes);
+        let end = start + bytes.len();
+        self.slices.push(SliceCacheIndexEntry {
+            start,
+            stop: end,
+            addr: self.offset as usize,
+        });
+        self.offset += bytes.len() as u64;
+    }
+
+    fn merged_slices(&mut self) -> tantivy::Result<Vec<SliceCacheIndexEntry>> {
+        if self.slices.is_empty() {
+            return Ok(Vec::new());
+        }
+        self.slices.sort_unstable_by_key(|e| e.range().start);
+        let mut slices = Vec::with_capacity(self.slices.len());
+        let mut last = self.slices[0].clone();
+        for segment in &self.slices[1..] {
+            if segment.range().start < last.range().end {
+                return Err(tantivy::TantivyError::InvalidArgument(format!(
+                    "Two segments are overlapping on byte {}",
+                    segment.range().start
+                )));
+            }
+            if last.stop == segment.range().start
+                && (last.addr + last.range().len() == segment.addr)
+            {
+                // We merge the current segment with the previous one
+                last.stop += segment.range().len();
+            } else {
+                slices.push(last);
+                last = segment.clone();
+            }
+        }
+        slices.push(last);
+        Ok(slices)
+    }
+
+    pub fn flush(mut self) -> tantivy::Result<Vec<u8>> {
+        let merged_slices_res = self.merged_slices();
+        if let Err(e) = merged_slices_res {
+            return Err(e);
+        }
+        let merged_slices = merged_slices_res?;
+        let slices_idx = SliceCacheIndex {
+            total_len: self.total_len,
+            slices: merged_slices,
+        };
+        serde_cbor::to_writer(&mut self.wrt, &slices_idx)
+            .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;
+        self.wrt.extend_from_slice(&self.offset.to_le_bytes()[..]);
+        Ok(self.wrt)
+    }
+}
+
+impl fmt::Debug for StaticSliceCache {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "SliceCache()")
+    }
+}
+
+#[derive(Clone)]
+pub struct HotDirectory {
+    inner: Arc<InnerHotDirectory>,
+}
+
+impl HotDirectory {
+    pub fn open<D: Directory>(
+        underlying: D,
+        hot_cache_bytes: OwnedBytes,
+    ) -> tantivy::Result<HotDirectory> {
+        let static_cache = StaticDirectoryCache::open(hot_cache_bytes)?;
+        Ok(HotDirectory {
+            inner: Arc::new(InnerHotDirectory {
+                underlying: Box::new(underlying),
+                cache: Arc::new(static_cache),
+            }),
+        })
+    }
+}
+
+struct FileSliceWithCache {
+    underlying: FileSlice,
+    static_cache: Arc<StaticSliceCache>,
+    file_length: u64,
+}
+
+#[async_trait]
+impl FileHandle for FileSliceWithCache {
+    fn read_bytes(&self, byte_range: Range<usize>) -> io::Result<OwnedBytes> {
+        if let Some(found_bytes) = self.static_cache.try_read_bytes(byte_range.clone()) {
+            return Ok(found_bytes);
+        }
+        self.underlying.read_bytes_slice(byte_range)
+    }
+
+    async fn read_bytes_async(&self, byte_range: Range<usize>) -> AsyncIoResult<OwnedBytes> {
+        if let Some(found_bytes) = self.static_cache.try_read_bytes(byte_range.clone()) {
+            return Ok(found_bytes);
+        }
+        self.underlying.read_bytes_slice_async(byte_range).await
+    }
+
+    fn get_physical_address(&self, range: Range<usize>) -> Option<String> {
+        self.underlying.get_physical_address(range)
+    }
+}
+
+impl fmt::Debug for FileSliceWithCache {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "FileSliceWithCache({:?})", &self.underlying)
+    }
+}
+
+impl HasLen for FileSliceWithCache {
+    fn len(&self) -> usize {
+        self.file_length as usize
+    }
+}
+
+struct InnerHotDirectory {
+    underlying: Box<dyn Directory>,
+    cache: Arc<StaticDirectoryCache>,
+}
+
+impl fmt::Debug for HotDirectory {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "HotDirectory(dir={:?}, cache={:?})",
+            self.inner.underlying.as_ref(),
+            self.inner.cache.as_ref()
+        )
+    }
+}
+
+impl Directory for HotDirectory {
+    fn get_file_handle(&self, path: &Path) -> Result<Box<dyn FileHandle>, OpenReadError> {
+        let file_length = self
+            .inner
+            .cache
+            .get_file_length(path)
+            .ok_or_else(|| OpenReadError::FileDoesNotExist(path.to_owned()))?;
+        let underlying_filehandle = self.inner.underlying.get_file_handle(path)?;
+        let underlying = FileSlice::new_with_num_bytes(underlying_filehandle, file_length as usize);
+        let file_slice_with_cache = FileSliceWithCache {
+            underlying,
+            static_cache: self.inner.cache.get_slice(path),
+            file_length,
+        };
+        Ok(Box::new(file_slice_with_cache))
+    }
+
+    fn delete(&self, path: &std::path::Path) -> Result<(), tantivy::directory::error::DeleteError> {
+        self.inner.underlying.delete(path)
+    }
+
+    fn exists(&self, path: &std::path::Path) -> Result<bool, OpenReadError> {
+        Ok(self.inner.cache.get_file_length(path).is_some())
+    }
+
+    fn open_write(
+        &self,
+        path: &std::path::Path,
+    ) -> Result<tantivy::directory::WritePtr, tantivy::directory::error::OpenWriteError> {
+        self.inner.underlying.open_write(path)
+    }
+
+    fn atomic_read(&self, path: &std::path::Path) -> Result<Vec<u8>, OpenReadError> {
+        let slice_cache = self.inner.cache.get_slice(path);
+        if let Some(all_bytes) = slice_cache.try_read_all() {
+            return Ok(all_bytes.as_slice().to_owned());
+        }
+        self.inner.underlying.atomic_read(path)
+    }
+
+    fn atomic_write(&self, _path: &std::path::Path, _data: &[u8]) -> std::io::Result<()> {
+        unimplemented!()
+    }
+
+    fn watch(&self, _watch_callback: WatchCallback) -> tantivy::Result<WatchHandle> {
+        Ok(WatchHandle::empty())
+    }
+
+    fn acquire_lock(&self, _lock: &tantivy::directory::Lock) -> Result<DirectoryLock, LockError> {
+        Ok(DirectoryLock::from(Box::new(|| {})))
+    }
+}
+
+fn list_index_files(index: &Index) -> tantivy::Result<HashSet<PathBuf>> {
+    let index_meta = index.load_metas()?;
+    let mut files: HashSet<PathBuf> = index_meta
+        .segments
+        .into_iter()
+        .flat_map(|segment_meta| segment_meta.list_files())
+        .collect();
+    files.insert(Path::new("meta.json").to_path_buf());
+    files.insert(Path::new(".managed.json").to_path_buf());
+    Ok(files)
+}
+
+/// Given a tantivy directory, automatically identify the parts that should be loaded on startup
+/// and writes a static cache file called hotcache in the `output`.
+///
+/// See [`HotDirectory`] for more information.
+pub fn write_hotcache<D: Directory>(
+    directory: D,
+    output: &mut dyn io::Write,
+) -> tantivy::Result<()> {
+    // We use the caching directory here in order to defensively ensure that
+    // the content of the directory that will be written in the hotcache is precisely
+    // the same that was read on the first pass.
+    let caching_directory = CachingDirectory::new_with_capacity_in_bytes(
+        Arc::new(directory),
+        10_000_000,
+        "".to_string(),
+    );
+    let debug_proxy_directory = DebugProxyDirectory::wrap(caching_directory);
+    let index = Index::open(debug_proxy_directory.clone())?;
+    let schema = index.schema();
+    let reader: IndexReader = index
+        .reader_builder()
+        .num_searchers(1)
+        .reload_policy(ReloadPolicy::Manual)
+        .try_into()?;
+    let searcher = reader.searcher();
+    for (field, field_entry) in schema.fields() {
+        if !field_entry.is_indexed() {
+            continue;
+        }
+        for reader in searcher.segment_readers() {
+            let _inv_idx = reader.inverted_index(field)?;
+        }
+    }
+    let mut cache_builder = StaticDirectoryCacheBuilder::default();
+    let read_operations = debug_proxy_directory.drain_read_operations();
+    let mut per_file_slices: HashMap<PathBuf, HashSet<Range<usize>>> = HashMap::default();
+    for read_operation in read_operations {
+        per_file_slices
+            .entry(read_operation.path)
+            .or_default()
+            .insert(read_operation.offset..read_operation.offset + read_operation.num_bytes);
+    }
+    let index_files = list_index_files(&index)?;
+    for file_path in index_files {
+        let file_slice_res = debug_proxy_directory.open_read(&file_path);
+        if let Err(tantivy::directory::error::OpenReadError::FileDoesNotExist(_)) = file_slice_res {
+            continue;
+        }
+        let file_slice = file_slice_res?;
+        let file_cache_builder = cache_builder.add_file(&file_path, file_slice.len() as u64);
+        if let Some(intervals) = per_file_slices.get(&file_path) {
+            for byte_range in intervals {
+                let len = byte_range.len();
+                if file_path.to_string_lossy().ends_with("store") || len < 10_000_000 {
+                    let bytes = file_slice.read_bytes_slice(byte_range.clone())?;
+                    file_cache_builder.add_bytes(bytes.as_slice(), byte_range.start);
+                }
+            }
+        }
+    }
+    cache_builder.write(output)?;
+    output.flush()?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn test_empty_slice_cache_index() -> tantivy::Result<()> {
+        let slice_cache_builder = StaticSliceCacheBuilder::new(10u64);
+        let cache_data = slice_cache_builder.flush()?;
+        let owned_bytes = OwnedBytes::new(cache_data);
+        let slice_cache = StaticSliceCache::open(owned_bytes)?;
+        assert!(slice_cache.try_read_bytes(5..6).is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn test_simple_slice_cache_index() -> tantivy::Result<()> {
+        let mut slice_cache_builder = StaticSliceCacheBuilder::new(10u64);
+        slice_cache_builder.add_bytes(b"abc", 2);
+        let cache_data = slice_cache_builder.flush()?;
+        let owned_bytes = OwnedBytes::new(cache_data);
+        let slice_cache = StaticSliceCache::open(owned_bytes)?;
+        assert_eq!(
+            slice_cache.try_read_bytes(2..5).unwrap().as_slice(),
+            &b"abc"[..]
+        );
+        assert_eq!(
+            slice_cache.try_read_bytes(2..3).unwrap().as_slice(),
+            &b"a"[..]
+        );
+        assert_eq!(
+            slice_cache.try_read_bytes(3..5).unwrap().as_slice(),
+            &b"bc"[..]
+        );
+        assert_eq!(
+            slice_cache.try_read_bytes(4..5).unwrap().as_slice(),
+            &b"c"[..]
+        );
+        assert!(slice_cache.try_read_bytes(5..6).is_none());
+        assert!(slice_cache.try_read_bytes(4..6).is_none());
+        assert!(slice_cache.try_read_bytes(6..7).is_none());
+        assert_eq!(
+            slice_cache.try_read_bytes(6..6).unwrap().as_slice(),
+            &b""[..]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_several_segments() -> tantivy::Result<()> {
+        let mut slice_cache_builder = StaticSliceCacheBuilder::new(100u64);
+        slice_cache_builder.add_bytes(b"def", 6);
+        slice_cache_builder.add_bytes(b"ghi", 12);
+        slice_cache_builder.add_bytes(b"abc", 2);
+        let cache_data = slice_cache_builder.flush()?;
+        let owned_bytes = OwnedBytes::new(cache_data);
+        let slice_cache = StaticSliceCache::open(owned_bytes)?;
+        assert_eq!(
+            slice_cache.try_read_bytes(2..5).unwrap().as_slice(),
+            &b"abc"[..]
+        );
+        assert_eq!(
+            slice_cache.try_read_bytes(2..3).unwrap().as_slice(),
+            &b"a"[..]
+        );
+        assert_eq!(
+            slice_cache.try_read_bytes(3..5).unwrap().as_slice(),
+            &b"bc"[..]
+        );
+        assert_eq!(
+            slice_cache.try_read_bytes(4..5).unwrap().as_slice(),
+            &b"c"[..]
+        );
+        assert!(slice_cache.try_read_bytes(5..6).is_none());
+        assert!(slice_cache.try_read_bytes(4..6).is_none());
+        assert_eq!(
+            slice_cache.try_read_bytes(6..7).unwrap().as_slice(),
+            &b"d"[..]
+        );
+        assert!(slice_cache.try_read_bytes(2..7).is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn test_slice_cache_merged_entries() -> tantivy::Result<()> {
+        let mut slice_cache_builder = StaticSliceCacheBuilder::new(100u64);
+        slice_cache_builder.add_bytes(b"abc", 2);
+        slice_cache_builder.add_bytes(b"def", 5);
+        let cache_data = slice_cache_builder.flush()?;
+        let owned_bytes = OwnedBytes::new(cache_data);
+        let slice_cache = StaticSliceCache::open(owned_bytes)?;
+        assert_eq!(
+            slice_cache.try_read_bytes(3..7).unwrap().as_slice(),
+            &b"bcde"[..]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_slice_cache_unmergeable_entries() -> tantivy::Result<()> {
+        let mut slice_cache_builder = StaticSliceCacheBuilder::new(100u64);
+        slice_cache_builder.add_bytes(b"def", 5);
+        slice_cache_builder.add_bytes(b"abc", 2);
+        let cache_data = slice_cache_builder.flush()?;
+        let owned_bytes = OwnedBytes::new(cache_data);
+        let slice_cache = StaticSliceCache::open(owned_bytes)?;
+        assert!(slice_cache.try_read_bytes(3..7).is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn test_slice_cache_overlapping_entries() -> tantivy::Result<()> {
+        let mut slice_cache_builder = StaticSliceCacheBuilder::new(100u64);
+        slice_cache_builder.add_bytes(b"abcd", 2);
+        slice_cache_builder.add_bytes(b"def", 5);
+        assert!(slice_cache_builder.flush().is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn test_slice_entry_serialization() -> anyhow::Result<()> {
+        let slice_entry = super::SliceCacheIndexEntry {
+            start: 1,
+            stop: 5,
+            addr: 4,
+        };
+        let bytes = serde_cbor::ser::to_vec(&slice_entry)?;
+        assert_eq!(
+            &bytes[..],
+            &[
+                163, 101, 115, 116, 97, 114, 116, 1, 100, 115, 116, 111, 112, 5, 100, 97, 100, 100,
+                114, 4
+            ]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_slice_directory_cache() -> tantivy::Result<()> {
+        let one_path = Path::new("one.txt");
+        let two_path = Path::new("two.txt");
+        let three_path = Path::new("three.txt");
+        let four_path = Path::new("four.txt");
+
+        let mut directory_cache_builder = StaticDirectoryCacheBuilder::default();
+        directory_cache_builder
+            .add_file(&one_path, 100)
+            .add_bytes(b" happy t", 5);
+        directory_cache_builder
+            .add_file(&two_path, 200)
+            .add_bytes(b"my name", 0);
+        directory_cache_builder.add_file(&three_path, 300);
+
+        let mut buffer = Vec::new();
+        directory_cache_builder.write(&mut buffer)?;
+        let directory_cache = StaticDirectoryCache::open(OwnedBytes::new(buffer))?;
+
+        assert_eq!(directory_cache.get_file_length(&one_path), Some(100));
+        assert_eq!(directory_cache.get_file_length(&two_path), Some(200));
+        assert_eq!(directory_cache.get_file_length(&three_path), Some(300));
+        assert_eq!(directory_cache.get_file_length(&four_path), None);
+
+        assert_eq!(
+            directory_cache
+                .get_slice(&one_path)
+                .try_read_bytes(6..11)
+                .unwrap()
+                .as_ref(),
+            b"happy"
+        );
+        assert_eq!(
+            directory_cache
+                .get_slice(&two_path)
+                .try_read_bytes(3..7)
+                .unwrap()
+                .as_ref(),
+            b"name"
+        );
+
+        Ok(())
+    }
+}

--- a/quickwit-hot-directory/src/lib.rs
+++ b/quickwit-hot-directory/src/lib.rs
@@ -1,0 +1,41 @@
+/*
+    Quickwit
+    Copyright (C) 2021 Quickwit Inc.
+
+    Quickwit is offered under the AGPL v3.0 and as commercial software.
+    For commercial licensing, contact us at hello@quickwit.io.
+
+    AGPL:
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/*!
+This crate contains all of the building pieces that make quickwit's IO possible.
+
+- The `StorageDirectory` justs wraps a `Storage` trait to make it compatible with tantivy's Directory API.
+- The `HotDirectory` wraps another directory with a static cache.
+- The `CachingDirectory` wraps a Directory with a dynamic cache.
+- The `DebugDirectory` acts as a proxy to another directory to instrument it and record all of its IO.
+*/
+#![allow(missing_docs)]
+
+mod caching_directory;
+mod debug_proxy_directory;
+mod hot_directory;
+mod storage_directory;
+
+pub use self::caching_directory::{Cache, CachingDirectory};
+pub use self::debug_proxy_directory::{DebugProxyDirectory, ReadOperation};
+pub use self::hot_directory::{write_hotcache, HotDirectory};
+pub use self::storage_directory::StorageDirectory;

--- a/quickwit-hot-directory/src/storage_directory.rs
+++ b/quickwit-hot-directory/src/storage_directory.rs
@@ -1,0 +1,171 @@
+/*
+    Quickwit
+    Copyright (C) 2021 Quickwit Inc.
+
+    Quickwit is offered under the AGPL v3.0 and as commercial software.
+    For commercial licensing, contact us at hello@quickwit.io.
+
+    AGPL:
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+use async_trait::async_trait;
+use quickwit_storage::Storage;
+use std::fmt;
+use std::fmt::Debug;
+use std::io;
+use std::ops::Range;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use tantivy::directory::error::{DeleteError, OpenReadError, OpenWriteError};
+use tantivy::directory::OwnedBytes;
+use tantivy::directory::{FileHandle, WatchCallback, WatchHandle, WritePtr};
+use tantivy::HasLen;
+use tantivy::{AsyncIoResult, Directory};
+use tracing::error;
+
+struct StorageDirectoryFileHandle {
+    storage_directory: StorageDirectory,
+    path: PathBuf,
+}
+
+impl HasLen for StorageDirectoryFileHandle {
+    fn len(&self) -> usize {
+        unimplemented!()
+    }
+}
+
+impl fmt::Debug for StorageDirectoryFileHandle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "StorageDirectoryFileHandle({:?}, dir={:?})",
+            &self.path, self.storage_directory
+        )
+    }
+}
+
+#[async_trait]
+impl FileHandle for StorageDirectoryFileHandle {
+    fn read_bytes(&self, _byte_range: Range<usize>) -> io::Result<OwnedBytes> {
+        Err(unsupported_operation(&self.path))
+    }
+
+    async fn read_bytes_async(&self, byte_range: Range<usize>) -> AsyncIoResult<OwnedBytes> {
+        if byte_range.is_empty() {
+            return Ok(OwnedBytes::empty());
+        }
+        let object_bytes = self
+            .storage_directory
+            .get_slice(&self.path, byte_range)
+            .await
+            .map_err(Into::<io::Error>::into)?;
+        Ok(OwnedBytes::new(object_bytes))
+    }
+
+    fn get_physical_address(&self, range: Range<usize>) -> Option<String> {
+        Some(format!(
+            "{}/{}:{}-{}",
+            self.storage_directory.uri(),
+            self.path.to_string_lossy(),
+            range.start,
+            range.end
+        ))
+    }
+}
+
+#[derive(Clone)]
+pub struct StorageDirectory {
+    storage: Arc<dyn Storage>,
+}
+
+impl Debug for StorageDirectory {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "StorageDirectory({:?})", self.uri())
+    }
+}
+
+impl StorageDirectory {
+    pub fn new(storage: Arc<dyn Storage>) -> StorageDirectory {
+        StorageDirectory { storage }
+    }
+
+    /// Fetches a slice of byte from a file asynchronously.
+    pub async fn get_slice(&self, path: &Path, range: Range<usize>) -> io::Result<Vec<u8>> {
+        let payload: Vec<u8> = self.storage.get_slice(path, range).await?;
+        Ok(payload)
+    }
+
+    /// Fetches an entire file asynchronously.
+    pub async fn get_all(&self, path: &Path) -> io::Result<Vec<u8>> {
+        let payload: Vec<u8> = self.storage.get_all(path).await?;
+        Ok(payload)
+    }
+
+    /// Returns the uri associated to the underlying storage.
+    pub fn uri(&self) -> String {
+        self.storage.uri()
+    }
+}
+
+fn unsupported_operation(path: &Path) -> io::Error {
+    let msg = "Unsupported operation. StorageDirectory only supports async reads";
+    error!(path=?path, msg);
+    io::Error::new(io::ErrorKind::Other, format!("{}: {:?}", msg, path))
+}
+
+impl Directory for StorageDirectory {
+    fn get_file_handle(&self, path: &Path) -> Result<Box<dyn FileHandle>, OpenReadError> {
+        Ok(Box::new(StorageDirectoryFileHandle {
+            storage_directory: self.clone(),
+            path: path.to_path_buf(),
+        }))
+    }
+
+    fn atomic_read(&self, path: &Path) -> Result<Vec<u8>, OpenReadError> {
+        Err(OpenReadError::wrap_io_error(
+            unsupported_operation(path),
+            path.to_path_buf(),
+        ))
+    }
+
+    fn delete(&self, path: &std::path::Path) -> Result<(), DeleteError> {
+        Err(DeleteError::IOError {
+            io_error: unsupported_operation(path),
+            filepath: path.to_path_buf(),
+        })
+    }
+
+    fn exists(&self, path: &std::path::Path) -> Result<bool, OpenReadError> {
+        Err(OpenReadError::wrap_io_error(
+            unsupported_operation(path),
+            path.to_path_buf(),
+        ))
+    }
+
+    fn open_write(&self, path: &std::path::Path) -> Result<WritePtr, OpenWriteError> {
+        Err(OpenWriteError::wrap_io_error(
+            unsupported_operation(path),
+            path.to_path_buf(),
+        ))
+    }
+
+    fn atomic_write(&self, path: &std::path::Path, _data: &[u8]) -> io::Result<()> {
+        Err(unsupported_operation(path))
+    }
+
+    fn watch(&self, _callback: WatchCallback) -> tantivy::Result<WatchHandle> {
+        Ok(WatchHandle::empty())
+    }
+}


### PR DESCRIPTION
### Context / purpose
We need the hot-directory implementation in the cli

### Description
Added `quickwit-hot-directory` from quickwit barrel

### Checklist
*Remove or complete this list if required.*
- [x] tested locally

