### PR TITLE
Added doc mapper options CLI

### DIFF
--- a/quickwit-cli/src/cli.yaml
+++ b/quickwit-cli/src/cli.yaml
@@ -11,6 +11,17 @@ subcommands:
                 long: index-uri
                 value_name: INDEX URI
                 required: true
+            - doc-mapper-type:
+                help: Type of the document mapper
+                long: doc-mapper-type
+                value_name: DOC MAPPER
+                default_value: default
+            - doc-mapper-config-path:
+                help: Configuration of the document mapper
+                long: doc-mapper-config-path
+                value_name: DOC MAPPER CONFIG
+                required_if:
+                - [doc-mapper-type, default]
             - timestamp-field:
                 help: Creates a time-series index with the specified timestamp field
                 long: timestamp-field

--- a/quickwit-cli/src/cli.yaml
+++ b/quickwit-cli/src/cli.yaml
@@ -17,7 +17,7 @@ subcommands:
                 value_name: DOC MAPPER
                 default_value: default
             - doc-mapper-config-path:
-                help: Configuration of the document mapper
+                help: Path of the document mapper configuration
                 long: doc-mapper-config-path
                 value_name: DOC MAPPER CONFIG
                 required_if:

--- a/quickwit-cli/src/main.rs
+++ b/quickwit-cli/src/main.rs
@@ -25,6 +25,7 @@ use byte_unit::Byte;
 use clap::{load_yaml, value_t, App, AppSettings, ArgMatches};
 use quickwit_doc_mapping::{build_doc_mapper, DocMapperType};
 use quickwit_metastore::IndexMetadata;
+use std::convert::TryFrom;
 use std::path::PathBuf;
 use tracing::debug;
 
@@ -33,6 +34,8 @@ use quickwit_core::indexing::{index_data, IndexDataParams};
 
 struct CreateIndexArgs {
     index_uri: String,
+    doc_mapper_type: DocMapperType,
+    doc_mapper_config_path: Option<PathBuf>,
     timestamp_field: Option<String>,
     overwrite: bool,
 }
