### PR TITLE
Add doc mapper basic implementations

### DIFF
--- a/quickwit-core/src/index.rs
+++ b/quickwit-core/src/index.rs
@@ -22,7 +22,7 @@
 
 use std::sync::Arc;
 
-use quickwit_doc_mapping::DocMapping;
+use quickwit_doc_mapping::DocMapper;
 use quickwit_metastore::{IndexMetadata, Metastore, MetastoreUriResolver, SplitState};
 use quickwit_storage::Storage;
 
@@ -30,12 +30,12 @@ use quickwit_storage::Storage;
 pub async fn create_index(
     metastore_uri: &str,
     index_metadata: IndexMetadata,
-    doc_mapping: DocMapping,
+    doc_mapper: Box<dyn DocMapper>,
 ) -> anyhow::Result<()> {
     let metastore = MetastoreUriResolver::default()
         .resolve(&metastore_uri)
         .await?;
-    metastore.create_index(index_metadata, doc_mapping).await?;
+    metastore.create_index(index_metadata, doc_mapper).await?;
     Ok(())
 }
 

--- a/quickwit-core/src/indexing/index.rs
+++ b/quickwit-core/src/indexing/index.rs
@@ -24,7 +24,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use futures::try_join;
-use quickwit_doc_mapping::DocMapping;
+use quickwit_doc_mapping::DocMapper;
 use quickwit_metastore::Metastore;
 use quickwit_metastore::{MetastoreUriResolver, SplitState};
 use quickwit_storage::StorageUriResolver;
