### PR TITLE
Renamed qwt-hotdirectory into qwt-directories and added docstring.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [
   "quickwit-cli",
   "quickwit-core",
   "quickwit-doc-mapping",
-  "quickwit-hot-directory",
+  "quickwit-directories",
   "quickwit-metastore",
   "quickwit-storage",
 ]

--- a/quickwit-directories/Cargo.toml
+++ b/quickwit-directories/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "quickwit-hot-directory"
+name = "quickwit-directories"
 version = "0.1.0"
 authors = ["Quickwit, Inc. <hello@quickwit.io>"]
 edition = "2018"

--- a/quickwit-directories/src/debug_proxy_directory.rs
+++ b/quickwit-directories/src/debug_proxy_directory.rs
@@ -251,10 +251,6 @@ impl DebugProxyDirectory<StorageDirectory> {
         self.register_async(read_operation).await;
         Ok(payload)
     }
-
-    pub fn underlying(&self) -> &StorageDirectory {
-        &self.underlying
-    }
 }
 
 #[cfg(test)]

--- a/quickwit-directories/src/lib.rs
+++ b/quickwit-directories/src/lib.rs
@@ -28,14 +28,14 @@ This crate contains all of the building pieces that make quickwit's IO possible.
 - The `CachingDirectory` wraps a Directory with a dynamic cache.
 - The `DebugDirectory` acts as a proxy to another directory to instrument it and record all of its IO.
 */
-#![allow(missing_docs)]
+#![warn(missing_docs)]
 
 mod caching_directory;
 mod debug_proxy_directory;
 mod hot_directory;
 mod storage_directory;
 
-pub use self::caching_directory::{Cache, CachingDirectory};
+pub use self::caching_directory::CachingDirectory;
 pub use self::debug_proxy_directory::{DebugProxyDirectory, ReadOperation};
 pub use self::hot_directory::{write_hotcache, HotDirectory};
 pub use self::storage_directory::StorageDirectory;

--- a/quickwit-directories/src/storage_directory.rs
+++ b/quickwit-directories/src/storage_directory.rs
@@ -85,6 +85,15 @@ impl FileHandle for StorageDirectoryFileHandle {
     }
 }
 
+/// Directory backed a quickwit `Storage` abstraction.
+///
+/// It should not be used in a context outside quickwit, as it contains
+/// several pitfalls:
+/// Fetching data synchronously panics.
+/// Writing data panics.
+///
+/// This directory is fetch slices of data to a possibly distant storage
+/// everytime `read_bytes` is called.
 #[derive(Clone)]
 pub struct StorageDirectory {
     storage: Arc<dyn Storage>,
@@ -97,6 +106,7 @@ impl Debug for StorageDirectory {
 }
 
 impl StorageDirectory {
+    /// Creates a new StorageDirectory, backed by the given `storage`.
     pub fn new(storage: Arc<dyn Storage>) -> StorageDirectory {
         StorageDirectory { storage }
     }


### PR DESCRIPTION
- Renamed quickwit-hotdirectory into quickwit-directories.
- Added docstring and lint rule to check for missing docstrings.