### PR TITLE
Added a TestIndex struct to make our test more testable.

### DIFF
--- a/quickwit-cli/Cargo.toml
+++ b/quickwit-cli/Cargo.toml
@@ -19,3 +19,5 @@ tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.6", features = ["full"] }
 crossterm = "0.19.0"
 atty = "0.2"
+serde_json = "1.0"
+tempfile = "3"

--- a/quickwit-cli/src/cli.yaml
+++ b/quickwit-cli/src/cli.yaml
@@ -51,10 +51,9 @@ subcommands:
                 long: input-path
                 value_name: INPUT PATH
             - temp-dir:
-                help: Creates intermediate files in this local directory
+                help: Creates intermediate files in this local directory. By default, the OS temp directory will be used.
                 long: temp-dir
                 value_name: TEMP DIR
-                default_value: /tmp
             - num-threads:
                 help: Number of threads allocated to the process
                 long: num-threads

--- a/quickwit-core/Cargo.toml
+++ b/quickwit-core/Cargo.toml
@@ -24,8 +24,8 @@ serde_json = "1.0"
 tracing = '0.1'
 tracing-subscriber = "0.2"
 tokio-stream = "0.1.6"
+tempfile = '3'
 
 [dev-dependencies]
-tempfile = '3'
 mockall = '0.9'
 quickwit-metastore = { version = "0.1.0", path = "../quickwit-metastore", features=["testsuite"]}

