### PR TITLE
Added SingeFileMetastoreFactory to metastoreUirResolver

### DIFF
--- a/quickwit-metastore/src/metastore/single_file_metastore.rs
+++ b/quickwit-metastore/src/metastore/single_file_metastore.rs
@@ -26,12 +26,16 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use quickwit_storage::StorageResolverError;
+use quickwit_storage::StorageUriResolver;
 use tokio::sync::RwLock;
 
 use quickwit_doc_mapping::DocMapping;
 use quickwit_storage::{PutPayload, Storage};
 
 use crate::metastore::FILE_FORMAT_VERSION;
+use crate::MetastoreFactory;
+use crate::MetastoreResolverError;
 use crate::{
     IndexMetadata, MetadataSet, Metastore, MetastoreErrorKind, MetastoreResult, SplitMetadata,
     SplitState,
@@ -59,11 +63,11 @@ pub struct SingleFileMetastore {
 #[allow(dead_code)]
 impl SingleFileMetastore {
     /// Creates a meta store given a storage.
-    pub async fn new(storage: Arc<dyn Storage>) -> MetastoreResult<Self> {
-        Ok(SingleFileMetastore {
+    pub fn new(storage: Arc<dyn Storage>) -> Self {
+        SingleFileMetastore {
             storage,
             cache: Arc::new(RwLock::new(HashMap::new())),
-        })
+        }
     }
 
     /// Check the index exists in storage.
@@ -493,6 +497,42 @@ impl Metastore for SingleFileMetastore {
     }
 }
 
+/// A SingeFileMetastore factory
+#[derive(Debug, Clone)]
+pub struct SingleFileMetastoreFactory {}
+
+impl Default for SingleFileMetastoreFactory {
+    fn default() -> Self {
+        SingleFileMetastoreFactory {}
+    }
+}
+
+impl MetastoreFactory for SingleFileMetastoreFactory {
+    fn protocol(&self) -> String {
+        "file".to_string()
+    }
+
+    fn resolve(&self, uri: &str) -> Result<Arc<dyn Metastore>, MetastoreResolverError> {
+        let storage = StorageUriResolver::default()
+            .resolve(uri)
+            .map_err(|err| match err {
+                StorageResolverError::InvalidUri(err_msg) => {
+                    MetastoreResolverError::InvalidUri(err_msg)
+                }
+                StorageResolverError::ProtocolUnsupported(err_msg) => {
+                    MetastoreResolverError::ProtocolUnsupported(err_msg)
+                }
+                StorageResolverError::FailedToOpenStorage(err) => {
+                    MetastoreResolverError::FailedToOpenMetastore(
+                        MetastoreErrorKind::InternalError.with_error(err),
+                    )
+                }
+            })?;
+        let metastore = SingleFileMetastore::new(storage);
+        Ok(Arc::new(metastore))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashSet;
@@ -508,7 +548,7 @@ mod tests {
     async fn test_single_file_metastore_index_exists() {
         let resolver = StorageUriResolver::default();
         let storage = resolver.resolve("ram://").unwrap();
-        let metastore = SingleFileMetastore::new(storage).await.unwrap();
+        let metastore = SingleFileMetastore::new(storage);
         let index_id = "my-index";
 
         {
@@ -534,7 +574,7 @@ mod tests {
     async fn test_single_file_metastore_create_index() {
         let resolver = StorageUriResolver::default();
         let storage = resolver.resolve("ram://").unwrap();
-        let metastore = SingleFileMetastore::new(storage).await.unwrap();
+        let metastore = SingleFileMetastore::new(storage);
         let index_id = "my-index";
 
         {
@@ -569,7 +609,7 @@ mod tests {
     async fn test_single_file_metastore_open_index() {
         let resolver = StorageUriResolver::default();
         let storage = resolver.resolve("ram://").unwrap();
-        let metastore = SingleFileMetastore::new(storage).await.unwrap();
+        let metastore = SingleFileMetastore::new(storage);
         let index_id = "my-index";
 
         {
@@ -607,7 +647,7 @@ mod tests {
     async fn test_single_file_metastore_delete_index() {
         let resolver = StorageUriResolver::default();
         let storage = resolver.resolve("ram://").unwrap();
-        let metastore = SingleFileMetastore::new(storage).await.unwrap();
+        let metastore = SingleFileMetastore::new(storage);
         let index_id = "my-index";
 
         {
@@ -645,7 +685,7 @@ mod tests {
     async fn test_single_file_metastore_stage_split() {
         let resolver = StorageUriResolver::default();
         let storage = resolver.resolve("ram://").unwrap();
-        let metastore = SingleFileMetastore::new(storage).await.unwrap();
+        let metastore = SingleFileMetastore::new(storage);
         let index_id = "my-index";
         let split_id = "one";
         let split_metadata = SplitMetadata {
@@ -773,7 +813,7 @@ mod tests {
     async fn test_single_file_metastore_publish_split() {
         let resolver = StorageUriResolver::default();
         let storage = resolver.resolve("ram://").unwrap();
-        let metastore = SingleFileMetastore::new(storage).await.unwrap();
+        let metastore = SingleFileMetastore::new(storage);
         let index_id = "my-index";
         let split_id = "one";
         let split_metadata = SplitMetadata {
@@ -868,7 +908,7 @@ mod tests {
     async fn test_single_file_metastore_list_splits() {
         let resolver = StorageUriResolver::default();
         let storage = resolver.resolve("ram://").unwrap();
-        let metastore = SingleFileMetastore::new(storage).await.unwrap();
+        let metastore = SingleFileMetastore::new(storage);
         let index_id = "my-index";
 
         {
@@ -1332,7 +1372,7 @@ mod tests {
     async fn test_single_file_metastore_mark_split_as_deleted() {
         let resolver = StorageUriResolver::default();
         let storage = resolver.resolve("ram://").unwrap();
-        let metastore = SingleFileMetastore::new(storage).await.unwrap();
+        let metastore = SingleFileMetastore::new(storage);
         let index_id = "my-index";
         let split_id = "split-one";
         let split_metadata = SplitMetadata {
@@ -1422,7 +1462,7 @@ mod tests {
     async fn test_single_file_metastore_delete_split() {
         let resolver = StorageUriResolver::default();
         let storage = resolver.resolve("ram://").unwrap();
-        let metastore = SingleFileMetastore::new(storage).await.unwrap();
+        let metastore = SingleFileMetastore::new(storage);
         let index_id = "my-index";
         let split_id = "split-one";
         let split_metadata = SplitMetadata {
@@ -1525,9 +1565,7 @@ mod tests {
                 .with_error(anyhow::anyhow!("Oops. Some network problem maybe?")))
         });
 
-        let metastore = SingleFileMetastore::new(Arc::new(mock_storage))
-            .await
-            .unwrap();
+        let metastore = SingleFileMetastore::new(Arc::new(mock_storage));
 
         let index_id = "my-index";
         let split_id = "split-one";

--- a/quickwit-metastore/src/metastore_resolver.rs
+++ b/quickwit-metastore/src/metastore_resolver.rs
@@ -23,6 +23,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use crate::metastore::single_file_metastore::SingleFileMetastoreFactory;
 use crate::{Metastore, MetastoreResolverError};
 
 /// A metastore factory builds a [`Metastore`] object from an URI.
@@ -42,11 +43,11 @@ pub struct MetastoreUriResolver {
 
 impl Default for MetastoreUriResolver {
     fn default() -> Self {
-        MetastoreUriResolver {
+        let mut resolver = MetastoreUriResolver {
             per_protocol_resolver: Default::default(),
-        }
-        //resolver.register(SingleFileMetastoreFactory::default());
-        //resolver
+        };
+        resolver.register(SingleFileMetastoreFactory::default());
+        resolver
     }
 }
 


### PR DESCRIPTION
### Context / purpose
[Issue-62](https://github.com/quickwit-inc/quickwit/issues/62)

### Description
Added a `SingleFileMetastoreFactory` to the `MetastoreUriResolver` .
@fulmicoton  @mosuka  
I want to stress that I have changed the signature of `async SingleFileMetastore::new(storage) ->  MetastoreResult<Self>`
 to `SingleFileMetastore::new(storage) ->  Self` in order to make it easier to use in the implementation of the `MetastoreFactory` resolve method. I feel like there was nothing async going on. But please advise if you were planning something later in the future.

