### PR TITLE
Publish splits at the end

### DIFF
--- a/quickwit-core/src/indexing/document_indexer.rs
+++ b/quickwit-core/src/indexing/document_indexer.rs
@@ -66,7 +66,6 @@ pub async fn index_documents(
                         error: false,
                     })
                     .await?;
-                current_split.metadata.num_records += 1;
                 current_split.metadata.size_in_bytes += doc_size;
                 doc
             }
@@ -139,10 +138,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_index_document() -> anyhow::Result<()> {
-        let split_dir = tempfile::tempdir()?;
         let index_id = "test";
+        let split_dir = tempfile::tempdir()?;
+        let index_dir = tempfile::tempdir()?;
+        let index_uri = format!("file://{}/{}", index_dir.path().display(), index_id);
         let params = IndexDataParams {
-            index_uri: PathBuf::from_str("file://test")?,
+            index_uri: PathBuf::from_str(&index_uri)?,
             input_uri: None,
             temp_dir: split_dir.into_path(),
             num_threads: 1,

--- a/quickwit-core/src/indexing/split_finalizer.rs
+++ b/quickwit-core/src/indexing/split_finalizer.rs
@@ -65,17 +65,17 @@ pub async fn finalize_split(
         .buffer_unordered(MAX_CONCURRENT_SPLIT_TASKS);
 
     let mut splits = vec![];
-    let mut finalize_erros: usize = 0;
+    let mut finalize_errors: usize = 0;
     while let Some(finalize_result) = finalize_stream.next().await {
         if finalize_result.is_ok() {
             let split = finalize_result?;
             splits.push(split);
         } else {
-            finalize_erros += 1;
+            finalize_errors += 1;
         }
     }
 
-    if finalize_erros > 0 {
+    if finalize_errors > 0 {
         warn!("Some splits were not finalised.");
     }
 


### PR DESCRIPTION
### Context / purpose
The indexing needed some enhancements

### Description
Changed split publishing to happen at the end but still need to be atomic [see](https://github.com/quickwit-inc/quickwit/issues/71)

### How was this PR tested?
Run the command `quickwit-cli index --index-uri 'file://./data' --input-path ./wiki-articles-10000.json`

### Checklist
*Remove or complete this list if required.*
- [x] tested locally
