### PR TITLE
Prefix Storage Implementation

### DIFF
--- a/quickwit-storage/src/lib.rs
+++ b/quickwit-storage/src/lib.rs
@@ -35,6 +35,7 @@ pub use self::storage::{PutPayload, Storage};
 mod error;
 mod local_file_storage;
 mod object_storage;
+mod prefix_storage;
 mod ram_storage;
 mod retry;
 mod storage_resolver;
@@ -43,6 +44,7 @@ pub use self::local_file_storage::{LocalFileStorage, LocalFileStorageFactory};
 pub use self::object_storage::{
     MultiPartPolicy, S3CompatibleObjectStorage, S3CompatibleObjectStorageFactory,
 };
+pub use self::prefix_storage::add_prefix_to_storage;
 pub use self::ram_storage::{RamStorage, RamStorageBuilder};
 pub use self::storage_resolver::{StorageFactory, StorageUriResolver};
 pub use crate::error::{StorageError, StorageErrorKind, StorageResolverError, StorageResult};

--- a/quickwit-storage/src/prefix_storage.rs
+++ b/quickwit-storage/src/prefix_storage.rs
@@ -1,9 +1,9 @@
+use async_trait::async_trait;
 use std::{
     ops::Range,
     path::{Path, PathBuf},
     sync::Arc,
 };
-use async_trait::async_trait;
 
 use crate::Storage;
 
@@ -50,6 +50,7 @@ impl Storage for PrefixStorage {
     }
 }
 
+/// Creates a [`PrefixStorage`] using an underlying storage and a prefix.
 pub fn add_prefix_to_storage(storage: Arc<dyn Storage>, prefix: PathBuf) -> Arc<dyn Storage> {
     Arc::new(PrefixStorage { storage, prefix })
 }

