### PR TITLE
Reorganize CLI command handlers into modules

### DIFF
--- a/quickwit-core/Cargo.toml
+++ b/quickwit-core/Cargo.toml
@@ -7,5 +7,7 @@ license = "AGPL-3.0-or-later" # For a commercial, license, contact hello@quickwi
 
 [dependencies]
 anyhow = "1.0"
+tracing = '0.1'
+tracing-subscriber = "0.2"
 quickwit-doc-mapping = { version = "0.1.0", path = "../quickwit-doc-mapping" }
 quickwit-metastore = { version = "0.1.0", path = "../quickwit-metastore" }

--- a/quickwit-core/src/command_args.rs
+++ b/quickwit-core/src/command_args.rs
@@ -20,14 +20,35 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-mod command_args;
-mod create_index;
-mod delete_index;
-mod index_data;
-mod search_index;
+use std::path::PathBuf;
 
-pub use command_args::{CreateIndexArgs, DeleteIndexArgs, IndexDataArgs, SearchIndexArgs};
-pub use create_index::create_index_cli;
-pub use delete_index::delete_index_cli;
-pub use index_data::index_data_cli;
-pub use search_index::search_index_cli;
+pub struct CreateIndexArgs {
+    pub index_uri: PathBuf,
+    pub timestamp_field: Option<String>,
+    pub overwrite: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct IndexDataArgs {
+    pub index_uri: PathBuf,
+    pub input_uri: Option<PathBuf>,
+    pub temp_dir: PathBuf,
+    pub num_threads: usize,
+    pub heap_size: u64,
+    pub overwrite: bool,
+}
+
+pub struct SearchIndexArgs {
+    pub index_uri: PathBuf,
+    pub query: String,
+    pub max_hits: usize,
+    pub start_offset: usize,
+    pub search_fields: Option<Vec<String>>,
+    pub start_timestamp: Option<i64>,
+    pub end_timestamp: Option<i64>,
+}
+
+pub struct DeleteIndexArgs {
+    pub index_uri: PathBuf,
+    pub dry_run: bool,
+}

--- a/quickwit-core/src/delete_index.rs
+++ b/quickwit-core/src/delete_index.rs
@@ -20,14 +20,30 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-mod command_args;
-mod create_index;
-mod delete_index;
-mod index_data;
-mod search_index;
+use quickwit_metastore::MetastoreUriResolver;
+use tracing::debug;
 
-pub use command_args::{CreateIndexArgs, DeleteIndexArgs, IndexDataArgs, SearchIndexArgs};
-pub use create_index::create_index_cli;
-pub use delete_index::delete_index_cli;
-pub use index_data::index_data_cli;
-pub use search_index::search_index_cli;
+use crate::DeleteIndexArgs;
+
+pub async fn delete_index_cli(args: DeleteIndexArgs) -> anyhow::Result<()> {
+    debug!(
+        index_uri =% args.index_uri.display(),
+        dry_run = args.dry_run,
+        "delete-index"
+    );
+
+    let index_uri = args.index_uri.to_string_lossy().to_string();
+
+    let metastore = MetastoreUriResolver::default().resolve(&index_uri)?;
+    metastore.delete_index(index_uri).await?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_delete_index_cli() -> anyhow::Result<()> {
+        Ok(())
+    }
+}

--- a/quickwit-core/src/index_data/mod.rs
+++ b/quickwit-core/src/index_data/mod.rs
@@ -20,59 +20,37 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-use quickwit_doc_mapping::DocMapping;
 use quickwit_metastore::{MetastoreUriResolver, SplitState};
+use std::path::PathBuf;
+use tracing::debug;
 
-type IndexUri = String;
+use crate::IndexDataArgs;
 
-// anyhow errors are fine for now but we'll want to move to a proper error type eventually.
-pub async fn create_index(index_uri: IndexUri, doc_mapping: DocMapping) -> anyhow::Result<()> {
-    let metastore = MetastoreUriResolver::default().resolve(&index_uri)?;
-    metastore.create_index(index_uri, doc_mapping).await?;
-    Ok(())
-}
+pub async fn index_data_cli(args: IndexDataArgs) -> anyhow::Result<()> {
+    debug!(
+        index_uri =% args.index_uri.display(),
+        input_uri =% args.input_uri.unwrap_or_else(|| PathBuf::from("stdin")).display(),
+        temp_dir =% args.temp_dir.display(),
+        num_threads = args.num_threads,
+        heap_size = args.heap_size,
+        overwrite = args.overwrite,
+        "indexing"
+    );
 
-// TODO
-pub async fn index_data(index_uri: IndexUri) -> anyhow::Result<()> {
-    let _metastore = MetastoreUriResolver::default().resolve(&index_uri)?;
-    Ok(())
-}
+    let index_uri = args.index_uri.to_string_lossy().to_string();
 
-// TODO
-pub async fn search_index(index_uri: IndexUri) -> anyhow::Result<()> {
     let metastore = MetastoreUriResolver::default().resolve(&index_uri)?;
     let _splits = metastore
         .list_splits(index_uri, SplitState::Published, None)
         .await?;
-    Ok(())
-}
 
-pub async fn delete_index(index_uri: IndexUri) -> anyhow::Result<()> {
-    let metastore = MetastoreUriResolver::default().resolve(&index_uri)?;
-    metastore.delete_index(index_uri).await?;
     Ok(())
 }
 
 #[cfg(test)]
 mod tests {
-
     #[test]
-    fn test_create_index() -> anyhow::Result<()> {
-        Ok(())
-    }
-
-    #[test]
-    fn test_index_data() -> anyhow::Result<()> {
-        Ok(())
-    }
-
-    #[test]
-    fn test_search_index() -> anyhow::Result<()> {
-        Ok(())
-    }
-
-    #[test]
-    fn test_delete_index() -> anyhow::Result<()> {
+    fn test_index_data_cli() -> anyhow::Result<()> {
         Ok(())
     }
 }

--- a/quickwit-core/src/search_index.rs
+++ b/quickwit-core/src/search_index.rs
@@ -20,14 +20,29 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-mod command_args;
-mod create_index;
-mod delete_index;
-mod index_data;
-mod search_index;
+use tracing::debug;
 
-pub use command_args::{CreateIndexArgs, DeleteIndexArgs, IndexDataArgs, SearchIndexArgs};
-pub use create_index::create_index_cli;
-pub use delete_index::delete_index_cli;
-pub use index_data::index_data_cli;
-pub use search_index::search_index_cli;
+use crate::SearchIndexArgs;
+
+pub async fn search_index_cli(args: SearchIndexArgs) -> anyhow::Result<()> {
+    debug!(
+        index_uri =% args.index_uri.display(),
+        query =% args.query,
+        max_hits = args.max_hits,
+        start_offset = args.start_offset,
+        search_fields =? args.search_fields,
+        start_timestamp =? args.start_timestamp,
+        end_timestamp =? args.end_timestamp,
+        "search-index"
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+
+    #[test]
+    fn test_search_index() -> anyhow::Result<()> {
+        Ok(())
+    }
+}


### PR DESCRIPTION
### Context / purpose
Since the `quickwit-core` contains the core function, we need a way to pass the CLI arguments (CreateIndexArgs, DeleteIndexArgs, IndexDataArgs, SearchIndexArgs) to those core function.

### Description
I have moved the CLI argument structs to quickwit-core and reorganized the functions into their own module. Index_data is in a folder module because it will need more separation. other modules can do the same if need be.

### How was this PR tested?
- Compiled and ran the test
- Executed few commands

### Checklist
*Remove or complete this list if required.*
- [x] tested locally
