### PR TITLE
Atomically publish splits

### DIFF
--- a/quickwit-core/src/indexing/document_indexer.rs
+++ b/quickwit-core/src/indexing/document_indexer.rs
@@ -157,7 +157,7 @@ mod tests {
             .times(0)
             .returning(|_index_uri, _split_id| Ok(()));
         mock_metastore
-            .expect_publish_split()
+            .expect_publish_splits()
             .times(0)
             .returning(|_uri, _id| Ok(()));
         let metastore = Arc::new(mock_metastore);

--- a/quickwit-core/src/indexing/index.rs
+++ b/quickwit-core/src/indexing/index.rs
@@ -85,13 +85,13 @@ pub async fn index_data(
         index_documents(
             index_id.to_owned(),
             &params,
-            metastore,
+            metastore.clone(),
             storage_resolver,
             document_retriever,
             split_sender,
             statistic_sender.clone(),
         ),
-        finalize_split(split_receiver, statistic_sender.clone()),
+        finalize_split(split_receiver, metastore, statistic_sender.clone()),
     )?;
 
     statistic_collector.lock().await.display_report();

--- a/quickwit-core/src/indexing/split.rs
+++ b/quickwit-core/src/indexing/split.rs
@@ -287,10 +287,6 @@ mod tests {
                 Ok(())
             },
         );
