### PR TITLE
If the index is not loaded into the cache, load it from storage.

### DIFF
--- a/quickwit-metastore/src/error.rs
+++ b/quickwit-metastore/src/error.rs
@@ -40,9 +40,6 @@ pub enum MetastoreErrorKind {
     /// The target index does not exist.
     IndexDoesNotExist,
 
-    /// The target index is not open.
-    IndexIsNotOpen,
-
     /// Any generic internal error.
     InternalError,
 

--- a/quickwit-metastore/src/metastore.rs
+++ b/quickwit-metastore/src/metastore.rs
@@ -96,18 +96,12 @@ pub struct MetadataSet {
 /// Metastore meant to manage quickwit's indices and its splits.
 #[async_trait]
 pub trait Metastore: Send + Sync + 'static {
-    /// Index exists.
-    async fn index_exists(&self, index_uri: IndexUri) -> MetastoreResult<bool>;
-
     /// Creates an index.
     async fn create_index(
         &self,
         index_uri: IndexUri,
         doc_mapping: DocMapping,
     ) -> MetastoreResult<()>;
-
-    /// Opens an index.
-    async fn open_index(&self, index_uri: IndexUri) -> MetastoreResult<()>;
 
     /// Deletes an index.
     async fn delete_index(&self, index_uri: IndexUri) -> MetastoreResult<()>;


### PR DESCRIPTION
### Context / purpose
If the index is not loaded into the cache, load it from storage in a lazy manner.

### Description
https://github.com/quickwit-inc/quickwit/issues/50
The open_index function of the `Metastore` trait will be moved to the private function of the `SingleFileMetastore`.
Change functions that operate splits, such as `list_splits`, `stage_split`, `publish_split`, `mark_split_as_deleted` and `delete_split` to lazily load the index's metadata set into the cache if the index is not open.

### How was this PR tested?
Ran `cargo test -- --nocapture test_single_file_metastore`

### Checklist
*Remove or complete this list if required.*
- [x] tested locally
- [x] added unit tests
- [x] included documentation