@@ -87,6 +90,14 @@ impl CliCommand {
             .value_of("index-uri")
             .context("'index-uri' is a required arg")?
             .to_string();
+        let doc_mapper_type = matches
+            .value_of("doc-mapper-type")
+            .map(DocMapperType::try_from)
+            .context("doc-mapper-type has a default value")?
+            .map_err(|err| anyhow::anyhow!(err))?;
+        let doc_mapper_config_path = matches
+            .value_of("doc-mapper-config-path")
+            .map(PathBuf::from);
         let timestamp_field = matches
             .value_of("timestamp-field")
             .map(|field| field.to_string());
@@ -94,6 +105,8 @@ impl CliCommand {
 
         Ok(CliCommand::New(CreateIndexArgs {
             index_uri,
+            doc_mapper_type,
+            doc_mapper_config_path,
             timestamp_field,
             overwrite,
         }))
@@ -196,6 +209,8 @@ fn extract_metastore_uri_and_index_id_from_index_uri(
 async fn create_index_cli(args: CreateIndexArgs) -> anyhow::Result<()> {
     debug!(
         index_uri = %args.index_uri,
+        doc_mapper_type = ?args.doc_mapper_type,
+        doc_mapper_config_path = ?args.doc_mapper_config_path,
         timestamp_field = ?args.timestamp_field,
         overwrite = args.overwrite,
         "create-index"
@@ -301,16 +316,28 @@ mod tests {
         DeleteIndexArgs, IndexDataArgs, SearchIndexArgs,
     };
     use clap::{load_yaml, App, AppSettings};
+    use quickwit_doc_mapping::DocMapperType;
     use std::path::{Path, PathBuf};
 
     #[test]
     fn test_parse_new_args() -> anyhow::Result<()> {
         let yaml = load_yaml!("cli.yaml");
         let app = App::from(yaml).setting(AppSettings::NoBinaryName);
+        let matches_result = app.get_matches_from_safe(vec![
+            "new",
+            "--index-uri",
+            "file:///indexes/wikipedia",
+            "--no-timestamp-field",
+        ]);
+        assert!(matches!(matches_result, Err(_)));
+
+        let app = App::from(yaml).setting(AppSettings::NoBinaryName);
         let matches = app.get_matches_from_safe(vec![
             "new",
             "--index-uri",
             "file:///indexes/wikipedia",
+            "--doc-mapper-config-path",
+            "./config.json",
             "--no-timestamp-field",
         ])?;
         let command = CliCommand::parse_cli_args(&matches);
@@ -318,17 +345,20 @@ mod tests {
             command,
             Ok(CliCommand::New(CreateIndexArgs {
                 index_uri,
+                doc_mapper_type: DocMapperType::Default(_),
+                doc_mapper_config_path: Some(path),
                 timestamp_field: None,
                 overwrite: false
-            })) if &index_uri == "file:///indexes/wikipedia"
+            })) if &index_uri == "file:///indexes/wikipedia" && path == Path::new("./config.json")
         ));
 
-        let yaml = load_yaml!("cli.yaml");
         let app = App::from(yaml).setting(AppSettings::NoBinaryName);
         let matches = app.get_matches_from_safe(vec![
             "new",
             "--index-uri",
             "file:///indexes/wikipedia",
+            "--doc-mapper-type",
+            "allflatten",
             "--timestamp-field",
             "ts",
             "--overwrite",
@@ -338,6 +368,8 @@ mod tests {
             command,
             Ok(CliCommand::New(CreateIndexArgs {
                 index_uri,
+                doc_mapper_type: DocMapperType::AllFlatten,
+                doc_mapper_config_path: None,
                 timestamp_field: Some(field_name),
                 overwrite: true
             })) if &index_uri == "file:///indexes/wikipedia" && field_name == "ts"

--- a/quickwit-doc-mapping/src/default_mapper.rs
+++ b/quickwit-doc-mapping/src/default_mapper.rs
@@ -136,7 +136,7 @@ impl DocMapper for DefaultDocMapper {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct DocMapperConfig {
     store_source: bool,
     ignore_unknown_fields: bool,

--- a/quickwit-doc-mapping/src/mapper.rs
+++ b/quickwit-doc-mapping/src/mapper.rs
@@ -20,6 +20,8 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+use std::convert::TryFrom;
+
 use crate::{
     all_flatten_mapper::AllFlattenDocMapper,
     default_mapper::{DefaultDocMapper, DocMapperConfig},
@@ -52,7 +54,7 @@ pub trait DocMapper: Send + Sync + 'static {
 pub struct SearchRequest {}
 
 /// A `DocMapperType` describe a set of rules to build a document, query and schema.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum DocMapperType {
     /// Default doc mapper which is build from a config file
     Default(DocMapperConfig),
@@ -60,6 +62,22 @@ pub enum DocMapperType {
     AllFlatten,
     /// Wikipedia doc mapper
     Wikipedia,
+}
+
+impl TryFrom<&str> for DocMapperType {
+    type Error = String;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        match s.trim().to_lowercase().as_str() {
+            "allflatten" => Ok(Self::AllFlatten),
+            "wikipedia" => Ok(Self::Wikipedia),
+            "default" => Ok(Self::Default(DocMapperConfig::default())),
+            _ => Err(format!(
+                "Could not parse `{}`  as valid doc mapper type.",
+                s
+            )),
+        }
+    }
 }
 
 /// Build a doc mapper given the doc mapper type.

--- a/quickwit-doc-mapping/src/mapper.rs
+++ b/quickwit-doc-mapping/src/mapper.rs
@@ -67,14 +67,14 @@ pub enum DocMapperType {
 impl TryFrom<&str> for DocMapperType {
     type Error = String;
 
-    fn try_from(s: &str) -> Result<Self, Self::Error> {
-        match s.trim().to_lowercase().as_str() {
+    fn try_from(doc_mapper_type_str: &str) -> Result<Self, Self::Error> {
+        match doc_mapper_type_str.trim().to_lowercase().as_str() {
             "allflatten" => Ok(Self::AllFlatten),
             "wikipedia" => Ok(Self::Wikipedia),
             "default" => Ok(Self::Default(DocMapperConfig::default())),
             _ => Err(format!(
                 "Could not parse `{}`  as valid doc mapper type.",
-                s
+                doc_mapper_type_str
             )),
         }
     }


### PR DESCRIPTION
### Context / purpose
We need to support doc mapper options in CLI when creating an index
[Issue 79](https://github.com/quickwit-inc/quickwit/issues/79)

### Description
Added changes to parse and extract 
- Doc mapper type  
- Doc mapper configuration path

### How was this PR tested?
Ran the create command

### Checklist
*Remove or complete this list if required.*
- [x] tested locally
- [x] added unit tests