--- a/quickwit-storage/src/prefix_storage.rs
+++ b/quickwit-storage/src/prefix_storage.rs
@@ -1,3 +1,25 @@
+/*
+    Quickwit
+    Copyright (C) 2021 Quickwit Inc.
+
+    Quickwit is offered under the AGPL v3.0 and as commercial software.
+    For commercial licensing, contact us at hello@quickwit.io.
+
+    AGPL:
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
 use async_trait::async_trait;
 use std::{
     ops::Range,

--- a/quickwit-storage/src/prefix_storage.rs
+++ b/quickwit-storage/src/prefix_storage.rs
@@ -1,0 +1,55 @@
+use std::{
+    ops::Range,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+use async_trait::async_trait;
+
+use crate::Storage;
+
+/// This storage acts as a proxy to another storage that simply modifies each API call
+/// by preceding each path with a given a prefix.
+struct PrefixStorage {
+    pub storage: Arc<dyn Storage>,
+    pub prefix: PathBuf,
+}
+
+#[async_trait]
+impl Storage for PrefixStorage {
+    async fn put(&self, path: &Path, payload: crate::PutPayload) -> crate::StorageResult<()> {
+        self.storage.put(&self.prefix.join(path), payload).await
+    }
+
+    async fn copy_to_file(&self, path: &Path, output_path: &Path) -> crate::StorageResult<()> {
+        self.storage
+            .copy_to_file(&self.prefix.join(path), output_path)
+            .await
+    }
+
+    async fn get_slice(&self, path: &Path, range: Range<usize>) -> crate::StorageResult<Vec<u8>> {
+        self.storage.get_slice(&self.prefix.join(path), range).await
+    }
+
+    async fn get_all(&self, path: &Path) -> crate::StorageResult<Vec<u8>> {
+        self.storage.get_all(&self.prefix.join(path)).await
+    }
+
+    async fn delete(&self, path: &Path) -> crate::StorageResult<()> {
+        self.storage.delete(&self.prefix.join(path)).await
+    }
+
+    async fn exists(&self, path: &Path) -> crate::StorageResult<bool> {
+        self.storage.exists(&self.prefix.join(path)).await
+    }
+
+    fn uri(&self) -> String {
+        Path::new(&self.storage.uri())
+            .join(&self.prefix)
+            .to_string_lossy()
+            .to_string()
+    }
+}
+
+pub fn add_prefix_to_storage(storage: Arc<dyn Storage>, prefix: PathBuf) -> Arc<dyn Storage> {
+    Arc::new(PrefixStorage { storage, prefix })
+}

--- a/quickwit-storage/src/ram_storage.rs
+++ b/quickwit-storage/src/ram_storage.rs
@@ -145,14 +145,12 @@ impl RamStorageBuilder {
 
 /// In Ram storage resolver
 pub struct RamStorageFactory {
-    storage_cache: std::sync::RwLock<HashMap<PathBuf, Arc<dyn Storage>>>,
     ram_storage: Arc<dyn Storage>,
 }
 
 impl Default for RamStorageFactory {
     fn default() -> Self {
         RamStorageFactory {
-            storage_cache: std::sync::RwLock::new(HashMap::default()),
             ram_storage: Arc::new(RamStorage::default()),
         }
     }
@@ -178,16 +176,7 @@ impl StorageFactory for RamStorageFactory {
         })?;
 
         let prefix_path = PathBuf::from(prefix);
-        let mut storage_cache = self.storage_cache.write().map_err(|err| {
-            StorageErrorKind::InternalError
-                .with_error(anyhow::anyhow!("Could not get the storage cache: {}", err))
-        })?;
-
-        let storage = storage_cache
-            .entry(prefix_path.clone())
-            .or_insert_with(|| add_prefix_to_storage(self.ram_storage.clone(), prefix_path));
-
-        Ok(storage.clone())
+        Ok(add_prefix_to_storage(self.ram_storage.clone(), prefix_path))
     }
 }
 

--- a/quickwit-storage/src/ram_storage.rs
+++ b/quickwit-storage/src/ram_storage.rs
@@ -20,6 +20,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+use crate::add_prefix_to_storage;
 use crate::{PutPayload, Storage, StorageErrorKind, StorageFactory, StorageResult};
 use async_trait::async_trait;
 use std::collections::HashMap;
@@ -144,12 +145,14 @@ impl RamStorageBuilder {
 
 /// In Ram storage resolver
 pub struct RamStorageFactory {
+    storage_cache: std::sync::RwLock<HashMap<PathBuf, Arc<dyn Storage>>>,
     ram_storage: Arc<dyn Storage>,
 }
 
 impl Default for RamStorageFactory {
     fn default() -> Self {
         RamStorageFactory {
+            storage_cache: std::sync::RwLock::new(HashMap::default()),
             ram_storage: Arc::new(RamStorage::default()),
         }
     }
@@ -161,14 +164,30 @@ impl StorageFactory for RamStorageFactory {
     }
 
     fn resolve(&self, uri: &str) -> crate::StorageResult<Arc<dyn Storage>> {
-        if uri != "ram://" {
+        if !uri.starts_with("ram://") {
             let err_msg = anyhow::anyhow!(
                 "{:?} is an invalid ram storage uri. Only ram:// is accepted.",
                 uri
             );
             return Err(StorageErrorKind::DoesNotExist.with_error(err_msg));
         }
-        Ok(self.ram_storage.clone())
+
+        let prefix = uri.split("://").nth(1).ok_or_else(|| {
+            StorageErrorKind::DoesNotExist
+                .with_error(anyhow::anyhow!("Invalid prefix path: {}", uri))
+        })?;
+
+        let prefix_path = PathBuf::from(prefix);
+        let mut storage_cache = self.storage_cache.write().map_err(|err| {
+            StorageErrorKind::InternalError
+                .with_error(anyhow::anyhow!("Could not get the storage cache: {}", err))
+        })?;
+
+        let storage = storage_cache
+            .entry(prefix_path.clone())
+            .or_insert_with(|| add_prefix_to_storage(self.ram_storage.clone(), prefix_path));
+
+        Ok(storage.clone())
     }
 }
 
@@ -187,8 +206,15 @@ mod tests {
     #[test]
     fn test_ram_storage_factory() {
         let ram_storage_factory = RamStorageFactory::default();
-        let err = ram_storage_factory.resolve("ram://toto").err().unwrap();
+        let err = ram_storage_factory.resolve("rom://toto").err().unwrap();
         assert_eq!(err.kind(), StorageErrorKind::DoesNotExist);
+
+        let data_result = ram_storage_factory.resolve("ram://data").ok().unwrap();
+        let home_result = ram_storage_factory.resolve("ram://home/data").ok().unwrap();
+        assert_ne!(data_result.uri(), home_result.uri());
+
+        let data_result_two = ram_storage_factory.resolve("ram://data").ok().unwrap();
+        assert_eq!(data_result.uri(), data_result_two.uri());
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Context / purpose
The current RamStorageFactory only resolves storage on this single uri `ram://`

### Description
@fulmicoton  has implemented a PrefixStorage that is used now in the RamStorageFactory in order to support multiple uri 
for RamStorage.

### Checklist
*Remove or complete this list if required.*
- [x] tested locally
- [x] updated unit tests
