### PR TITLE
Fixed LocalFileStorage bug

### DIFF
--- a/quickwit-storage/src/lib.rs
+++ b/quickwit-storage/src/lib.rs
@@ -138,6 +138,24 @@ pub(crate) mod tests {
         Ok(())
     }
 
+    async fn test_write_and_delete_with_dir_separator(
+        storage: &mut dyn Storage,
+    ) -> anyhow::Result<()> {
+        let test_path = Path::new("foo/bar/write_and_delete_with_separator");
+        let payload_bytes = b"abcdefghijklmnopqrstuvwxyz".as_ref();
+        storage
+            .put(test_path, PutPayload::from(payload_bytes))
+            .await?;
+        storage.delete(test_path).await?;
+
+        assert!(matches!(
+            storage.exists(Path::new("foo/bar")).await,
+            Ok(false)
+        ));
+        assert!(matches!(storage.exists(Path::new("foo")).await, Ok(false)));
+        Ok(())
+    }
+
     /// Generic test suite for a storage.
     pub async fn storage_test_suite(storage: &mut dyn Storage) -> anyhow::Result<()> {
         test_get_inexistent_file(storage)
@@ -156,6 +174,9 @@ pub(crate) mod tests {
             .await
             .with_context(|| "write_and_delete")?;
         test_exists(storage).await.with_context(|| "exists")?;
+        test_write_and_delete_with_dir_separator(storage)
+            .await
+            .with_context(|| "write_and_delete_with_separator")?;
         Ok(())
     }
 }

--- a/quickwit-storage/src/lib.rs
+++ b/quickwit-storage/src/lib.rs
@@ -146,6 +146,10 @@ pub(crate) mod tests {
         storage
             .put(test_path, PutPayload::from(payload_bytes))
             .await?;
+        assert!(matches!(
+            storage.exists(Path::new("foo/bar")).await,
+            Ok(false)
+        ));
         storage.delete(test_path).await?;
 
         assert!(matches!(

--- a/quickwit-storage/src/local_file_storage.rs
+++ b/quickwit-storage/src/local_file_storage.rs
@@ -141,7 +141,13 @@ impl Storage for LocalFileStorage {
     async fn exists(&self, path: &Path) -> StorageResult<bool> {
         let full_path = self.root.join(path);
         match fs::metadata(full_path).await {
-            Ok(_) => Ok(true),
+            Ok(metadata) => {
+                if metadata.is_file() {
+                    Ok(true)
+                } else {
+                    Ok(false)
+                }
+            }
             Err(err) => {
                 if err.kind() == ErrorKind::NotFound {
                     Ok(false)

--- a/quickwit-storage/src/local_file_storage.rs
+++ b/quickwit-storage/src/local_file_storage.rs
@@ -63,6 +63,8 @@ impl LocalFileStorage {
     }
 }
 
+/// This function deletes a directory path recursively from inside out
+///  with the condition that the directory is empty
 fn try_delete_dir_all(root: PathBuf, path: Option<&Path>) -> BoxFuture<'_, std::io::Result<()>> {
     async move {
         if path.is_none() {

--- a/quickwit-storage/src/storage.rs
+++ b/quickwit-storage/src/storage.rs
@@ -72,6 +72,13 @@ impl<'a> From<&'a [u8]> for PutPayload {
 ///
 /// Object storage are the primary target implementation of this trait,
 /// and its interface is meant to allow for multipart download/upload.
+///
+/// Note that Storage does not have the notion of directory separators.
+/// For underlying implementation where directory separator have meaning,
+/// The implementation should treat directory separators as exactly the same way
+/// object storage treat them. This means when directory separators a present
+/// in the storage operation path, the storage implementation should create and remove transparently
+/// these intermediate directories.  
 #[cfg_attr(any(test, feature = "testsuite"), mockall::automock)]
 #[async_trait]
 pub trait Storage: Send + Sync + 'static {


### PR DESCRIPTION
### Context / purpose
[Issues-59](https://github.com/quickwit-inc/quickwit/issues/59)

### Description
Implemented fix for LocalFileStorage to transparently create & remove intermediate directories

### Checklist
*Remove or complete this list if required.*
- [x] Clarify the semantics in the Storage trait.
- [x] Fix the LocalFileStorage implementation
- [x] Add tests
