### PR TITLE
Integrated DocMapper into indexing

### DIFF
--- a/quickwit-doc-mapping/Cargo.toml
+++ b/quickwit-doc-mapping/Cargo.toml
@@ -7,7 +7,7 @@ license = "AGPL-3.0-or-later" # For a commercial, license, contact hello@quickwi
 
 [dependencies]
 anyhow = "1"
-tantivy = "0.14"
+tantivy = { git= "https://github.com/quickwit-inc/tantivy", rev="d90fb7d", default-features=false, features = ["mmap", "lz4-compression"] }
 serde_json = "1.0"
 thiserror = "1.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/quickwit-doc-mapping/src/default_mapper.rs
+++ b/quickwit-doc-mapping/src/default_mapper.rs
@@ -140,7 +140,7 @@ impl DocMapper for DefaultDocMapper {
             } else {
                 format!("{:?}...", &doc_json[0..20])
             };
-            DocParsingError::NotJSON(doc_json_sample)
+            DocParsingError::NotJson(doc_json_sample)
         })?;
         self.fill_document(&json_obj, &mut document)?;
         Ok(document)

--- a/quickwit-doc-mapping/src/wikipedia_mapper.rs
+++ b/quickwit-doc-mapping/src/wikipedia_mapper.rs
@@ -24,7 +24,7 @@ use crate::{mapper::SearchRequest, DocMapper};
 use serde::{Deserialize, Serialize};
 use tantivy::{
     query::Query,
-    schema::{DocParsingError, Schema, SchemaBuilder, TextFieldIndexing, TextOptions},
+    schema::{DocParsingError, Schema, TextFieldIndexing, TextOptions},
     Document,
 };
 
@@ -44,6 +44,12 @@ impl std::fmt::Debug for WikipediaMapper {
 impl WikipediaMapper {
     /// Create a new instance of wikipedia document mapper.
     pub fn new() -> anyhow::Result<Self> {
+        Ok(WikipediaMapper {
+            schema: Self::default_schema(),
+        })
+    }
+
+    fn default_schema() -> Schema {
         let mut schema_builder = Schema::builder();
         let text_options = TextOptions::default()
             .set_stored()
@@ -51,13 +57,7 @@ impl WikipediaMapper {
         schema_builder.add_text_field("title", text_options.clone());
         schema_builder.add_text_field("body", text_options.clone());
         schema_builder.add_text_field("url", text_options);
-        Ok(WikipediaMapper {
-            schema: schema_builder.build(),
-        })
-    }
-
-    fn default_schema() -> Schema {
-        SchemaBuilder::new().build()
+        schema_builder.build()
     }
 }
 


### PR DESCRIPTION
### Context / purpose
Currently, the indexing command was faking documents.

### Description
Removed the `todos` to replace with the real `DocMapper` from the metastore.

### How was this PR tested?
Run the create & index command on a local Wikipedia corpus.

`cargo run -- new --index-uri file://./data --no-timestamp-field --doc-mapper-type wikipedia`
`cargo run -- index --index-uri file://./data --input-path ./wiki-articles.json`

or

`cargo run -- new --index-uri s3://quickwit-dev/evance/data --no-timestamp-field --doc-mapper-type wikipedia`
`cargo run -- index --index-uri s3://quickwit-dev/evance/data --input-path ./wiki-articles.json`

Note: *This could be a good opportunity to try indexing the Wikipedia corpus on our main branch now*

### Checklist
*Remove or complete this list if required.*
- [x] tested locally
- [x] updated unit tests
