### PR TITLE
Fixes & statistics on Indexing

### DIFF
--- a/quickwit-core/Cargo.toml
+++ b/quickwit-core/Cargo.toml
@@ -10,7 +10,6 @@ anyhow = "1.0"
 async-trait = "0.1"
 quickwit-doc-mapping = { version = "0.1.0", path = "../quickwit-doc-mapping" }
 quickwit-metastore = { version = "0.1.0", path = "../quickwit-metastore" }
-
 quickwit-directories = { version = "0.1.0", path = "../quickwit-directories" }
 quickwit-storage = { version = "0.1.0", path = "../quickwit-storage" }
 tokio = { version = "1", features = ["full"] }
@@ -25,6 +24,7 @@ serde_json = "1.0"
 tracing = '0.1'
 tracing-subscriber = "0.2"
 tokio-stream = "0.1.6"
+crossterm = "0.19.0"
 
 [dev-dependencies]
 tempfile = '3'

--- a/quickwit-core/src/indexing/document_indexer.rs
+++ b/quickwit-core/src/indexing/document_indexer.rs
@@ -75,7 +75,6 @@ pub async fn index_documents(
                         error: false,
                     })
                     .await?;
-                current_split.metadata.num_records += 1;
                 current_split.metadata.size_in_bytes += doc_size;
                 doc
             }

