### PR TITLE
Remove dangling split folder

### DIFF
--- a/quickwit-cli/src/main.rs
+++ b/quickwit-cli/src/main.rs
@@ -112,7 +112,7 @@ impl CliCommand {
             .map(|field| field.to_string());
         let overwrite = matches.is_present("overwrite");
 
-        // TODO: find better way to build doc mapper when when we clarify the specs.
+        // TODO: find better way to build doc mapper when we clarify the specs.
         let doc_mapper = match doc_mapper_type.trim().to_lowercase().as_str() {
             "all_flatten" => {
                 AllFlattenDocMapper::new().map(|mapper| Box::new(mapper) as Box<dyn DocMapper>)

--- a/quickwit-core/src/indexing/document_indexer.rs
+++ b/quickwit-core/src/indexing/document_indexer.rs
@@ -93,18 +93,7 @@ pub async fn index_documents(
 
     // build last split if it has docs
     if current_split.metadata.num_records > 0 {
-        let split = std::mem::replace(
-            &mut current_split,
-            Split::create(
-                index_id.to_string(),
-                &params,
-                storage_resolver,
-                metastore,
-                schema.clone(),
-            )
-            .await?,
-        );
-        split_sender.send(split).await?;
+        split_sender.send(current_split).await?;
     }
 
     Ok(())

--- a/quickwit-storage/src/local_file_storage.rs
+++ b/quickwit-storage/src/local_file_storage.rs
@@ -56,9 +56,6 @@ impl LocalFileStorage {
             StorageErrorKind::DoesNotExist.with_error(anyhow::anyhow!("Invalid root path: {}", uri))
         })?;
 
-        // TODO remove when fixed: https://github.com/quickwit-inc/quickwit/issues/59
-        std::fs::create_dir_all(root_path).map_err(|err| StorageErrorKind::Io.with_error(err))?;
-
         Ok(LocalFileStorage::new(PathBuf::from(root_path)))
     }
 }


### PR DESCRIPTION
### Context / purpose
A useless split folder is created in the indexing target folder after the index command.
[See Issue 92](https://github.com/quickwit-inc/quickwit/issues/92)

### Description
- Removed the temperary fix we previously had in `SingleFileStorageFactory::from_uri()` 
- simplified last split sending code

### How was this PR tested?
Changed the number of docs per split and indexed wikipedia.json on file:// and s3 

### Checklist
- [x] tested locally
