### PR TITLE
Fix metastore bugs

### DIFF
--- a/quickwit-metastore/src/error.rs
+++ b/quickwit-metastore/src/error.rs
@@ -33,6 +33,7 @@ pub enum MetastoreErrorKind {
     ExistingSplitId,
     Forbidden,
     IndexDoesNotExist,
+    IndexIsNotOpen,
     InternalError,
     InvalidManifest,
     Io,

--- a/quickwit-metastore/src/metastore.rs
+++ b/quickwit-metastore/src/metastore.rs
@@ -88,6 +88,9 @@ pub struct MetadataSet {
 
 #[async_trait]
 pub trait Metastore: Send + Sync + 'static {
+    /// Index exists.
+    async fn index_exists(&self, index_uri: IndexUri) -> MetastoreResult<bool>;
+
     /// Creates an index.
     async fn create_index(
         &self,
@@ -95,7 +98,10 @@ pub trait Metastore: Send + Sync + 'static {
         doc_mapping: DocMapping,
     ) -> MetastoreResult<()>;
 
-    /// Deletes and index.
+    /// Opens an index.
+    async fn open_index(&self, index_uri: IndexUri) -> MetastoreResult<()>;
+
+    /// Deletes an index.
     async fn delete_index(&self, index_uri: IndexUri) -> MetastoreResult<()>;
 
     /// Stages a split.

--- a/quickwit-metastore/src/metastore/single_file_metastore.rs
+++ b/quickwit-metastore/src/metastore/single_file_metastore.rs
@@ -63,44 +63,6 @@ impl SingleFileMetastore {
             data: Arc::new(RwLock::new(HashMap::new())),
         })
     }
-
-    async fn split_exists(&self, index_uri: IndexUri, split_id: SplitId) -> MetastoreResult<bool> {
-        let data = self.data.read().await;
-
-        // Check for the existence of index.
-        let metadata_set = data.get(&index_uri).ok_or_else(|| {
-            MetastoreErrorKind::IndexIsNotOpen
-                .with_error(anyhow::anyhow!("Index is not open: {:?}", &index_uri))
-        })?;
-
-        // Check for the existence of split.
-        let exist = metadata_set.splits.contains_key(&split_id);
-
-        Ok(exist)
-    }
-
-    /// Get split metadata.
-    pub async fn get_split(
-        &self,
-        index_uri: IndexUri,
-        split_id: SplitId,
-    ) -> MetastoreResult<SplitMetadata> {
-        let data = self.data.read().await;
-
-        // Check for the existence of index.
-        let metadata_set = data.get(&index_uri).ok_or_else(|| {
-            MetastoreErrorKind::IndexIsNotOpen
-                .with_error(anyhow::anyhow!("Index is not open: {:?}", &index_uri))
-        })?;
-
-        // Check for the existence of split.
-        let split_metadata = metadata_set.splits.get(&split_id).ok_or_else(|| {
-            MetastoreErrorKind::DoesNotExist
-                .with_error(anyhow::anyhow!("Split does not exist: {:?}", &split_id))
-        })?;
-
-        Ok(split_metadata.clone())
-    }
 }
 
 #[async_trait]

