### PR TITLE
Changes in create_index and IndexMetada API

### DIFF
--- a/quickwit-cli/Cargo.toml
+++ b/quickwit-cli/Cargo.toml
@@ -10,6 +10,7 @@ anyhow = "1"
 byte-unit = "4"
 clap = { version = "2", features = ["yaml"] }
 quickwit-core = { version = "0.1.0", path = "../quickwit-core" }
+quickwit-metastore = { version = "0.1.0", path = "../quickwit-metastore" }
 quickwit-doc-mapping = { version = "0.1.0", path = "../quickwit-doc-mapping" }
 tracing = '0.1'
 tracing-subscriber = "0.2"

--- a/quickwit-cli/src/main.rs
+++ b/quickwit-cli/src/main.rs
@@ -23,6 +23,7 @@
 use anyhow::{bail, Context};
 use byte_unit::Byte;
 use clap::{load_yaml, value_t, App, AppSettings, ArgMatches};
+use quickwit_metastore::IndexMetadata;
 use std::path::PathBuf;
 use tracing::debug;
 
@@ -206,7 +207,11 @@ async fn create_index_cli(args: CreateIndexArgs) -> anyhow::Result<()> {
     if args.overwrite {
         delete_index(metastore_uri, index_id).await?;
     }
-    create_index(metastore_uri, index_id, doc_mapping).await?;
+    let index_metadata = IndexMetadata {
+        index_id: index_id.to_string(),
+        index_uri: args.index_uri.to_string(),
+    };
+    create_index(metastore_uri, index_metadata, doc_mapping).await?;
     Ok(())
 }
 

--- a/quickwit-core/src/index.rs
+++ b/quickwit-core/src/index.rs
@@ -23,19 +23,19 @@
 use std::sync::Arc;
 
 use quickwit_doc_mapping::DocMapping;
-use quickwit_metastore::{Metastore, MetastoreUriResolver, SplitState};
+use quickwit_metastore::{IndexMetadata, Metastore, MetastoreUriResolver, SplitState};
 use quickwit_storage::Storage;
 
 // anyhow errors are fine for now but we'll want to move to a proper error type eventually.
 pub async fn create_index(
     metastore_uri: &str,
-    index_id: &str,
+    index_metadata: IndexMetadata,
     doc_mapping: DocMapping,
 ) -> anyhow::Result<()> {
     let metastore = MetastoreUriResolver::default()
         .resolve(&metastore_uri)
         .await?;
-    metastore.create_index(index_id, doc_mapping).await?;
+    metastore.create_index(index_metadata, doc_mapping).await?;
     Ok(())
 }
 

--- a/quickwit-metastore/src/metastore.rs
+++ b/quickwit-metastore/src/metastore.rs
@@ -33,13 +33,14 @@ use quickwit_doc_mapping::DocMapping;
 
 use crate::MetastoreResult;
 
-/// A file format version.
-const FILE_FORMAT_VERSION: &str = "0";
-
 /// An index metadata carries all meta data about an index.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct IndexMetadata {
-    version: String,
+    /// Index Id. The index id serves to identify the index when querying the metastore.
+    pub index_id: String,
+    /// Index Uri. The index uri defines the location of the storage that contains the
+    /// split files.
+    pub index_uri: String,
 }
 
 /// A split metadata carries all meta data about a split.
@@ -100,8 +101,10 @@ pub enum SplitState {
 /// A MetadataSet carries an index metadata and its split metadata.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct MetadataSet {
-    index: IndexMetadata,
-    splits: HashMap<String, SplitMetadata>,
+    /// Metadata specific to the index
+    pub index: IndexMetadata,
+    /// List of split belonging to the index.
+    pub splits: HashMap<String, SplitMetadata>,
 }
 
 /// Metastore meant to manage quickwit's indices and its splits.
@@ -136,7 +139,11 @@ pub trait Metastore: Send + Sync + 'static {
     /// Creates an index.
     /// This API creates index metadata set in the metastore.
     /// An error will occur if an index that exists in the storage is specified.
-    async fn create_index(&self, index_id: &str, doc_mapping: DocMapping) -> MetastoreResult<()>;
+    async fn create_index(
+        &self,
+        index_metadata: IndexMetadata,
+        doc_mapping: DocMapping,
+    ) -> MetastoreResult<()>;
 
     /// Returns the index_metadata for a given index.
     ///


### PR DESCRIPTION
 Following the index metadata change in #55, this PR adds an Index uri to the index metadata and makes it possible for users to specify an index_uri in the IndexMetadata passed in the create_index API.
