### PR TITLE
Index wikipedia [NOT FOR MERGE]

### DIFF
--- a/quickwit-core/src/indexing/document_indexer.rs
+++ b/quickwit-core/src/indexing/document_indexer.rs
@@ -129,9 +129,7 @@ pub async fn index_documents(
 
 fn parse_document(doc_json: &str, schema: &Schema) -> anyhow::Result<Document> {
     //TODO: remove this when using docMapper
-    schema
-        .parse_document(doc_json)
-        .map_err(anyhow::Error::new)
+    schema.parse_document(doc_json).map_err(anyhow::Error::new)
 }
 
 #[cfg(test)]

--- a/quickwit-core/src/indexing/statistics.rs
+++ b/quickwit-core/src/indexing/statistics.rs
@@ -121,6 +121,7 @@ impl StatisticsCollector {
                         if error {
                             statistics.num_parse_errors += 1;
                         }
+                        println!("new doc -> {}", statistics.num_docs);
                     }
                     StatisticEvent::SplitCreated {
                         id,
@@ -128,6 +129,7 @@ impl StatisticsCollector {
                         size_in_bytes,
                         num_parse_errors,
                     } => {
+                        println!("new split");
                         debug!(split_id =% id, num_docs = num_docs,  size_in_bytes = size_in_bytes, parse_errors = num_parse_errors, "Split created");
                         statistics.num_local_splits += 1;
                     }
@@ -174,6 +176,15 @@ impl StatisticsCollector {
 
         let throughput_mb_s =
             self.total_bytes_processed as f64 / 1_000_000f64 / elapsed_secs.max(1) as f64;
-        println!("Indexing throughput: {} MB/s", throughput_mb_s);
+        println!("Indexing throughput: {:.1$}MB/s", throughput_mb_s, 2);
+        if elapsed_secs >= 60 {
+            println!(
+                "Ekapsed time: {:.1$}min",
+                elapsed_secs.max(1) as f64 / 60f64,
+                2
+            );
+        } else {
+            println!("Ekapsed time: {}s", elapsed_secs.max(1));
+        }
     }
 }

--- a/quickwit-core/src/indexing/statistics.rs
+++ b/quickwit-core/src/indexing/statistics.rs
@@ -21,6 +21,7 @@
 */
 
 use std::sync::Arc;
+use std::time::Instant;
 use tokio::sync::Mutex;
 use tokio::{
     sync::mpsc::{channel, Sender},
@@ -77,6 +78,8 @@ pub struct StatisticsCollector {
     total_bytes_processed: usize,
     /// Size in bytes of resulting split
     total_size_splits: usize,
+    /// Denotes the time this collector started
+    start_time: Instant,
 }
 
 impl StatisticsCollector {
@@ -91,6 +94,7 @@ impl StatisticsCollector {
             num_published_splits: 0,
             total_bytes_processed: 0,
             total_size_splits: 0,
+            start_time: Instant::now(),
         }
     }
 
@@ -158,7 +162,18 @@ impl StatisticsCollector {
 
     /// Display a one-shot report.
     pub fn display_report(&self) {
-        //TODO: better display stats
-        println!("Statistics: {:?}", self);
+        // TODO: better display stats
+        let elapsed_secs = self.start_time.elapsed().as_secs();
+        println!("Statistics");
+        println!("Num documents: {}", self.num_docs);
+        println!("Num parse errors: {}", self.num_parse_errors);
+        println!("Num splits: {}", self.num_local_splits);
+
+        println!("Total size: {} MB", self.total_bytes_processed / 1_000_000);
+        println!("Index size: {} MB", self.total_size_splits / 1_000_000);
+
+        let throughput_mb_s =
+            self.total_bytes_processed as f64 / 1_000_000f64 / elapsed_secs.max(1) as f64;
+        println!("Indexing throughput: {} MB/s", throughput_mb_s);
     }
 }


### PR DESCRIPTION
### Context / purpose
This is a test drive branch to try out the indexing command against the Wikipedia English corpus. 
We should revisit this and try out to see how are we doing for indexing a real dataset.

### How to run it.
`cargo run --release  -- index --index-uri file://./data --input-path ./wiki-articles.json`
`cargo run  -- index --index-uri s3://quickwit-dev/evance/test --input-path ./wiki-articles.json` [subject to implementing](https://github.com/quickwit-inc/quickwit/issues/70)

### How we currently do on my box?
We use 2 threads for indexing with 1GB allocated to each.
Spec:
Lenovo Thinkpad:
Intel(R) Xeon(R) W-10855M CPU @ 2.80GHz
RAM: 32GB

Statistics
Num documents: 5032105
Num parse errors: 0
Num splits: 3
Total size: 8886 MB
Index size: 6386 MB
Indexing throughput: 35.98MB/s
Elapsed time: 4.12min


### Checklist
- [ ] Still need to harmonize the storage and run this against S3