--- a/quickwit-core/src/indexing/document_indexer.rs
+++ b/quickwit-core/src/indexing/document_indexer.rs
@@ -139,10 +139,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_index_document() -> anyhow::Result<()> {
-        let split_dir = tempfile::tempdir()?;
         let index_id = "test";
+        let split_dir = tempfile::tempdir()?;
+        let index_dir = tempfile::tempdir()?;
+        let index_uri = format!("file://{}/{}", index_dir.path().display(), index_id);
         let params = IndexDataParams {
-            index_uri: PathBuf::from_str("file://test")?,
+            index_uri: PathBuf::from_str(&index_uri)?,
             input_uri: None,
             temp_dir: split_dir.into_path(),
             num_threads: 1,

--- a/quickwit-core/src/indexing/document_indexer.rs
+++ b/quickwit-core/src/indexing/document_indexer.rs
@@ -23,6 +23,8 @@
 use quickwit_metastore::Metastore;
 use quickwit_storage::StorageUriResolver;
 use std::sync::Arc;
+use tantivy::schema::TextFieldIndexing;
+use tantivy::schema::TextOptions;
 use tantivy::{schema::Schema, Document};
 use tokio::sync::mpsc::Sender;
 
@@ -43,7 +45,14 @@ pub async fn index_documents(
     statistic_sender: Sender<StatisticEvent>,
 ) -> anyhow::Result<()> {
     //TODO replace with  DocMapper::schema()
-    let schema = Schema::builder().build();
+    let mut schema_builder = Schema::builder();
+    let text_options = TextOptions::default()
+        .set_stored()
+        .set_indexing_options(TextFieldIndexing::default());
+    schema_builder.add_text_field("title", text_options.clone());
+    schema_builder.add_text_field("body", text_options.clone());
+    schema_builder.add_text_field("url", text_options);
+    let schema = schema_builder.build();
 
     let mut current_split = Split::create(
         index_id.to_string(),
@@ -56,7 +65,7 @@ pub async fn index_documents(
     while let Some(raw_doc) = document_retriever.next_document().await? {
         let doc_size = raw_doc.as_bytes().len();
         //TODO: replace with DocMapper::doc_from_json(raw_doc)
-        let parse_result = parse_document(raw_doc);
+        let parse_result = parse_document(&raw_doc, &schema);
 
         let doc = match parse_result {
             Ok(doc) => {
@@ -118,9 +127,9 @@ pub async fn index_documents(
     Ok(())
 }
 
-fn parse_document(_raw_doc: String) -> anyhow::Result<Document> {
+fn parse_document(doc_json: &str, schema: &Schema) -> anyhow::Result<Document> {
     //TODO: remove this when using docMapper
-    Ok(Document::default())
+    schema.parse_document(doc_json).map_err(anyhow::Error::new)
 }
 
 #[cfg(test)]

--- a/quickwit-core/src/indexing/index.rs
+++ b/quickwit-core/src/indexing/index.rs
@@ -97,6 +97,7 @@ pub async fn index_data(
     )?;
 
     statistic_collector.lock().await.display_report();
+    println!("You can now query your index with `quickwit search --index-path {} --query \"barack obama\"`" , params.index_uri.display());
     Ok(())
 }
 

--- a/quickwit-core/src/indexing/split.rs
+++ b/quickwit-core/src/indexing/split.rs
@@ -39,7 +39,7 @@ use uuid::Uuid;
 
 use super::IndexDataParams;
 
-pub const MAX_DOC_PER_SPLIT: usize = if cfg!(test) { 100 } else { 5_000_000 };
+pub const MAX_DOC_PER_SPLIT: usize = if cfg!(test) { 100 } else { 5_0000_000 };
 
 /// Struct that represents an instance of split
 pub struct Split {
@@ -119,7 +119,6 @@ impl Split {
     /// Add document to the index split.
     pub fn add_document(&mut self, doc: Document) -> anyhow::Result<()> {
         //TODO: handle time range when docMapper is available
-        self.metadata.num_records += 1;
         self.index_writer
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("Missing index writer."))?
@@ -270,9 +269,6 @@ async fn put_to_storage(storage: &dyn Storage, split: &Split) -> anyhow::Result<
         };
 
         manifest.push(&file_name, metadata.len());
-        // TODO fix LocalFileStorage bug (https://github.com/quickwit-inc/quickwit/issues/59)
-        // for now this dirsty hack allows to work with LocalFileStorage
-        // let key = Path::new(&split.split_uri).join(&file_name);
         let key = PathBuf::from(file_name);
         let payload = quickwit_storage::PutPayload::from(path.clone());
         let upload_res_future = async move {
@@ -292,9 +288,6 @@ async fn put_to_storage(storage: &dyn Storage, split: &Split) -> anyhow::Result<
     futures::future::try_join_all(upload_res_futures).await?;
 
     let manifest_body = manifest.to_json()?.into_bytes();
-    // TODO fix LocalFileStorage bug (https://github.com/quickwit-inc/quickwit/issues/59)
-    // for now this dirsty hack allows to work with LocalFileStorage
-    // let manifest_path = Path::new(split.index_uri.as_str()).join(".manifest");
     let manifest_path = PathBuf::from(".manifest");
     storage
         .put(&manifest_path, PutPayload::from(manifest_body))

--- a/quickwit-core/src/indexing/split.rs
+++ b/quickwit-core/src/indexing/split.rs
@@ -123,6 +123,7 @@ impl Split {
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("Missing index writer."))?
             .add_document(doc);
+        self.metadata.num_records += 1;
         Ok(())
     }
 

--- a/quickwit-core/src/indexing/split.rs
+++ b/quickwit-core/src/indexing/split.rs
@@ -39,7 +39,7 @@ use uuid::Uuid;
 
 use super::IndexDataParams;
 
-pub const MAX_DOC_PER_SPLIT: usize = if cfg!(test) { 100 } else { 5_0000_000 };
+pub const MAX_DOC_PER_SPLIT: usize = if cfg!(test) { 100 } else { 5_000_000 };
 
 /// Struct that represents an instance of split
 pub struct Split {

--- a/quickwit-core/src/indexing/split_finalizer.rs
+++ b/quickwit-core/src/indexing/split_finalizer.rs
@@ -79,6 +79,8 @@ pub async fn finalize_split(
         warn!("Some splits were not finalised.");
     }
 
+    // TODO: we want to atomically publish all splits.
+    // See [https://github.com/quickwit-inc/quickwit/issues/71]
     let mut publish_stream = tokio_stream::iter(splits)
         .map(|split| {
             let moved_statistic_sender = statistic_sender.clone();

--- a/quickwit-core/src/indexing/split_finalizer.rs
+++ b/quickwit-core/src/indexing/split_finalizer.rs
@@ -41,7 +41,7 @@ pub async fn finalize_split(
     statistic_sender: Sender<StatisticEvent>,
 ) -> anyhow::Result<()> {
     let stream = ReceiverStream::new(split_receiver);
-    let mut stream = stream
+    let mut finalize_stream = stream
         .map(|mut split| {
             let moved_statistic_sender = statistic_sender.clone();
             async move {
@@ -59,21 +59,46 @@ pub async fn finalize_split(
                 split.merge_all_segments().await?;
                 split.stage(moved_statistic_sender.clone()).await?;
                 split.upload(moved_statistic_sender.clone()).await?;
-                split.publish(moved_statistic_sender).await?;
                 anyhow::Result::<Split>::Ok(split)
             }
         })
         .buffer_unordered(MAX_CONCURRENT_SPLIT_TASKS);
 
-    let mut num_erros: usize = 0;
-    while let Some(finalize_result) = stream.next().await {
-        if finalize_result.is_err() {
-            num_erros += 1;
+    let mut splits = vec![];
+    let mut finalize_erros: usize = 0;
+    while let Some(finalize_result) = finalize_stream.next().await {
+        if finalize_result.is_ok() {
+            let split = finalize_result?;
+            splits.push(split);
+        } else {
+            finalize_erros += 1;
         }
     }
 
-    if num_erros > 0 {
+    if finalize_erros > 0 {
         warn!("Some splits were not finalised.");
     }
+
+    let mut publish_stream = tokio_stream::iter(splits)
+        .map(|split| {
+            let moved_statistic_sender = statistic_sender.clone();
+            async move {
+                split.publish(moved_statistic_sender.clone()).await?;
+                anyhow::Result::<()>::Ok(())
+            }
+        })
+        .buffer_unordered(MAX_CONCURRENT_SPLIT_TASKS);
+
+    let mut publish_errors: usize = 0;
+    while let Some(publish_result) = publish_stream.next().await {
+        if publish_result.is_err() {
+            publish_errors += 1;
+        }
+    }
+
+    if publish_errors > 0 {
+        warn!("Some splits were not published.");
+    }
+
     Ok(())
 }

--- a/quickwit-core/src/indexing/statistics.rs
+++ b/quickwit-core/src/indexing/statistics.rs
@@ -121,7 +121,7 @@ impl StatisticsCollector {
                         if error {
                             statistics.num_parse_errors += 1;
                         }
-                        println!("new doc -> {}", statistics.num_docs);
+                        //println!("new doc -> {}", statistics.num_docs);
                     }
                     StatisticEvent::SplitCreated {
                         id,
@@ -131,7 +131,7 @@ impl StatisticsCollector {
                     } => {
                         debug!(split_id =% id, num_docs = num_docs,  size_in_bytes = size_in_bytes, parse_errors = num_parse_errors, "Split created");
                         statistics.num_local_splits += 1;
-                        println!("new split -> {}", statistics.num_local_splits);
+                        //println!("new split -> {}", statistics.num_local_splits);
                     }
                     StatisticEvent::SplitStage { id, error } => {
                         debug!(split_id =% id, error = error, "Split staged");
@@ -169,7 +169,7 @@ impl StatisticsCollector {
         println!("Statistics");
         println!("Num documents: {}", self.num_docs);
         println!("Num parse errors: {}", self.num_parse_errors);
-        println!("Num splits: {}", (self.num_local_splits-1).max(1));
+        println!("Num splits: {}", self.num_local_splits);
 
         println!("Total size: {} MB", self.total_bytes_processed / 1_000_000);
         println!("Index size: {} MB", self.total_size_splits / 1_000_000);

--- a/quickwit-core/src/indexing/statistics.rs
+++ b/quickwit-core/src/indexing/statistics.rs
@@ -121,7 +121,6 @@ impl StatisticsCollector {
                         if error {
                             statistics.num_parse_errors += 1;
                         }
-                        //println!("new doc -> {}", statistics.num_docs);
                     }
                     StatisticEvent::SplitCreated {
                         id,
@@ -131,7 +130,6 @@ impl StatisticsCollector {
                     } => {
                         debug!(split_id =% id, num_docs = num_docs,  size_in_bytes = size_in_bytes, parse_errors = num_parse_errors, "Split created");
                         statistics.num_local_splits += 1;
-                        //println!("new split -> {}", statistics.num_local_splits);
                     }
                     StatisticEvent::SplitStage { id, error } => {
                         debug!(split_id =% id, error = error, "Split staged");
@@ -179,7 +177,7 @@ impl StatisticsCollector {
         println!("Indexing throughput: {:.1$}MB/s", throughput_mb_s, 2);
         if elapsed_secs >= 60 {
             println!(
-                "Ekapsed time: {:.1$}min",
+                "Elapsed time: {:.1$}min",
                 elapsed_secs.max(1) as f64 / 60f64,
                 2
             );

--- a/quickwit-core/src/indexing/statistics.rs
+++ b/quickwit-core/src/indexing/statistics.rs
@@ -20,6 +20,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+use crossterm::terminal::{Clear, ClearType};
 use crossterm::{cursor, QueueableCommand};
 use std::io::{stdout, Stdout};
 use std::sync::Arc;
@@ -169,16 +170,17 @@ impl StatisticsCollector {
     /// Display a one-shot report.
     pub fn display_report(&self) {
         let elapsed_secs = self.start_time.elapsed().as_secs();
+        println!();
         if elapsed_secs >= 60 {
             println!(
-                "\nIndexded {} documents {:.2$}min",
+                "Indexded {} documents in {:.2$}min",
                 self.num_docs,
                 elapsed_secs.max(1) as f64 / 60f64,
                 2
             );
         } else {
             println!(
-                "\nIndexded {} documents {}s",
+                "Indexded {} documents in {}s",
                 self.num_docs,
                 elapsed_secs.max(1)
             );
@@ -187,11 +189,12 @@ impl StatisticsCollector {
 
     fn display_inline_report(&mut self) -> anyhow::Result<()> {
         let elapsed_secs = self.start_time.elapsed().as_secs();
+        self.stdout.queue(Clear(ClearType::CurrentLine))?;
         self.stdout.queue(cursor::SavePosition)?;
         let throughput_mb_s =
             self.total_bytes_processed as f64 / 1_000_000f64 / elapsed_secs.max(1) as f64;
 
-        println!("Documents: {}   Errors: {}  Splits: {}  Dataset Size: {}  Index Size: {} Throughput:  {:.6$}MB/s", 
+        println!("Documents: {} Errors: {}  Splits: {} Dataset Size: {} Index Size: {} Throughput: {:.6$}MB/s \nPlease hold on.", 
             self.num_docs, self.num_parse_errors,  self.num_local_splits,
             self.total_bytes_processed / 1_000_000,
             self.total_size_splits / 1_000_000,

--- a/quickwit-metastore/src/metastore/single_file_metastore.rs
+++ b/quickwit-metastore/src/metastore/single_file_metastore.rs
@@ -378,10 +378,7 @@ impl Default for SingleFileMetastoreFactory {
 #[async_trait]
 impl MetastoreFactory for SingleFileMetastoreFactory {
     fn protocols(&self) -> Vec<String> {
-        vec![
-            "file".to_string(),
-            "s3".to_string()
-        ]
+        vec!["file".to_string(), "s3".to_string()]
     }
 
     async fn resolve(&self, uri: String) -> Result<Arc<dyn Metastore>, MetastoreResolverError> {

--- a/quickwit-metastore/src/metastore/single_file_metastore.rs
+++ b/quickwit-metastore/src/metastore/single_file_metastore.rs
@@ -377,8 +377,11 @@ impl Default for SingleFileMetastoreFactory {
 
 #[async_trait]
 impl MetastoreFactory for SingleFileMetastoreFactory {
-    fn protocol(&self) -> String {
-        "file".to_string()
+    fn protocols(&self) -> Vec<String> {
+        vec![
+            "file".to_string(),
+            "s3".to_string()
+        ]
     }
 
     async fn resolve(&self, uri: String) -> Result<Arc<dyn Metastore>, MetastoreResolverError> {

--- a/quickwit-metastore/src/metastore_resolver.rs
+++ b/quickwit-metastore/src/metastore_resolver.rs
@@ -62,8 +62,7 @@ impl MetastoreUriResolver {
         let suported_protocols = resolver.protocols();
         let factory = Arc::new(resolver);
         for protocol in suported_protocols {
-            self.per_protocol_resolver
-            .insert(protocol, factory.clone());
+            self.per_protocol_resolver.insert(protocol, factory.clone());
         }
     }
 

--- a/quickwit-metastore/src/metastore_resolver.rs
+++ b/quickwit-metastore/src/metastore_resolver.rs
@@ -31,7 +31,9 @@ use crate::{Metastore, MetastoreResolverError};
 #[cfg_attr(any(test, feature = "testsuite"), mockall::automock)]
 #[async_trait]
 pub trait MetastoreFactory: Send + Sync + 'static {
-    /// Returns the protocol this URI resolver is serving.
+    // TODO: Changed this in order to support s3 indexing in the mean time.
+    // We need to agree on how we should resolve [https://github.com/quickwit-inc/quickwit/issues/70]
+    /// Returns the protocols this URI resolver is serving.
     fn protocols(&self) -> Vec<String>;
     /// Given an URI, returns a [`Metastore`] object.
     async fn resolve(&self, uri: String) -> Result<Arc<dyn Metastore>, MetastoreResolverError>;


### PR DESCRIPTION
### Context / purpose
The indexing needed some enhancements 

### Description
- Added changes to display statistics
- Added temporary changes for `MetastoreUriResolver` can resolve multiple protocols
- changed split publishing to happen at the end but still need to be atomic [see](https://github.com/quickwit-inc/quickwit/issues/71)
- added command report and how a user can search his index

### How was this PR tested?
I Ran the command `quickwit-cli index --index-uri 's3://quickwit-dev/evance/van2' --input-path ./wiki-articles-10000.json`

### Checklist
*Remove or complete this list if required.*
- [x] tested locally

