### PR TITLE
Persist doc mapper In IndexMetadata

### DIFF
--- a/quickwit-cli/src/main.rs
+++ b/quickwit-cli/src/main.rs
@@ -357,7 +357,7 @@ mod tests {
             "--index-uri",
             "file:///indexes/wikipedia",
             "--doc-mapper-type",
-            "allflatten",
+            "all_flatten",
             "--timestamp-field",
             "ts",
             "--overwrite",

--- a/quickwit-cli/src/main.rs
+++ b/quickwit-cli/src/main.rs
@@ -23,7 +23,7 @@
 use anyhow::{bail, Context};
 use byte_unit::Byte;
 use clap::{load_yaml, value_t, App, AppSettings, ArgMatches};
-use quickwit_doc_mapping::{build_doc_mapper, DocMapperType};
+use quickwit_doc_mapping::DocMapperType;
 use quickwit_metastore::IndexMetadata;
 use std::convert::TryFrom;
 use std::path::PathBuf;
@@ -223,9 +223,9 @@ async fn create_index_cli(args: CreateIndexArgs) -> anyhow::Result<()> {
     let index_metadata = IndexMetadata {
         index_id: index_id.to_string(),
         index_uri: args.index_uri.to_string(),
+        doc_mapper_type: args.doc_mapper_type,
     };
-    let mapper = build_doc_mapper(DocMapperType::AllFlatten)?;
-    create_index(metastore_uri, index_metadata, mapper).await?;
+    create_index(metastore_uri, index_metadata).await?;
     Ok(())
 }
 
@@ -251,8 +251,7 @@ async fn index_data_cli(args: IndexDataArgs) -> anyhow::Result<()> {
 
     let (metastore_uri, index_id) =
         extract_metastore_uri_and_index_id_from_index_uri(&args.index_uri)?;
-    let mapper = build_doc_mapper(DocMapperType::AllFlatten)?;
-    index_data(metastore_uri, index_id, mapper, params).await?;
+    index_data(metastore_uri, index_id, params).await?;
     Ok(())
 }
 

--- a/quickwit-core/src/index.rs
+++ b/quickwit-core/src/index.rs
@@ -22,7 +22,6 @@
 
 use std::sync::Arc;
 
-use quickwit_doc_mapping::DocMapper;
 use quickwit_metastore::{IndexMetadata, Metastore, MetastoreUriResolver, SplitState};
 use quickwit_storage::Storage;
 
@@ -30,12 +29,11 @@ use quickwit_storage::Storage;
 pub async fn create_index(
     metastore_uri: &str,
     index_metadata: IndexMetadata,
-    doc_mapper: Box<dyn DocMapper>,
 ) -> anyhow::Result<()> {
     let metastore = MetastoreUriResolver::default()
         .resolve(&metastore_uri)
         .await?;
-    metastore.create_index(index_metadata, doc_mapper).await?;
+    metastore.create_index(index_metadata).await?;
     Ok(())
 }
 

--- a/quickwit-core/src/indexing/index.rs
+++ b/quickwit-core/src/indexing/index.rs
@@ -24,7 +24,6 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use futures::try_join;
-use quickwit_doc_mapping::DocMapper;
 use quickwit_metastore::Metastore;
 use quickwit_metastore::{MetastoreUriResolver, SplitState};
 use quickwit_storage::StorageUriResolver;
@@ -57,7 +56,6 @@ pub struct IndexDataParams {
 pub async fn index_data(
     metastore_uri: &str,
     index_id: &str,
-    _doc_mapper: Box<dyn DocMapper>,
     params: IndexDataParams,
 ) -> anyhow::Result<()> {
     let index_uri = params.index_uri.to_string_lossy().to_string();

--- a/quickwit-doc-mapping/src/default_mapper.rs
+++ b/quickwit-doc-mapping/src/default_mapper.rs
@@ -138,9 +138,9 @@ impl DocMapper for DefaultDocMapper {
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct DocMapperConfig {
-    store_source: bool,
-    ignore_unknown_fields: bool,
-    properties: Vec<FieldEntry>,
+    pub store_source: bool,
+    pub ignore_unknown_fields: bool,
+    pub properties: Vec<FieldEntry>,
 }
 
 impl DocMapperConfig {

--- a/quickwit-doc-mapping/src/mapper.rs
+++ b/quickwit-doc-mapping/src/mapper.rs
@@ -27,6 +27,7 @@ use crate::{
     default_mapper::{DefaultDocMapper, DocMapperConfig},
     wikipedia_mapper::WikipediaMapper,
 };
+use serde::{Deserialize, Serialize};
 use tantivy::{
     query::Query,
     schema::{DocParsingError, Schema},
@@ -54,7 +55,7 @@ pub trait DocMapper: Send + Sync + 'static {
 pub struct SearchRequest {}
 
 /// A `DocMapperType` describe a set of rules to build a document, query and schema.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum DocMapperType {
     /// Default doc mapper which is build from a config file
     Default(DocMapperConfig),
@@ -73,7 +74,7 @@ impl TryFrom<&str> for DocMapperType {
             "wikipedia" => Ok(Self::Wikipedia),
             "default" => Ok(Self::Default(DocMapperConfig::default())),
             _ => Err(format!(
-                "Could not parse `{}`  as valid doc mapper type.",
+                "Could not parse `{}` as valid doc mapper type.",
                 doc_mapper_type_str
             )),
         }

--- a/quickwit-metastore/src/metastore.rs
+++ b/quickwit-metastore/src/metastore.rs
@@ -27,7 +27,7 @@ use std::fmt::Debug;
 use std::ops::Range;
 
 use async_trait::async_trait;
-use quickwit_doc_mapping::DocMapper;
+use quickwit_doc_mapping::DocMapperType;
 use serde::{Deserialize, Serialize};
 
 use crate::MetastoreResult;
@@ -40,6 +40,8 @@ pub struct IndexMetadata {
     /// Index Uri. The index uri defines the location of the storage that contains the
     /// split files.
     pub index_uri: String,
+    /// The doc mapper type used for this index
+    pub doc_mapper_type: DocMapperType,
 }
 
 /// A split metadata carries all meta data about a split.
@@ -138,11 +140,7 @@ pub trait Metastore: Send + Sync + 'static {
     /// Creates an index.
     /// This API creates index metadata set in the metastore.
     /// An error will occur if an index that exists in the storage is specified.
-    async fn create_index(
-        &self,
-        index_metadata: IndexMetadata,
-        doc_mapper: Box<dyn DocMapper>,
-    ) -> MetastoreResult<()>;
+    async fn create_index(&self, index_metadata: IndexMetadata) -> MetastoreResult<()>;
 
     /// Returns the index_metadata for a given index.
     ///

--- a/quickwit-metastore/src/metastore/single_file_metastore.rs
+++ b/quickwit-metastore/src/metastore/single_file_metastore.rs
@@ -489,19 +489,33 @@ mod tests {
             let index_metadata = IndexMetadata {
                 index_id: index_id.to_string(),
                 index_uri: "ram://indexes//my-index".to_string(),
-                doc_mapper_type: DocMapperType::AllFlatten,
+                doc_mapper_type: DocMapperType::Wikipedia,
             };
 
             // Create index
-            metastore.create_index(index_metadata).await.unwrap();
+            metastore
+                .create_index(index_metadata.clone())
+                .await
+                .unwrap();
 
             // Check for the existence of index.
             let result = metastore.index_exists(index_id).await.unwrap();
             let expected = true;
             assert_eq!(result, expected);
 
-            // Open index
-            metastore.get_index(index_id).await.unwrap();
+            // Open index and check its metadata
+            let created_index = metastore.get_index(index_id).await.unwrap();
+            assert_eq!(created_index.index.index_id, index_metadata.index_id);
+            assert_eq!(
+                created_index.index.index_uri.clone(),
+                index_metadata.index_uri
+            );
+            match created_index.index.doc_mapper_type {
+                DocMapperType::Wikipedia => (),
+                _ => {
+                    panic!("Wrong DocMapperType");
+                }
+            }
 
             // Open a non-existent index.
             let result = metastore

--- a/quickwit-metastore/src/metastore/single_file_metastore.rs
+++ b/quickwit-metastore/src/metastore/single_file_metastore.rs
@@ -26,7 +26,6 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use quickwit_doc_mapping::DocMapper;
 use quickwit_storage::StorageResolverError;
 use quickwit_storage::StorageUriResolver;
 use tokio::sync::RwLock;
@@ -155,11 +154,7 @@ impl SingleFileMetastore {
 
 #[async_trait]
 impl Metastore for SingleFileMetastore {
-    async fn create_index(
-        &self,
-        index_metadata: IndexMetadata,
-        _doc_mapper: Box<dyn DocMapper>,
-    ) -> MetastoreResult<()> {
+    async fn create_index(&self, index_metadata: IndexMetadata) -> MetastoreResult<()> {
         // Check for the existence of index.
         let exists = self
             .index_exists(&index_metadata.index_id)
@@ -412,7 +407,7 @@ mod tests {
 
     use crate::IndexMetadata;
     use crate::{Metastore, MetastoreErrorKind, SingleFileMetastore, SplitMetadata, SplitState};
-    use quickwit_doc_mapping::{build_doc_mapper, DocMapperType};
+    use quickwit_doc_mapping::DocMapperType;
     use quickwit_storage::{MockStorage, StorageErrorKind};
 
     #[tokio::test]
@@ -429,14 +424,11 @@ mod tests {
             let index_metadata = IndexMetadata {
                 index_id: index_id.to_string(),
                 index_uri: "ram://indexes/my-index".to_string(),
+                doc_mapper_type: DocMapperType::AllFlatten,
             };
-            let mapper = build_doc_mapper(DocMapperType::AllFlatten).unwrap();
 
             // Create index
-            metastore
-                .create_index(index_metadata, mapper)
-                .await
-                .unwrap();
+            metastore.create_index(index_metadata).await.unwrap();
 
             // Check for the existence of index.
             let result = metastore.index_exists(index_id).await.unwrap();
@@ -459,12 +451,12 @@ mod tests {
             let index_metadata = IndexMetadata {
                 index_id: index_id.to_string(),
                 index_uri: "ram://indexes//my-index".to_string(),
+                doc_mapper_type: DocMapperType::AllFlatten,
             };
-            let mapper = build_doc_mapper(DocMapperType::AllFlatten).unwrap();
 
             // Create index
             metastore
-                .create_index(index_metadata.clone(), mapper)
+                .create_index(index_metadata.clone())
                 .await
                 .unwrap();
 
@@ -473,9 +465,8 @@ mod tests {
             let expected = true;
             assert_eq!(result, expected);
 
-            let mapper = build_doc_mapper(DocMapperType::AllFlatten).unwrap();
             let result = metastore
-                .create_index(index_metadata, mapper)
+                .create_index(index_metadata)
                 .await
                 .unwrap_err()
                 .kind();
@@ -498,13 +489,11 @@ mod tests {
             let index_metadata = IndexMetadata {
                 index_id: index_id.to_string(),
                 index_uri: "ram://indexes//my-index".to_string(),
+                doc_mapper_type: DocMapperType::AllFlatten,
             };
-            let mapper = build_doc_mapper(DocMapperType::AllFlatten).unwrap();
+
             // Create index
-            metastore
-                .create_index(index_metadata, mapper)
-                .await
-                .unwrap();
+            metastore.create_index(index_metadata).await.unwrap();
 
             // Check for the existence of index.
             let result = metastore.index_exists(index_id).await.unwrap();
@@ -539,14 +528,11 @@ mod tests {
             let index_metadata = IndexMetadata {
                 index_id: index_id.to_string(),
                 index_uri: "ram://indexes//my-index".to_string(),
+                doc_mapper_type: DocMapperType::AllFlatten,
             };
-            let mapper = build_doc_mapper(DocMapperType::AllFlatten).unwrap();
 
             // Create index
-            metastore
-                .create_index(index_metadata, mapper)
-                .await
-                .unwrap();
+            metastore.create_index(index_metadata).await.unwrap();
 
             // Check for the existence of index.
             let result = metastore.index_exists(index_id).await.unwrap();
@@ -590,14 +576,11 @@ mod tests {
             let index_metadata = IndexMetadata {
                 index_id: index_id.to_string(),
                 index_uri: "ram://indexes/my-index".to_string(),
+                doc_mapper_type: DocMapperType::AllFlatten,
             };
-            let mapper = build_doc_mapper(DocMapperType::AllFlatten).unwrap();
 
             // Create index
-            metastore
-                .create_index(index_metadata, mapper)
-                .await
-                .unwrap();
+            metastore.create_index(index_metadata).await.unwrap();
 
             // Check for the existence of index.
             let result = metastore.index_exists(index_id).await.unwrap();
@@ -722,13 +705,11 @@ mod tests {
             let index_metadata = IndexMetadata {
                 index_id: index_id.to_string(),
                 index_uri: "ram://indexes/my-index".to_string(),
+                doc_mapper_type: DocMapperType::AllFlatten,
             };
-            let mapper = build_doc_mapper(DocMapperType::AllFlatten).unwrap();
+
             // Create index
-            metastore
-                .create_index(index_metadata, mapper)
-                .await
-                .unwrap();
+            metastore.create_index(index_metadata).await.unwrap();
 
             // Check for the existence of index.
             let result = metastore.index_exists(index_id).await.unwrap();
@@ -806,14 +787,11 @@ mod tests {
             let index_metadata = IndexMetadata {
                 index_id: index_id.to_string(),
                 index_uri: "ram://indexes/my-index".to_string(),
+                doc_mapper_type: DocMapperType::AllFlatten,
             };
-            let mapper = build_doc_mapper(DocMapperType::AllFlatten).unwrap();
 
             // create index
-            metastore
-                .create_index(index_metadata, mapper)
-                .await
-                .unwrap();
+            metastore.create_index(index_metadata).await.unwrap();
         }
 
         {
@@ -1331,14 +1309,11 @@ mod tests {
             let index_metadata = IndexMetadata {
                 index_id: index_id.to_string(),
                 index_uri: "ram://indexes/my-index".to_string(),
+                doc_mapper_type: DocMapperType::AllFlatten,
             };
-            let mapper = build_doc_mapper(DocMapperType::AllFlatten).unwrap();
 
             // Create index
-            metastore
-                .create_index(index_metadata, mapper)
-                .await
-                .unwrap();
+            metastore.create_index(index_metadata).await.unwrap();
 
             // Check for the existence of index.
             let result = metastore.index_exists(index_id).await.unwrap();
@@ -1425,14 +1400,11 @@ mod tests {
             let index_metadata = IndexMetadata {
                 index_id: index_id.to_string(),
                 index_uri: "ram://indexes/my-index".to_string(),
+                doc_mapper_type: DocMapperType::AllFlatten,
             };
-            let mapper = build_doc_mapper(DocMapperType::AllFlatten).unwrap();
 
             // Create index
-            metastore
-                .create_index(index_metadata, mapper)
-                .await
-                .unwrap();
+            metastore.create_index(index_metadata).await.unwrap();
 
             // Check for the existence of index.
             let result = metastore.index_exists(index_id).await.unwrap();
@@ -1529,14 +1501,11 @@ mod tests {
         let index_metadata = IndexMetadata {
             index_id: index_id.to_string(),
             index_uri: "ram://my-indexes/my-index".to_string(),
+            doc_mapper_type: DocMapperType::AllFlatten,
         };
-        let mapper = build_doc_mapper(DocMapperType::AllFlatten).unwrap();
 
         // create index
-        metastore
-            .create_index(index_metadata, mapper)
-            .await
-            .unwrap();
+        metastore.create_index(index_metadata).await.unwrap();
 
         // stage split
         metastore


### PR DESCRIPTION
### Context / purpose
The metastore needs to store the document mapper. 
[Issue 80](https://github.com/quickwit-inc/quickwit/issues/80)

### Description
- Add serialization attributes to store document mapper type in the index metadata
- Refactored `create_index` and `index_data` interface

### How was this PR tested?
Run the local command

### Checklist
*Remove or complete this list if required.*
- [x] tested locally
- [x] updated united tests