--- a/quickwit-metastore/src/metastore/single_file_metastore.rs
+++ b/quickwit-metastore/src/metastore/single_file_metastore.rs
@@ -1523,7 +1523,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_storage_failing() {
+    async fn test_single_file_metastore_storage_failing() {
         // The single file metastore should not update its internal state if the storage fails.
         let mut mock_storage = MockStorage::default();
 

--- a/quickwit-metastore/src/metastore/single_file_metastore.rs
+++ b/quickwit-metastore/src/metastore/single_file_metastore.rs
@@ -922,10 +922,10 @@ mod tests {
             for split_metadata in splits {
                 split_id_vec.push(split_metadata.split_id);
             }
-            assert_eq!(split_id_vec.contains(&"one".to_string()), true); // (0..100)
-            assert_eq!(split_id_vec.contains(&"two".to_string()), false); // (100..200)
-            assert_eq!(split_id_vec.contains(&"three".to_string()), false); // (200..300)
-            assert_eq!(split_id_vec.contains(&"four".to_string()), false); // (300..400)
+            assert_eq!(split_id_vec.contains(&"one".to_string()), true);
+            assert_eq!(split_id_vec.contains(&"two".to_string()), false);
+            assert_eq!(split_id_vec.contains(&"three".to_string()), false);
+            assert_eq!(split_id_vec.contains(&"four".to_string()), false);
         }
 
         {
@@ -939,10 +939,10 @@ mod tests {
             for split_metadata in splits {
                 split_id_vec.push(split_metadata.split_id);
             }
-            assert_eq!(split_id_vec.contains(&"one".to_string()), true); // (0..100)
-            assert_eq!(split_id_vec.contains(&"two".to_string()), false); // (100..200)
-            assert_eq!(split_id_vec.contains(&"three".to_string()), false); // (200..300)
-            assert_eq!(split_id_vec.contains(&"four".to_string()), false); // (300..400)
+            assert_eq!(split_id_vec.contains(&"one".to_string()), true);
+            assert_eq!(split_id_vec.contains(&"two".to_string()), false);
+            assert_eq!(split_id_vec.contains(&"three".to_string()), false);
+            assert_eq!(split_id_vec.contains(&"four".to_string()), false);
         }
 
         {

--- a/quickwit-metastore/src/metastore/single_file_metastore.rs
+++ b/quickwit-metastore/src/metastore/single_file_metastore.rs
@@ -368,25 +368,6 @@ impl Metastore for SingleFileMetastore {
 
         let mut splits: Vec<SplitMetadata> = Vec::new();
         for (_, split_metadata) in split_with_meta_matching_state_it {
-            // match time_range {
-            //     Some(ref filter_time_range) => {
-            //         if let Some(split_time_range) = &split_metadata.time_range {
-            //             // Splits that overlap at least part of the time range of the filter
-            //             // and the time range of the split are added to the list as search targets.
-            //             if split_time_range.contains(&filter_time_range.start)
-            //                 || split_time_range.contains(&filter_time_range.end)
-            //                 || filter_time_range.contains(&split_time_range.start)
-            //                 || filter_time_range.contains(&split_time_range.end)
-            //             {
-            //                 splits.push(split_metadata.clone());
-            //             }
-            //         }
-            //     }
-            //     None => {
-            //         // if `time_range` is omitted, the metadata is not filtered.
-            //         splits.push(split_metadata.clone());
-            //     }
-            // }
             let match_filter_time_range =
                 match (time_range_opt.as_ref(), split_metadata.time_range.as_ref()) {
                     (Some(filter_time_range), Some(split_time_range)) => {
@@ -511,12 +492,12 @@ impl Metastore for SingleFileMetastore {
 #[cfg(test)]
 mod tests {
     use std::ops::Range;
-    use std::path::Path;
     use std::sync::Arc;
 
     use quickwit_doc_mapping::DocMapping;
     use quickwit_storage::{MockStorage, StorageErrorKind, StorageUriResolver};
 
+    use crate::metastore::single_file_metastore::meta_uri;
     use crate::{
         IndexUri, Metastore, MetastoreErrorKind, SingleFileMetastore, SplitMetadata, SplitState,
     };
@@ -1545,65 +1526,65 @@ mod tests {
     async fn test_storage_failing() {
         // The single file metastore should not update its internal state if the storage fails.
         let mut mock_storage = MockStorage::default();
+
         mock_storage // remove this if we end up changing the semantics of create.
             .expect_exists()
             .returning(|_| Ok(false));
         mock_storage.expect_put().times(2).returning(|uri, _| {
-            assert_eq!(uri, Path::new("ram://test/index")); // TODO change uri once we fix the meta.json file
+            let path = meta_uri("ram://test/index".to_string());
+            assert_eq!(uri, path);
             Ok(())
         });
         mock_storage.expect_put().times(1).returning(|_uri, _| {
             Err(StorageErrorKind::Io
                 .with_error(anyhow::anyhow!("Oops. Some network problem maybe?")))
         });
+
         let metastore = SingleFileMetastore::new(Arc::new(mock_storage))
             .await
             .unwrap();
+
         let index_uri = IndexUri::from("ram://test/index");
-        {
-            // create index
-            metastore
-                .create_index(index_uri.clone(), DocMapping::Dynamic)
-                .await
-                .unwrap();
-        }
         let split_id = "one".to_string();
-        {
-            // stage split
-            let split_metadata = SplitMetadata {
-                split_id: split_id.clone(),
-                split_state: SplitState::Staged,
-                num_records: 1,
-                size_in_bytes: 2,
-                time_range: None,
-                generation: 3,
-            };
-            metastore
-                .stage_split(index_uri.clone(), split_id.clone(), split_metadata)
-                .await
-                .unwrap();
-        }
-        {
-            // publish split fails
-            let err = metastore
-                .publish_split(index_uri.clone(), split_id.clone())
-                .await;
-            assert!(err.is_err());
-        }
-        // TODO(mosuka) Fixme
-        // {
-        //     let split = metastore
-        //         .list_splits(index_uri.clone(), SplitState::Published, None)
-        //         .await
-        //         .unwrap();
-        //     assert!(split.is_empty());
-        // }
-        // {
-        //     let split = metastore
-        //         .list_splits(index_uri.clone(), SplitState::Staged, None)
-        //         .await
-        //         .unwrap();
-        //     assert!(!split.is_empty());
-        // }
+        let split_metadata = SplitMetadata {
+            split_id: split_id.clone(),
+            split_state: SplitState::Staged,
+            num_records: 1,
+            size_in_bytes: 2,
+            time_range: None,
+            generation: 3,
+        };
+
+        // create index
+        metastore
+            .create_index(index_uri.clone(), DocMapping::Dynamic)
+            .await
+            .unwrap();
+
+        // stage split
+        metastore
+            .stage_split(index_uri.clone(), split_id.clone(), split_metadata)
+            .await
+            .unwrap();
+
+        // publish split fails
+        let err = metastore
+            .publish_split(index_uri.clone(), split_id.clone())
+            .await;
+        assert!(err.is_err());
+
+        // empty
+        let split = metastore
+            .list_splits(index_uri.clone(), SplitState::Published, None)
+            .await
+            .unwrap();
+        assert!(split.is_empty());
+
+        // not empty
+        let split = metastore
+            .list_splits(index_uri.clone(), SplitState::Staged, None)
+            .await
+            .unwrap();
+        assert!(!split.is_empty());
     }
 }

--- a/quickwit-metastore/src/metastore/single_file_metastore.rs
+++ b/quickwit-metastore/src/metastore/single_file_metastore.rs
@@ -134,28 +134,12 @@ impl Metastore for SingleFileMetastore {
     }
 
     async fn open_index(&self, index_uri: IndexUri) -> MetastoreResult<()> {
-        // Check for the existence of index.
-        let exists = self.index_exists(index_uri.clone()).await.map_err(|e| {
-            MetastoreErrorKind::InternalError.with_error(anyhow::anyhow!(
-                "Failed to check the existence of the index: {:?}",
-                e
-            ))
-        })?;
-        if !exists {
-            return Err(
-                MetastoreErrorKind::IndexDoesNotExist.with_error(anyhow::anyhow!(
-                    "The index does not exist.: {:?}",
-                    &index_uri
-                )),
-            );
-        }
-
         let path = meta_uri(index_uri.clone());
 
         // Get metadata set from storage.
         let contents = self.storage.get_all(&path).await.map_err(|e| {
-            MetastoreErrorKind::InternalError
-                .with_error(anyhow::anyhow!("Failed to put metadata set: {:?}", e))
+            MetastoreErrorKind::IndexDoesNotExist
+                .with_error(anyhow::anyhow!("The index does not exist: {:?}", e))
         })?;
 
         // Deserialize metadata.


### PR DESCRIPTION
### Context / purpose
Fix metastore bugs.

### Description
Fixed a bug that the internal state of the metastore is updated even when writing to the storage fails.
In addition, when an existing index is specified in the argument of the `create_index` function of `Metastore` trait, the index has opened, but the function name does not match the behavior, so the `create_index` function and the `open_index function` are now prepared separately.

### How was this PR tested?
Ran `cargo test test_single_file_metastore`

### Checklist
*Remove or complete this list if required.*
- [x] tested locally
- [x] added unit tests
- [x] included documentation