@@ -57,7 +57,7 @@ pub struct IndexDataParams {
 pub async fn index_data(
     metastore_uri: &str,
     index_id: &str,
-    _doc_mapping: DocMapping,
+    _doc_mapper: Box<dyn DocMapper>,
     params: IndexDataParams,
 ) -> anyhow::Result<()> {
     let index_uri = params.index_uri.to_string_lossy().to_string();

--- a/quickwit-doc-mapping/Cargo.toml
+++ b/quickwit-doc-mapping/Cargo.toml
@@ -6,3 +6,8 @@ edition = "2018"
 license = "AGPL-3.0-or-later" # For a commercial, license, contact hello@quickwit.io
 
 [dependencies]
+anyhow = "1"
+tantivy = "0.14"
+serde_json = "1.0"
+thiserror = "1.0"
+serde = { version = "1.0", features = ["derive"] }

--- a/quickwit-doc-mapping/src/all_flatten_mapper.rs
+++ b/quickwit-doc-mapping/src/all_flatten_mapper.rs
@@ -1,0 +1,62 @@
+/*
+    Quickwit
+    Copyright (C) 2021 Quickwit Inc.
+
+    Quickwit is offered under the AGPL v3.0 and as commercial software.
+    For commercial licensing, contact us at hello@quickwit.io.
+
+    AGPL:
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+use crate::{mapper::SearchRequest, DocMapper};
+use tantivy::{
+    query::Query,
+    schema::{DocParsingError, Schema, SchemaBuilder, STORED},
+    Document,
+};
+
+pub struct AllFlattenDocMapper {
+    schema: Schema,
+}
+
+impl AllFlattenDocMapper {
+    pub fn new() -> anyhow::Result<Self> {
+        let mut schema_builder = SchemaBuilder::new();
+        schema_builder.add_text_field("_source", STORED);
+        Ok(AllFlattenDocMapper {
+            schema: schema_builder.build(),
+        })
+    }
+}
+
+impl DocMapper for AllFlattenDocMapper {
+    fn doc_from_json(&self, doc_json: &str) -> Result<Document, DocParsingError> {
+        let source = self
+            .schema
+            .get_field("_source")
+            .ok_or_else(|| DocParsingError::NoSuchFieldInSchema("_source".to_string()))?;
+        let mut document = self.schema.parse_document(doc_json)?;
+        document.add_text(source, doc_json);
+        Ok(document)
+    }
+
+    fn query(&self, _request: SearchRequest) -> Box<dyn Query> {
+        todo!()
+    }
+
+    fn schema(&self) -> Schema {
+        self.schema.clone()
+    }
+}

--- a/quickwit-doc-mapping/src/default_mapper.rs
+++ b/quickwit-doc-mapping/src/default_mapper.rs
@@ -1,0 +1,329 @@
+/*
+    Quickwit
+    Copyright (C) 2021 Quickwit Inc.
+
+    Quickwit is offered under the AGPL v3.0 and as commercial software.
+    For commercial licensing, contact us at hello@quickwit.io.
+
+    AGPL:
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+use crate::{mapper::SearchRequest, DocMapper};
+use serde::{Deserialize, Serialize};
+use serde_json::{self, Value as JsonValue};
+use std::collections::HashMap;
+use tantivy::{
+    query::Query,
+    schema::{DocParsingError, FieldEntry, FieldValue, Schema, SchemaBuilder, STORED},
+    Document,
+};
+
+pub struct DefaultDocMapper {
+    schema: Schema, // transient
+    config: DocMapperConfig,
+}
+
+impl DefaultDocMapper {
+    pub fn new(config: DocMapperConfig) -> anyhow::Result<DefaultDocMapper> {
+        Ok(DefaultDocMapper {
+            schema: config.schema(),
+            config,
+        })
+    }
+
+    /// Walk through the json object and for each json path :
+    /// - find the corresponding schema field
+    /// - create a tantivy::FieldValue with the found field and the json value
+    /// - add the FieldValue to the document
+    fn fill_document(
+        &self,
+        json_obj: &JsonValue,
+        document: &mut Document,
+    ) -> Result<(), DocParsingError> {
+        let mut values_by_json_path = HashMap::new();
+        let mut json_path: Vec<String> = vec![];
+        get_json_paths_and_values(&json_obj, &mut json_path, &mut values_by_json_path);
+        for (path, values) in values_by_json_path.iter() {
+            let field = self
+                .schema
+                .get_field(path)
+                .ok_or_else(|| DocParsingError::NoSuchFieldInSchema(path.clone()))?;
+            let field_entry = self.schema.get_field_entry(field);
+            let field_type = field_entry.field_type();
+            for value in values.iter() {
+                let value = field_type
+                    .value_from_json(value)
+                    .map_err(|e| DocParsingError::ValueError(path.clone(), e))?;
+                document.add(FieldValue::new(field, value));
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Walk through a json object and fill the map `values_by_json_path` for each node with:
+/// - key: json path as a string
+/// - value: list of json values matching the key
+fn get_json_paths_and_values(
+    object: &JsonValue,
+    current_path: &mut Vec<String>,
+    values_by_json_path: &mut HashMap<String, Vec<JsonValue>>,
+) {
+    match *object {
+        JsonValue::Array(ref object_array) => {
+            for value in object_array.iter() {
+                get_json_paths_and_values(value, current_path, values_by_json_path);
+            }
+        }
+        JsonValue::Object(ref object_map) => {
+            for (key, value) in object_map.iter() {
+                current_path.push(key.clone());
+                get_json_paths_and_values(value, current_path, values_by_json_path);
+                current_path.pop();
+            }
+        }
+        JsonValue::Null => {
+            // TODO: define how to handle null values
+        }
+        _ => {
+            let path = current_path.join(".");
+            let entry = values_by_json_path.entry(path).or_insert_with(Vec::new);
+            entry.push(object.clone());
+        }
+    }
+}
+
+impl DocMapper for DefaultDocMapper {
+    fn doc_from_json(&self, doc_json: &str) -> Result<Document, DocParsingError> {
+        let mut document = Document::default();
+        if self.config.store_source {
+            let source = self
+                .schema
+                .get_field("_source")
+                .ok_or_else(|| DocParsingError::NoSuchFieldInSchema("_source".to_string()))?;
+            document.add_text(source, doc_json);
+        }
+        let json_obj = serde_json::from_str(doc_json).map_err(|_| {
+            let doc_json_sample: String = if doc_json.len() < 20 {
+                String::from(doc_json)
+            } else {
+                format!("{:?}...", &doc_json[0..20])
+            };
+            DocParsingError::NotJSON(doc_json_sample)
+        })?;
+        self.fill_document(&json_obj, &mut document)?;
+        Ok(document)
+    }
+
+    fn query(&self, _request: SearchRequest) -> Box<dyn Query> {
+        todo!()
+    }
+
+    fn schema(&self) -> Schema {
+        self.config.schema()
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct DocMapperConfig {
+    store_source: bool,
+    ignore_unknown_fields: bool,
+    properties: Vec<FieldEntry>,
+}
+
+impl DocMapperConfig {
+    /// Build the schema from the config
+    pub fn schema(&self) -> Schema {
+        let mut builder = SchemaBuilder::new();
+        self.properties.iter().for_each(|entry| {
+            builder.add_field(entry.clone());
+        });
+        if self.store_source {
+            builder.add_text_field("_source", STORED);
+        }
+        builder.build()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{get_json_paths_and_values, DefaultDocMapper, DocMapper, DocMapperConfig};
+    use serde_json::{self, Value as JsonValue};
+    use std::collections::HashMap;
+
+    const JSON_DOC_VALUE: &str = r#"
+        {
+            "timestamp": 1586960586000,
+            "severity_text": "INFO",
+            "resources.label": "20200415T072306-0700 INFO This is a great log",
+            "attributes": {
+                "server": "ABC",
+                "tags": ["prod", "region-1"]
+            },
+            "meta": [
+                {
+                    "organization": "quickwit"
+                }
+            ]
+        }"#;
+
+    const EXPECTED_JSON_PATHS_AND_VALUES: &str = r#"{
+            "timestamp": [1586960586000],
+            "severity_text": ["INFO"],
+            "resources.label": ["20200415T072306-0700 INFO This is a great log"],
+            "attributes.server": ["ABC"],
+            "attributes.tags": ["prod", "region-1"],
+            "meta.organization": ["quickwit"]
+        }"#;
+
+    const JSON_MAPPING_VALUE: &str = r#"
+        {
+            "store_source": true,
+            "ignore_unknown_fields": true,
+            "properties": [{
+                "name": "timestamp",
+                "type": "u64",
+                "options": {
+                    "indexed": true,
+                    "fast": "single",
+                    "stored": false
+                }
+            }, 
+            {
+                "name": "severity_text",
+                "type": "text",
+                "options": {
+                    "indexing": {
+                      "record": "basic",
+                      "tokenizer": "raw"
+                    },
+                    "stored": false
+                }
+            }, 
+            {
+                "name": "resources.label",
+                "type": "text",
+                "options": {
+                    "indexing": {
+                      "record": "position",
+                      "tokenizer": "default"
+                    },
+                    "stored": false
+                }
+            },
+            {
+                "name": "attributes.server",
+                "type": "text",
+                "options": {
+                    "indexing": {
+                      "record": "basic",
+                      "tokenizer": "raw"
+                    },
+                    "stored": false
+                }
+            },
+            {
+                "name": "attributes.tags",
+                "type": "text",
+                "options": {
+                    "indexing": {
+                      "record": "basic",
+                      "tokenizer": "raw"
+                    },
+                    "stored": false
+                }
+            },
+            {
+                "name": "meta.organization",
+                "type": "text",
+                "options": {
+                    "indexing": {
+                      "record": "basic",
+                      "tokenizer": "raw"
+                    },
+                    "stored": false
+                }
+            }]
+        }"#;
+
+    #[test]
+    fn test_deserialize_mapping() -> anyhow::Result<()> {
+        serde_json::from_str::<DocMapperConfig>(JSON_MAPPING_VALUE)?;
+        Ok(())
+    }
+
+    #[test]
+    fn test_config_schema() -> anyhow::Result<()> {
+        let config = serde_json::from_str::<DocMapperConfig>(JSON_MAPPING_VALUE)?;
+        assert_eq!(config.schema().fields().count(), 7);
+        Ok(())
+    }
+
+    #[test]
+    fn test_get_json_paths_and_values() {
+        let json_object = serde_json::from_str(JSON_DOC_VALUE).unwrap();
+        let expected_json_paths_and_values: HashMap<String, JsonValue> =
+            serde_json::from_str(EXPECTED_JSON_PATHS_AND_VALUES).unwrap();
+        let mut values_by_json_path = HashMap::new();
+        let mut json_path: Vec<String> = vec![];
+        get_json_paths_and_values(
+            &JsonValue::Object(json_object),
+            &mut json_path,
+            &mut values_by_json_path,
+        );
+        for (json_path, values) in values_by_json_path.iter() {
+            assert_eq!(expected_json_paths_and_values.contains_key(json_path), true);
+            let expected_values = expected_json_paths_and_values
+                .get(json_path)
+                .unwrap()
+                .as_array()
+                .unwrap();
+            assert_eq!(values.len(), expected_values.len());
+            for idx in 0..expected_values.len() {
+                assert_eq!(values[idx], expected_values[idx]);
+            }
+        }
+    }
+
+    #[test]
+    fn test_parsing_document() -> anyhow::Result<()> {
+        let config = serde_json::from_str::<DocMapperConfig>(JSON_MAPPING_VALUE)?;
+        let schema = config.schema();
+        let doc_mapper = DefaultDocMapper::new(config)?;
+        let document = doc_mapper.doc_from_json(JSON_DOC_VALUE)?;
+        // 6 fields with 1 value + one field with two values
+        assert_eq!(document.len(), 8);
+        let expected_json_paths_and_values: HashMap<String, JsonValue> =
+            serde_json::from_str(EXPECTED_JSON_PATHS_AND_VALUES).unwrap();
+        document.field_values().iter().for_each(|field_value| {
+            let field_name = schema.get_field_name(field_value.field());
+            if field_name == "_source" {
+                assert_eq!(field_value.value().text().unwrap(), JSON_DOC_VALUE, "");
+            } else {
+                let value = serde_json::to_string_pretty(field_value.value()).unwrap();
+                let is_value_in_expected_values = expected_json_paths_and_values
+                    .get(field_name)
+                    .unwrap()
+                    .as_array()
+                    .unwrap()
+                    .iter()
+                    .map(|expected_value| format!("{}", expected_value))
+                    .any(|expected_value| expected_value == value);
+                assert!(is_value_in_expected_values);
+            }
+        });
+        Ok(())
+    }
+}

--- a/quickwit-doc-mapping/src/lib.rs
+++ b/quickwit-doc-mapping/src/lib.rs
@@ -19,13 +19,15 @@
     You should have received a copy of the GNU Affero General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 #![warn(missing_docs)]
 
 //! Doc mapping defines the way to convert a json like documents to
 //! a document indexable by tantivy engine, aka tantivy::Document.
 
-/// Placeholder implementation before merging the DocMapper PR
-pub enum DocMapping {
-    /// Dynamic mapper...
-    Dynamic,
-}
+mod all_flatten_mapper;
+mod default_mapper;
+mod mapper;
+mod wikipedia_mapper;
+
+pub use self::mapper::{build_doc_mapper, DocMapper, DocMapperType};

--- a/quickwit-doc-mapping/src/mapper.rs
+++ b/quickwit-doc-mapping/src/mapper.rs
@@ -1,0 +1,78 @@
+/*
+    Quickwit
+    Copyright (C) 2021 Quickwit Inc.
+
+    Quickwit is offered under the AGPL v3.0 and as commercial software.
+    For commercial licensing, contact us at hello@quickwit.io.
+
+    AGPL:
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+use crate::{
+    all_flatten_mapper::AllFlattenDocMapper,
+    default_mapper::{DefaultDocMapper, DocMapperConfig},
+    wikipedia_mapper::WikipediaMapper,
+};
+use tantivy::{
+    query::Query,
+    schema::{DocParsingError, Schema},
+    Document,
+};
+
+/// The `DocMapper` trait defines the way of defining how a (json) document,
+/// and the fields it contains, are stored and indexed.
+///
+/// The `DocMapper` trait is in charge of implementing :
+///
+/// - a way to build a tantivy::Document from a json payload
+/// - a way to build a tantivy::Query from a SearchRequest
+/// - a way to build a tantivy:Schema
+///
+pub trait DocMapper: Send + Sync + 'static {
+    /// Returns the document built from a json string.
+    fn doc_from_json(&self, doc_json: &str) -> Result<Document, DocParsingError>;
+    /// Returns the schema.
+    fn schema(&self) -> Schema;
+    /// Returns the query.
+    fn query(&self, _request: SearchRequest) -> Box<dyn Query>;
+}
+// TODO: this is a placeholder, to be removed when it will be implementend in the search-api crate
+pub struct SearchRequest {}
+
+/// A `DocMapperType` describe a set of rules to build a document, query and schema.
+#[derive(Clone)]
+pub enum DocMapperType {
+    /// Default doc mapper which is build from a config file
+    Default(DocMapperConfig),
+    /// All flatten doc mapper which indexes everything in one single field
+    AllFlatten,
+    /// Wikipedia doc mapper
+    Wikipedia,
+}
+
+/// Build a doc mapper given the doc mapper type.
+pub fn build_doc_mapper(mapper_type: DocMapperType) -> anyhow::Result<Box<dyn DocMapper>> {
+    match mapper_type {
+        DocMapperType::Default(config) => {
+            DefaultDocMapper::new(config).map(|mapper| Box::new(mapper) as Box<dyn DocMapper>)
+        }
+        DocMapperType::AllFlatten => {
+            AllFlattenDocMapper::new().map(|mapper| Box::new(mapper) as Box<dyn DocMapper>)
+        }
+        DocMapperType::Wikipedia => {
+            WikipediaMapper::new().map(|mapper| Box::new(mapper) as Box<dyn DocMapper>)
+        }
+    }
+}

--- a/quickwit-doc-mapping/src/wikipedia_mapper.rs
+++ b/quickwit-doc-mapping/src/wikipedia_mapper.rs
@@ -1,0 +1,61 @@
+/*
+    Quickwit
+    Copyright (C) 2021 Quickwit Inc.
+
+    Quickwit is offered under the AGPL v3.0 and as commercial software.
+    For commercial licensing, contact us at hello@quickwit.io.
+
+    AGPL:
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+use crate::{mapper::SearchRequest, DocMapper};
+use tantivy::{
+    query::Query,
+    schema::{DocParsingError, Schema, TextFieldIndexing, TextOptions},
+    Document,
+};
+
+pub struct WikipediaMapper {
+    schema: Schema,
+}
+
+impl WikipediaMapper {
+    pub fn new() -> anyhow::Result<Self> {
+        let mut schema_builder = Schema::builder();
+        let text_options = TextOptions::default()
+            .set_stored()
+            .set_indexing_options(TextFieldIndexing::default());
+        schema_builder.add_text_field("title", text_options.clone());
+        schema_builder.add_text_field("body", text_options.clone());
+        schema_builder.add_text_field("url", text_options);
+        Ok(WikipediaMapper {
+            schema: schema_builder.build(),
+        })
+    }
+}
+
+impl DocMapper for WikipediaMapper {
+    fn doc_from_json(&self, doc_json: &str) -> Result<Document, DocParsingError> {
+        self.schema.parse_document(doc_json)
+    }
+
+    fn query(&self, _request: SearchRequest) -> Box<dyn Query> {
+        todo!()
+    }
+
+    fn schema(&self) -> Schema {
+        self.schema.clone()
+    }
+}

--- a/quickwit-metastore/src/metastore.rs
+++ b/quickwit-metastore/src/metastore.rs
@@ -27,9 +27,8 @@ use std::fmt::Debug;
 use std::ops::Range;
 
 use async_trait::async_trait;
+use quickwit_doc_mapping::DocMapper;
 use serde::{Deserialize, Serialize};
-
-use quickwit_doc_mapping::DocMapping;
 
 use crate::MetastoreResult;
 
@@ -142,7 +141,7 @@ pub trait Metastore: Send + Sync + 'static {
     async fn create_index(
         &self,
         index_metadata: IndexMetadata,
-        doc_mapping: DocMapping,
+        doc_mapper: Box<dyn DocMapper>,
     ) -> MetastoreResult<()>;
 
     /// Returns the index_metadata for a given index.

--- a/quickwit-metastore/src/metastore/single_file_metastore.rs
+++ b/quickwit-metastore/src/metastore/single_file_metastore.rs
@@ -26,11 +26,11 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use quickwit_doc_mapping::DocMapper;
 use quickwit_storage::StorageResolverError;
 use quickwit_storage::StorageUriResolver;
 use tokio::sync::RwLock;
 
-use quickwit_doc_mapping::DocMapping;
 use quickwit_storage::{PutPayload, Storage};
 
 use crate::MetastoreFactory;
@@ -158,7 +158,7 @@ impl Metastore for SingleFileMetastore {
     async fn create_index(
         &self,
         index_metadata: IndexMetadata,
-        _doc_mapping: DocMapping,
+        _doc_mapper: Box<dyn DocMapper>,
     ) -> MetastoreResult<()> {
         // Check for the existence of index.
         let exists = self
@@ -412,7 +412,7 @@ mod tests {
 
     use crate::IndexMetadata;
     use crate::{Metastore, MetastoreErrorKind, SingleFileMetastore, SplitMetadata, SplitState};
-    use quickwit_doc_mapping::DocMapping;
+    use quickwit_doc_mapping::{build_doc_mapper, DocMapperType};
     use quickwit_storage::{MockStorage, StorageErrorKind};
 
     #[tokio::test]
@@ -430,10 +430,11 @@ mod tests {
                 index_id: index_id.to_string(),
                 index_uri: "ram://indexes/my-index".to_string(),
             };
+            let mapper = build_doc_mapper(DocMapperType::AllFlatten).unwrap();
 
             // Create index
             metastore
-                .create_index(index_metadata, DocMapping::Dynamic)
+                .create_index(index_metadata, mapper)
                 .await
                 .unwrap();
 
@@ -459,10 +460,11 @@ mod tests {
                 index_id: index_id.to_string(),
                 index_uri: "ram://indexes//my-index".to_string(),
             };
+            let mapper = build_doc_mapper(DocMapperType::AllFlatten).unwrap();
 
             // Create index
             metastore
-                .create_index(index_metadata.clone(), DocMapping::Dynamic)
+                .create_index(index_metadata.clone(), mapper)
                 .await
                 .unwrap();
 
@@ -471,8 +473,9 @@ mod tests {
             let expected = true;
             assert_eq!(result, expected);
 
+            let mapper = build_doc_mapper(DocMapperType::AllFlatten).unwrap();
             let result = metastore
-                .create_index(index_metadata, DocMapping::Dynamic)
+                .create_index(index_metadata, mapper)
                 .await
                 .unwrap_err()
                 .kind();
@@ -496,9 +499,10 @@ mod tests {
                 index_id: index_id.to_string(),
                 index_uri: "ram://indexes//my-index".to_string(),
             };
+            let mapper = build_doc_mapper(DocMapperType::AllFlatten).unwrap();
             // Create index
             metastore
-                .create_index(index_metadata, DocMapping::Dynamic)
+                .create_index(index_metadata, mapper)
                 .await
                 .unwrap();
 
@@ -536,10 +540,11 @@ mod tests {
                 index_id: index_id.to_string(),
                 index_uri: "ram://indexes//my-index".to_string(),
             };
+            let mapper = build_doc_mapper(DocMapperType::AllFlatten).unwrap();
 
             // Create index
             metastore
-                .create_index(index_metadata, DocMapping::Dynamic)
+                .create_index(index_metadata, mapper)
                 .await
                 .unwrap();
 
@@ -586,10 +591,11 @@ mod tests {
                 index_id: index_id.to_string(),
                 index_uri: "ram://indexes/my-index".to_string(),
             };
+            let mapper = build_doc_mapper(DocMapperType::AllFlatten).unwrap();
 
             // Create index
             metastore
-                .create_index(index_metadata, DocMapping::Dynamic)
+                .create_index(index_metadata, mapper)
                 .await
                 .unwrap();
 
@@ -717,9 +723,10 @@ mod tests {
                 index_id: index_id.to_string(),
                 index_uri: "ram://indexes/my-index".to_string(),
             };
+            let mapper = build_doc_mapper(DocMapperType::AllFlatten).unwrap();
             // Create index
             metastore
-                .create_index(index_metadata, DocMapping::Dynamic)
+                .create_index(index_metadata, mapper)
                 .await
                 .unwrap();
 
@@ -800,9 +807,11 @@ mod tests {
                 index_id: index_id.to_string(),
                 index_uri: "ram://indexes/my-index".to_string(),
             };
+            let mapper = build_doc_mapper(DocMapperType::AllFlatten).unwrap();
+
             // create index
             metastore
-                .create_index(index_metadata, DocMapping::Dynamic)
+                .create_index(index_metadata, mapper)
                 .await
                 .unwrap();
         }
@@ -1323,10 +1332,11 @@ mod tests {
                 index_id: index_id.to_string(),
                 index_uri: "ram://indexes/my-index".to_string(),
             };
+            let mapper = build_doc_mapper(DocMapperType::AllFlatten).unwrap();
 
             // Create index
             metastore
-                .create_index(index_metadata, DocMapping::Dynamic)
+                .create_index(index_metadata, mapper)
                 .await
                 .unwrap();
 
@@ -1416,10 +1426,11 @@ mod tests {
                 index_id: index_id.to_string(),
                 index_uri: "ram://indexes/my-index".to_string(),
             };
+            let mapper = build_doc_mapper(DocMapperType::AllFlatten).unwrap();
 
             // Create index
             metastore
-                .create_index(index_metadata, DocMapping::Dynamic)
+                .create_index(index_metadata, mapper)
                 .await
                 .unwrap();
 
@@ -1519,10 +1530,11 @@ mod tests {
             index_id: index_id.to_string(),
             index_uri: "ram://my-indexes/my-index".to_string(),
         };
+        let mapper = build_doc_mapper(DocMapperType::AllFlatten).unwrap();
 
         // create index
         metastore
-            .create_index(index_metadata, DocMapping::Dynamic)
+            .create_index(index_metadata, mapper)
             .await
             .unwrap();
 


### PR DESCRIPTION
This PR aims at solving issue #28
It's definitely not the implementation that we target but there is the trait and basic implementations that we can use to index wikipedia.
This will be followed by another PR for the full implementations of default doc mapper and all flatten doc mapper.
