### PR TITLE
Minor fixes in quickwit-cli

### DIFF
--- a/quickwit-cli/src/cli.yaml
+++ b/quickwit-cli/src/cli.yaml
@@ -35,9 +35,9 @@ subcommands:
                 long: index-uri
                 value_name: INDEX URI
                 required: true
-            - input-uri:
+            - input-path:
                 help: Location of the source dataset
-                long: input-uri
+                long: input-path
                 value_name: INPUT PATH
             - temp-dir:
                 help: Creates intermediate files in this local directory


### PR DESCRIPTION
This changes the type of URI parameters in arguments to String instead of Pathbuf, and some minor code quality stuff.
- in tracing the % and ? modifier are indented as follow
`key = ?value` as opposed to `key =? value`
- removing unwrap that are justified but not required. (Being able to grep for unwrap and expect is quite comfortable.)