-        mock_metastore
-            .expect_publish_splits()
-            .times(0)
-            .returning(|_uri, _id| Ok(()));
 
         let metastore = Arc::new(mock_metastore);
         let split_result = Split::create(

--- a/quickwit-core/src/indexing/split.rs
+++ b/quickwit-core/src/indexing/split.rs
@@ -177,13 +177,13 @@ impl Split {
         Ok(manifest)
     }
 
-    /// Publish the split in the metastore.
-    pub async fn publish(&self) -> anyhow::Result<()> {
-        self.metastore
-            .publish_split(&self.index_uri, &self.id.to_string())
-            .await?;
-        Ok(())
-    }
+    // /// Publish the split in the metastore.
+    // pub async fn publish(&self) -> anyhow::Result<()> {
+    //     self.metastore
+    //         .publish_split(&self.index_uri, &self.id.to_string())
+    //         .await?;
+    //     Ok(())
+    // }
 }
 
 async fn put_to_storage(storage: &dyn Storage, split: &Split) -> anyhow::Result<Manifest> {
@@ -297,7 +297,7 @@ mod tests {
         );
         mock_metastore
             .expect_publish_splits()
-            .times(1)
+            .times(0)
             .returning(|_uri, _id| Ok(()));
 
         let metastore = Arc::new(mock_metastore);
@@ -333,8 +333,7 @@ mod tests {
 
         task::spawn(async move {
             split.stage().await?;
-            split.upload().await?;
-            split.publish().await
+            split.upload().await
         })
         .await??;
 

--- a/quickwit-core/src/indexing/split.rs
+++ b/quickwit-core/src/indexing/split.rs
@@ -177,13 +177,6 @@ impl Split {
         Ok(manifest)
     }
 
-    // /// Publish the split in the metastore.
-    // pub async fn publish(&self) -> anyhow::Result<()> {
-    //     self.metastore
-    //         .publish_split(&self.index_uri, &self.id.to_string())
-    //         .await?;
-    //     Ok(())
-    // }
 }
 
 async fn put_to_storage(storage: &dyn Storage, split: &Split) -> anyhow::Result<Manifest> {

--- a/quickwit-core/src/indexing/split.rs
+++ b/quickwit-core/src/indexing/split.rs
@@ -176,7 +176,6 @@ impl Split {
         let manifest = put_to_storage(&*self.storage, self).await?;
         Ok(manifest)
     }
-
 }
 
 async fn put_to_storage(storage: &dyn Storage, split: &Split) -> anyhow::Result<Manifest> {

--- a/quickwit-core/src/indexing/split.rs
+++ b/quickwit-core/src/indexing/split.rs
@@ -215,7 +215,7 @@ impl Split {
     pub async fn publish(&self, statistic_sender: Sender<StatisticEvent>) -> anyhow::Result<()> {
         let publish_result = self
             .metastore
-            .publish_split(&self.index_uri, &self.id.to_string())
+            .publish_splits(&self.index_uri, vec![&self.id.to_string()])
             .await;
         statistic_sender
             .send(StatisticEvent::SplitPublish {
@@ -339,7 +339,7 @@ mod tests {
             },
         );
         mock_metastore
-            .expect_publish_split()
+            .expect_publish_splits()
             .times(1)
             .returning(|_uri, _id| Ok(()));
 

--- a/quickwit-metastore/src/metastore.rs
+++ b/quickwit-metastore/src/metastore.rs
@@ -168,7 +168,11 @@ pub trait Metastore: Send + Sync + 'static {
     /// At this point, the split files are assumed to have already been uploaded.
     /// If the split is already published, this API call returns a success.
     /// An error will occur if you specify an index or split that does not exist in the storage.
-    async fn publish_split(&self, index_id: &str, split_id: &str) -> MetastoreResult<()>;
+    async fn publish_splits<'a>(
+        &self,
+        index_id: &str,
+        split_ids: Vec<&'a str>,
+    ) -> MetastoreResult<()>;
 
     /// Lists the splits.
     /// Returns a list of splits that intersect the given time_range and split_state.

--- a/quickwit-metastore/src/metastore/single_file_metastore.rs
+++ b/quickwit-metastore/src/metastore/single_file_metastore.rs
@@ -239,30 +239,42 @@ impl Metastore for SingleFileMetastore {
         Ok(())
     }
 
-    async fn publish_split(&self, index_id: &str, split_id: &str) -> MetastoreResult<()> {
+    async fn publish_splits<'a>(
+        &self,
+        index_id: &str,
+        split_ids: Vec<&'a str>,
+    ) -> MetastoreResult<()> {
         let mut metadata_set = self.get_index(index_id).await?;
 
-        // Check for the existence of split.
-        let split_metadata = metadata_set.splits.get_mut(split_id).ok_or_else(|| {
-            MetastoreErrorKind::SplitDoesNotExist
-                .with_error(anyhow::anyhow!("Split does not exist: {:?}", split_id))
-        })?;
+        let mut updatable_split_ids = vec![];
+        for split_id in split_ids {
+            // Check for the existence of split.
+            let split_metadata = metadata_set.splits.get(split_id).ok_or_else(|| {
+                MetastoreErrorKind::SplitDoesNotExist
+                    .with_error(anyhow::anyhow!("Split does not exist: {:?}", split_id))
+            })?;
 
-        // Check the split state.
-        match split_metadata.split_state {
-            SplitState::Published => {
-                // If the split is already published, this API call returns a success.
-                return Ok(());
-            }
-            SplitState::Staged => {
-                // Update the split state to `Published`.
-                split_metadata.split_state = SplitState::Published;
-            }
-            _ => {
-                return Err(MetastoreErrorKind::SplitIsNotStaged
-                    .with_error(anyhow::anyhow!("Split ID is not staged: {:?}", split_id)));
+            match split_metadata.split_state {
+                SplitState::Published => {
+                    // Split is already published. This is fine, we just skip it.
+                    continue;
+                }
+                SplitState::Staged => {
+                    // The split state needs to be updated.
+                    updatable_split_ids.push(split_id);
+                }
+                _ => {
+                    return Err(MetastoreErrorKind::SplitIsNotStaged
+                        .with_error(anyhow::anyhow!("Split ID is not staged: {:?}", split_id)));
+                }
             }
         }
+
+        // Update the splits state to `Published`.
+        updatable_split_ids.into_iter().for_each(|split_id| {
+            let split_metadata = metadata_set.splits.get_mut(split_id).unwrap();
+            split_metadata.split_state = SplitState::Published;
+        });
 
         self.put_index(metadata_set).await?;
 
@@ -658,14 +670,26 @@ mod tests {
     async fn test_single_file_metastore_publish_split() {
         let metastore = SingleFileMetastore::for_test();
         let index_id = "my-index";
-        let split_id = "one";
-        let split_metadata = SplitMetadata {
-            split_id: split_id.to_string(),
+        let split_id_one = "one";
+        let split_id_two = "two";
+        let split_metadata_one = SplitMetadata {
+            split_id: split_id_one.to_string(),
             split_state: SplitState::Staged,
             num_records: 1,
             size_in_bytes: 2,
             time_range: Some(Range { start: 0, end: 100 }),
             generation: 3,
+        };
+        let split_metadata_two = SplitMetadata {
+            split_id: split_id_two.to_string(),
+            split_state: SplitState::Staged,
+            num_records: 5,
+            size_in_bytes: 6,
+            time_range: Some(Range {
+                start: 30,
+                end: 100,
+            }),
+            generation: 2,
         };
 
         {
@@ -690,12 +714,15 @@ mod tests {
 
             // stage split
             metastore
-                .stage_split(index_id, split_metadata.clone())
+                .stage_split(index_id, split_metadata_one.clone())
                 .await
                 .unwrap();
 
             // publish split
-            metastore.publish_split(index_id, split_id).await.unwrap();
+            metastore
+                .publish_splits(index_id, vec![split_id_one])
+                .await
+                .unwrap();
         }
 
         {
@@ -705,7 +732,7 @@ mod tests {
                     .get(index_id)
                     .unwrap()
                     .splits
-                    .get(split_id)
+                    .get(split_id_one)
                     .unwrap()
                     .split_state,
                 SplitState::Published
@@ -714,16 +741,18 @@ mod tests {
 
         {
             // publish published split
-            metastore.publish_split(index_id, split_id).await.unwrap();
+            metastore
+                .publish_splits(index_id, vec![split_id_one])
+                .await
+                .unwrap();
 
             // publish non-staged split
-            let split_id = "one";
             metastore
-                .mark_split_as_deleted(index_id, split_id) // mark as deleted
+                .mark_split_as_deleted(index_id, split_id_one) // mark as deleted
                 .await
                 .unwrap();
             let result = metastore
-                .publish_split(index_id, split_id) // publish
+                .publish_splits(index_id, vec![split_id_one]) // publish
                 .await
                 .unwrap_err()
                 .kind();
@@ -732,7 +761,7 @@ mod tests {
 
             // publish non-existent index
             let result = metastore
-                .publish_split("non-existent-index", split_id)
+                .publish_splits("non-existent-index", vec![split_id_one])
                 .await
                 .unwrap_err()
                 .kind();
@@ -741,12 +770,65 @@ mod tests {
 
             // publish non-existent split
             let result = metastore
-                .publish_split(index_id, "non-existent-split")
+                .publish_splits(index_id, vec!["non-existent-split"])
                 .await
                 .unwrap_err()
                 .kind();
             let expected = MetastoreErrorKind::SplitDoesNotExist;
             assert_eq!(result, expected);
+        }
+
+        {
+            // publish one non-staged split and one non-existent split
+            let result = metastore
+                .publish_splits(index_id, vec![split_id_one, split_id_two]) // publish
+                .await
+                .unwrap_err()
+                .kind();
+            let expected = MetastoreErrorKind::SplitIsNotStaged;
+            assert_eq!(result, expected);
+
+            // publish two non-existent splits
+            metastore
+                .delete_split(index_id, split_id_one)
+                .await
+                .unwrap();
+            let result = metastore
+                .publish_splits(index_id, vec![split_id_one, split_id_two]) // publish
+                .await
+                .unwrap_err()
+                .kind();
+            let expected = MetastoreErrorKind::SplitDoesNotExist;
+            assert_eq!(result, expected);
+
+            // publish one staged split and one non-exitent split
+            metastore
+                .stage_split(index_id, split_metadata_one.clone())
+                .await
+                .unwrap();
+            let result = metastore
+                .publish_splits(index_id, vec![split_id_one, split_id_two]) // publish
+                .await
+                .unwrap_err()
+                .kind();
+            let expected = MetastoreErrorKind::SplitDoesNotExist;
+            assert_eq!(result, expected);
+
+            // publish two staged splits
+            metastore
+                .stage_split(index_id, split_metadata_two.clone())
+                .await
+                .unwrap();
+            metastore
+                .publish_splits(index_id, vec![split_id_one, split_id_two])
+                .await
+                .unwrap();
+
+            //publishe two published splits
+            metastore
+                .publish_splits(index_id, vec![split_id_one, split_id_two])
+                .await
+                .unwrap();
         }
     }
 
@@ -1299,7 +1381,10 @@ mod tests {
                 .unwrap();
 
             // publish split
-            metastore.publish_split(index_id, split_id).await.unwrap();
+            metastore
+                .publish_splits(index_id, vec![split_id])
+                .await
+                .unwrap();
 
             // mark split as deleted
             metastore
@@ -1390,7 +1475,10 @@ mod tests {
                 .unwrap();
 
             // publish split
-            metastore.publish_split(index_id, split_id).await.unwrap();
+            metastore
+                .publish_splits(index_id, vec![split_id])
+                .await
+                .unwrap();
 
             // delete split (published split)
             let result = metastore
@@ -1486,7 +1574,7 @@ mod tests {
             .unwrap();
 
         // publish split fails
-        let err = metastore.publish_split(index_id, split_id).await;
+        let err = metastore.publish_splits(index_id, vec![split_id]).await;
         assert!(err.is_err());
 
         // empty

--- a/quickwit-metastore/src/metastore/single_file_metastore.rs
+++ b/quickwit-metastore/src/metastore/single_file_metastore.rs
@@ -272,8 +272,9 @@ impl Metastore for SingleFileMetastore {
 
         // Update the splits state to `Published`.
         updatable_split_ids.into_iter().for_each(|split_id| {
-            let split_metadata = metadata_set.splits.get_mut(split_id).unwrap();
-            split_metadata.split_state = SplitState::Published;
+            if let Some(split_metadata) = metadata_set.splits.get_mut(split_id) {
+                split_metadata.split_state = SplitState::Published;
+            };
         });
 
         self.put_index(metadata_set).await?;
@@ -781,7 +782,7 @@ mod tests {
         {
             // publish one non-staged split and one non-existent split
             let result = metastore
-                .publish_splits(index_id, vec![split_id_one, split_id_two]) // publish
+                .publish_splits(index_id, vec![split_id_one, split_id_two])
                 .await
                 .unwrap_err()
                 .kind();
@@ -794,7 +795,7 @@ mod tests {
                 .await
                 .unwrap();
             let result = metastore
-                .publish_splits(index_id, vec![split_id_one, split_id_two]) // publish
+                .publish_splits(index_id, vec![split_id_one, split_id_two])
                 .await
                 .unwrap_err()
                 .kind();
@@ -807,7 +808,7 @@ mod tests {
                 .await
                 .unwrap();
             let result = metastore
-                .publish_splits(index_id, vec![split_id_one, split_id_two]) // publish
+                .publish_splits(index_id, vec![split_id_one, split_id_two])
                 .await
                 .unwrap_err()
                 .kind();


### PR DESCRIPTION
### Context / purpose
We need a way in the Metastore to have an all-or-nothing behavior during split publishing. 
[See Issue 71](https://github.com/quickwit-inc/quickwit/issues/71)

### Description
- Changed metastore publish split interface to accepts multiple split at once.
- Updated indexing command to use this new interface 

### How was this PR tested?
Run the create & index command on a local wikipedia corpus.
`cargo run -- new --index-uri file://./data --no-timestamp-field --doc-mapper-type wikipedia`
`cargo run -- index --index-uri file://./data --input-path ./wiki-articles.json`

### Checklist
- [x] tested locally
- [x] added unit tests