--- a/quickwit-core/src/indexing/document_indexer.rs
+++ b/quickwit-core/src/indexing/document_indexer.rs
@@ -115,7 +115,7 @@ mod tests {
         let split_dir = tempfile::tempdir()?;
         let params = IndexDataParams {
             index_id: index_id.to_string(),
-            temp_dir: split_dir.into_path(),
+            temp_dir: Arc::new(split_dir),
             num_threads: 1,
             heap_size: 3000000,
             overwrite: false,

--- a/quickwit-core/src/indexing/split.rs
+++ b/quickwit-core/src/indexing/split.rs
@@ -36,7 +36,7 @@ use tantivy::Directory;
 use tantivy::SegmentId;
 use tantivy::SegmentMeta;
 use tantivy::{directory::MmapDirectory, merge_policy::NoMergePolicy, schema::Schema, Document};
-use tokio::fs;
+use tempfile::TempDir;
 use tracing::{info, warn};
 use uuid::Uuid;
 
@@ -57,7 +57,7 @@ pub struct Split {
     /// The split metadata.
     pub metadata: SplitMetadata,
     /// The local directory hosting this split artifacts.
-    pub local_directory: PathBuf,
+    pub split_scratch_dir: Arc<TempDir>,
     /// The tantivy index for this split.
     pub index: tantivy::Index,
     /// The configured index writer for this split.
@@ -76,7 +76,7 @@ impl fmt::Debug for Split {
             .debug_struct("Split")
             .field("id", &self.id)
             .field("metadata", &self.metadata)
-            .field("local_directory", &self.local_directory)
+            .field("local_directory", &self.split_scratch_dir.path())
             .field("index_uri", &self.index_uri)
             .field("num_parsing_errors", &self.num_parsing_errors)
             .finish()
@@ -105,9 +105,8 @@ impl Split {
         schema: Schema,
     ) -> anyhow::Result<Self> {
         let id = Uuid::new_v4();
-        let local_directory = params.temp_dir.join(format!("{}", id));
-        fs::create_dir(local_directory.as_path()).await?;
-        let index = tantivy::Index::create_in_dir(local_directory.as_path(), schema)?;
+        let split_scratch_dir = Arc::new(tempfile::tempdir_in(params.temp_dir.path())?);
+        let index = tantivy::Index::create_in_dir(split_scratch_dir.path(), schema)?;
         let index_writer =
             index.writer_with_num_threads(params.num_threads, params.heap_size as usize)?;
         index_writer.set_merge_policy(Box::new(NoMergePolicy));
@@ -122,7 +121,7 @@ impl Split {
             index_id: params.index_id.clone(),
             split_uri,
             metadata,
-            local_directory,
+            split_scratch_dir,
             index,
             index_writer: Some(index_writer),
             num_parsing_errors: 0,
@@ -183,11 +182,11 @@ impl Split {
 
     /// Build the split hotcache file
     pub async fn build_hotcache(&mut self) -> anyhow::Result<()> {
-        let directory_path = self.local_directory.to_path_buf();
+        let split_scratch_dir = self.split_scratch_dir.clone();
         tokio::task::spawn_blocking(move || {
-            let hotcache_path = directory_path.join("hotcache");
+            let hotcache_path = split_scratch_dir.path().join("hotcache");
             let mut hotcache_file = std::fs::File::create(&hotcache_path)?;
-            let mmap_directory = MmapDirectory::open(directory_path)?;
+            let mmap_directory = MmapDirectory::open(split_scratch_dir.path())?;
             write_hotcache(mmap_directory, &mut hotcache_file)?;
             anyhow::Result::<()>::Ok(())
         })
@@ -234,10 +233,10 @@ async fn put_split_files_to_storage(
             split.index.directory().exists(filepath).unwrap_or(true) //< true might look like a very odd choice here.
                                                                      // It has the benefit of triggering an error when we will effectively try to upload the files.
         })
-        .map(|relative_filepath| split.local_directory.join(relative_filepath))
+        .map(|relative_filepath| split.split_scratch_dir.path().join(relative_filepath))
         .collect();
-    files_to_upload.push(split.local_directory.join("meta.json"));
-    files_to_upload.push(split.local_directory.join("hotcache"));
+    files_to_upload.push(split.split_scratch_dir.path().join("meta.json"));
+    files_to_upload.push(split.split_scratch_dir.path().join("hotcache"));
 
     let mut upload_res_futures = vec![];
 
@@ -345,11 +344,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_split() -> anyhow::Result<()> {
-        let split_dir = tempfile::tempdir()?;
         let index_uri = "ram://test-index/index";
         let params = &IndexDataParams {
             index_id: "test".to_string(),
-            temp_dir: split_dir.path().to_path_buf(),
+            temp_dir: Arc::new(tempfile::tempdir()?),
             num_threads: 1,
             heap_size: 3000000,
             overwrite: false,

--- a/quickwit-core/src/lib.rs
+++ b/quickwit-core/src/lib.rs
@@ -31,8 +31,10 @@
 mod counter;
 mod index;
 mod indexing;
+mod test_utils;
 
-pub use self::index::{create_index, delete_index, search_index};
-pub use self::indexing::{
+pub use index::{create_index, delete_index, search_index};
+pub use indexing::{
     index_data, test_document_source, DocumentSource, IndexDataParams, IndexingStatistics,
 };
+pub use test_utils::TestSandbox;

--- a/quickwit-core/src/test_utils.rs
+++ b/quickwit-core/src/test_utils.rs
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2021 Quickwit Inc.
+ *
+ * Quickwit is offered under the AGPL v3.0 and as commercial software.
+ * For commercial licensing, contact us at hello@quickwit.io.
+ *
+ * AGPL:
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+use std::sync::Arc;
+
+use quickwit_doc_mapping::DocMapper;
+use quickwit_metastore::{IndexMetadata, Metastore, MetastoreUriResolver};
+use quickwit_storage::StorageUriResolver;
+use tempfile::tempdir;
+
+use crate::index_data;
+use crate::indexing::test_document_source;
+use crate::IndexDataParams;
+use crate::IndexingStatistics;
+
+/// Creates a Test environment.
+///
+/// It makes it easy to create a test index, perfect for unit testing.
+/// The test index content is entirely in RAM and isolated,
+/// but the construction of the index involves temporary file directory.
+pub struct TestSandbox {
+    index_id: String,
+    storage_uri_resolver: StorageUriResolver,
+    metastore: Arc<dyn Metastore>,
+}
+
+impl TestSandbox {
+    /// Creates a new test environment.
+    pub async fn create(index_id: &str, doc_mapper: Box<dyn DocMapper>) -> anyhow::Result<Self> {
+        let metastore_uri = "ram://quickwit-test-indices";
+        let index_metadata = IndexMetadata {
+            index_id: index_id.to_string(),
+            index_uri: format!("{}/{}", metastore_uri, index_id),
+            doc_mapper,
+        };
+        let storage_uri_resolver = StorageUriResolver::default();
+        let metastore = MetastoreUriResolver::with_storage_resolver(storage_uri_resolver.clone())
+            .resolve(&metastore_uri)
+            .await?;
+        metastore.create_index(index_metadata).await?;
+        Ok(TestSandbox {
+            index_id: index_id.to_string(),
+            storage_uri_resolver,
+            metastore,
+        })
+    }
+
+    /// Adds documents.
+    ///
+    /// The documents are expected to be `serde_json::Value`.
+    /// They can be created using the `serde_json::json!` macro.
+    pub async fn add_documents<I>(&self, splits: I) -> anyhow::Result<Arc<IndexingStatistics>>
+    where
+        I: IntoIterator<Item = serde_json::Value> + 'static,
+        I::IntoIter: Send,
+    {
+        let document_source = test_document_source(splits);
+        let index_data_params = IndexDataParams {
+            index_id: self.index_id.clone(),
+            temp_dir: Arc::new(tempdir()?),
+            num_threads: 1,
+            heap_size: 100_000_000,
+            overwrite: false,
+        };
+        let statistics = Arc::new(IndexingStatistics::default());
+        index_data(
+            self.metastore.clone(),
+            index_data_params,
+            document_source,
+            self.storage_uri_resolver.clone(),
+            statistics.clone(),
+        )
+        .await?;
+        Ok(statistics)
+    }
+
+    /// Returns the metastore of the TestIndex
+    ///
+    /// The metastore is a single file metastore.
+    /// Its data can be found via the `storage_uri_resolver` in
+    /// the `ram://quickwit-test-indices` directory.
+    pub fn metastore(&self) -> Arc<dyn Metastore> {
+        self.metastore.clone()
+    }
+
+    /// Returns the storage uri resolver
+    pub fn storage_uri_resolver(&self) -> StorageUriResolver {
+        self.storage_uri_resolver.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TestSandbox;
+    use quickwit_doc_mapping::WikipediaMapper;
+
+    #[tokio::test]
+    async fn test_test_sandbox() -> anyhow::Result<()> {
+        let doc_mapper = Box::new(WikipediaMapper::new());
+        let test_index_builder = TestSandbox::create("test_index", doc_mapper).await?;
+        let statistics = test_index_builder.add_documents(vec![
+            serde_json::json!({"title": "Hurricane Fay", "body": "...", "url": "http://hurricane-fay"}),
+            serde_json::json!({"title": "Ganimede", "body": "...", "url": "http://ganimede"}),
+        ]).await?;
+        assert_eq!(statistics.num_uploaded_splits.get(), 1);
+        let metastore = test_index_builder.metastore();
+        {
+            let splits = metastore.list_all_splits("test_index").await?;
+            assert_eq!(splits.len(), 1);
+            test_index_builder.add_documents(vec![
+            serde_json::json!({"title": "Byzantine-Ottoman wars", "body": "...", "url": "http://biz-ottoman"}),
+        ]).await?;
+        }
+        {
+            let splits = metastore.list_all_splits("test_index").await?;
+            assert_eq!(splits.len(), 2);
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
This PR adds a TestIndex struct that makes unit testing simpler.
To make it possible it, the temp_dir is passed as `Arc<TempDir>` in order to rely on RIIA to remove this scratch directory.