### PR TITLE
Added a function to send telemetry to Quickwit's server.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,5 @@ members = [
   "quickwit-search",
   "quickwit-serve",
   "quickwit-storage",
+  "quickwit-telemetry",
 ]

--- a/quickwit-cli/Cargo.toml
+++ b/quickwit-cli/Cargo.toml
@@ -16,6 +16,7 @@ quickwit-storage = { version = "0.1.0", path = "../quickwit-storage" }
 quickwit-doc-mapping = { version = "0.1.0", path = "../quickwit-doc-mapping" }
 quickwit-search = { version = "0.1", path = "../quickwit-search" }
 quickwit-serve = { version = "0.1", path = "../quickwit-serve" }
+quickwit-telemetry = { version = "0.1", path = "../quickwit-telemetry" }
 quickwit-proto = { version = "0.1", path = "../quickwit-proto" }
 tracing = '0.1'
 tracing-subscriber = "0.2"

--- a/quickwit-serve/Cargo.toml
+++ b/quickwit-serve/Cargo.toml
@@ -14,13 +14,14 @@ serde_json = "1"
 quickwit-storage = {path="../quickwit-storage"}
 quickwit-common = {path="../quickwit-common"}
 quickwit-metastore = {path="../quickwit-metastore"}
+quickwit-telemetry = {path="../quickwit-telemetry"}
 thiserror = "1"
 tonic = "0.4"
 async-trait = "0.1"
 termcolor = "1"
 
 [dev-dependencies]
-mockall = "0.9"
+mockall = "0.10"
 assert-json-diff = "2.0.1"
 tokio = { version = "1", features = ["full"] }
 

--- a/quickwit-serve/src/lib.rs
+++ b/quickwit-serve/src/lib.rs
@@ -30,6 +30,7 @@ pub use args::ServeArgs;
 use quickwit_metastore::{Metastore, MetastoreUriResolver};
 use quickwit_search::SearchServiceImpl;
 use quickwit_storage::StorageUriResolver;
+use quickwit_telemetry::payload::{ServeEvent, TelemetryEvent};
 use tracing::debug;
 mod error;
 mod rest;
@@ -106,6 +107,10 @@ fn display_help_message(
 
 pub async fn serve_cli(args: ServeArgs) -> anyhow::Result<()> {
     debug!(args=?args, "serve-cli");
+    quickwit_telemetry::send_telemetry_event(TelemetryEvent::Serve(ServeEvent {
+        has_seed: !args.peers.is_empty(),
+    }))
+    .await;
     let storage_resolver = StorageUriResolver::default();
     let metastore_resolver = MetastoreUriResolver::with_storage_resolver(storage_resolver.clone());
     let metastore_router =

--- a/quickwit-telemetry/Cargo.toml
+++ b/quickwit-telemetry/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "quickwit-telemetry"
+version = "0.1.0"
+authors = ["Quickwit <hello@quickwit.io>"]
+edition = "2018"
+
+[dependencies]
+once_cell = "1.8.0"
+reqwest = { version = "0.11", features = ["json"] }
+tokio = {version = "1", features = ["full"]}
+anyhow = "1"
+serde = {version="1", features = ["derive"]}
+uuid = { version= "0.8", features = ["v4", "serde"]}
+tracing = "0.1"
+async-trait = "0.1"
+hostname = "0.3"
+username = "0.2"
+md5 = "0.7"

--- a/quickwit-telemetry/src/lib.rs
+++ b/quickwit-telemetry/src/lib.rs
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2021 Quickwit Inc.
+ *
+ * Quickwit is offered under the AGPL v3.0 and as commercial software.
+ * For commercial licensing, contact us at hello@quickwit.io.
+ *
+ * AGPL:
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#![allow(clippy::bool_assert_comparison)]
+pub mod payload;
+/// This crate contains  the code responsible for sending usage data to Quickwit inc's server.
+mod sender;
+pub(crate) mod sink;
+
+use crate::payload::TelemetryEvent;
+use crate::sender::{TelemetryLoopHandle, TelemetrySender};
+use once_cell::sync::OnceCell;
+
+pub fn start_telemetry_loop() -> TelemetryLoopHandle {
+    get_telemetry_sender_singleton().start_loop()
+}
+
+fn get_telemetry_sender_singleton() -> &'static TelemetrySender {
+    static INSTANCE: OnceCell<TelemetrySender> = OnceCell::new();
+    INSTANCE.get_or_init(TelemetrySender::default)
+}
+
+/// Sends a telemetry event to Quickwit's server via HTTP.
+///
+/// Telemetry guarantees to send at most 1 request per minute.
+/// Each requests can ship at most 10 messages.
+///
+/// If this methods is called too often, some events will be dropped.
+///
+/// If the http requests fail, the error will be silent.
+///
+/// We voluntarily use an enum here to make it easier for reader
+/// to audit the type of information that is send home.
+pub async fn send_telemetry_event(event: TelemetryEvent) {
+    get_telemetry_sender_singleton().send(event).await
+}

--- a/quickwit-telemetry/src/payload.rs
+++ b/quickwit-telemetry/src/payload.rs
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2021 Quickwit Inc.
+ *
+ * Quickwit is offered under the AGPL v3.0 and as commercial software.
+ * For commercial licensing, contact us at hello@quickwit.io.
+ *
+ * AGPL:
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+use serde::{Deserialize, Serialize};
+use std::env;
+use std::time::UNIX_EPOCH;
+use uuid::Uuid;
+
+/// Represents the payload of the request sent with telemetry requests.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TelemetryPayload {
+    /// Client information. See details in `[ClientInformation]`.
+    pub client_information: ClientInformation,
+    pub events: Vec<EventWithTimestamp>,
+    /// Represents the number of events that where drops due to the
+    /// combination of the `TELEMETRY_PUSH_COOLDOWN` and `MAX_EVENT_IN_QUEUE`.
+    pub num_dropped_events: usize,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct EventWithTimestamp {
+    /// Unix time in seconds.
+    pub unixtime: u64,
+    /// Telemetry event.
+    pub event: TelemetryEvent,
+}
+
+/// Returns the number of seconds elapsed since UNIX_EPOCH.
+///
+/// If the system clock is set before 1970, returns 0.
+fn unixtime() -> u64 {
+    match UNIX_EPOCH.elapsed() {
+        Ok(duration) => duration.as_secs(),
+        Err(_) => 0u64,
+    }
+}
+
+impl From<TelemetryEvent> for EventWithTimestamp {
+    fn from(event: TelemetryEvent) -> Self {
+        EventWithTimestamp {
+            unixtime: unixtime(),
+            event,
+        }
+    }
+}
+
+/// Represents a Telemetry Event send to Quickwit's server for usage information.
+#[derive(Debug, Serialize, Deserialize)]
+pub enum TelemetryEvent {
+    /// Create command is called.
+    Create,
+    /// Index command is called.
+    IndexStart,
+    /// Delete command
+    Delete,
+    /// Serve command is called.
+    Serve(ServeEvent),
+    /// EndCommand (with the return code)
+    EndCommand { return_code: i32 },
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ServeEvent {
+    pub has_seed: bool,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ClientInformation {
+    session_uuid: uuid::Uuid,
+    quickwit_version: String,
+    os: String,
+    arch: String,
+    hashed_host_username: String,
+    kubernetes: bool,
+}
+
+fn hashed_host_username() -> String {
+    let hostname = hostname::get()
+        .map(|hostname| hostname.to_string_lossy().to_string())
+        .unwrap_or_else(|_| "".to_string());
+    let username = username::get_user_name().unwrap_or_else(|_| "".to_string());
+    let hashed_value = format!("{}:{}", hostname, username);
+    let digest = md5::compute(hashed_value.as_bytes());
+    format!("{:x}", digest)
+}
+
+impl Default for ClientInformation {
+    fn default() -> ClientInformation {
+        ClientInformation {
+            session_uuid: Uuid::new_v4(),
+            quickwit_version: env!("CARGO_PKG_VERSION").to_string(),
+            os: env::consts::OS.to_string(),
+            arch: env::consts::ARCH.to_string(),
+            hashed_host_username: hashed_host_username(),
+            kubernetes: std::env::var_os("KUBERNETES_SERVICE_HOST").is_some(),
+        }
+    }
+}

--- a/quickwit-telemetry/src/sender.rs
+++ b/quickwit-telemetry/src/sender.rs
@@ -1,0 +1,403 @@
+/*
+ * Copyright (C) 2021 Quickwit Inc.
+ *
+ * Quickwit is offered under the AGPL v3.0 and as commercial software.
+ * For commercial licensing, contact us at hello@quickwit.io.
+ *
+ * AGPL:
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+use std::mem;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::mpsc::{Receiver, Sender};
+use tokio::sync::oneshot;
+use tokio::sync::Mutex;
+use tokio::sync::RwLock;
+use tokio::task::JoinHandle;
+use tokio::time::Interval;
+use tracing::info;
+
+use crate::payload::{ClientInformation, EventWithTimestamp, TelemetryEvent, TelemetryPayload};
+use crate::sink::HttpClient;
+use crate::sink::Sink;
+
+/// At most 1 Request per minutes.
+const TELEMETRY_PUSH_COOLDOWN: Duration = Duration::from_secs(60);
+
+/// Upon termination of the program, we send one last telemetry request with pending events.
+/// This duration is the amount of time we wait for at most to send that last telemetry request.
+const LAST_REQUEST_TIMEOUT: Duration = Duration::from_secs(1);
+
+const DISABLE_TELEMETRY_ENV_KEY: &str = "DISABLE_QUICKWIT_TELEMETRY";
+
+const MAX_NUM_EVENTS_IN_QUEUE: usize = 10;
+
+#[cfg(test)]
+struct ClockButton(Sender<()>);
+
+#[cfg(test)]
+impl ClockButton {
+    async fn tick(&self) {
+        let _ = self.0.send(()).await;
+    }
+}
+
+enum Clock {
+    Periodical(Mutex<Interval>),
+    #[cfg(test)]
+    Manual(Mutex<Receiver<()>>),
+}
+
+impl Clock {
+    pub fn periodical(period: Duration) -> Clock {
+        let interval = tokio::time::interval(period);
+        Clock::Periodical(Mutex::new(interval))
+    }
+
+    #[cfg(test)]
+    pub async fn manual() -> (ClockButton, Clock) {
+        let (tx, rx) = tokio::sync::mpsc::channel(1);
+        let _ = tx.send(()).await;
+        let button = ClockButton(tx);
+        (button, Clock::Manual(Mutex::new(rx)))
+    }
+
+    async fn tick(&self) {
+        match self {
+            Clock::Periodical(interval) => {
+                interval.lock().await.tick().await;
+            }
+            #[cfg(test)]
+            Clock::Manual(channel) => {
+                channel.lock().await.recv().await;
+            }
+        }
+    }
+}
+
+#[derive(Default)]
+struct EventsState {
+    events: Vec<EventWithTimestamp>,
+    num_dropped_events: usize,
+}
+
+impl EventsState {
+    fn drain_events(&mut self) -> EventsState {
+        mem::replace(
+            self,
+            EventsState {
+                events: Vec::new(),
+                num_dropped_events: 0,
+            },
+        )
+    }
+
+    /// Adds an event.
+    /// If the queue is already saturated, (ie. it has reached the len `MAX_NUM_EVENTS_IN_QUEUE`)
+    // Returns true iff it was the first event in the queue.
+    fn push_event(&mut self, event: TelemetryEvent) -> bool {
+        if self.events.len() >= MAX_NUM_EVENTS_IN_QUEUE {
+            self.num_dropped_events += 1;
+            return false;
+        }
+        let events_was_empty = self.events.is_empty();
+        self.events.push(EventWithTimestamp::from(event));
+        events_was_empty
+    }
+}
+
+struct Events {
+    state: RwLock<EventsState>,
+    items_available_tx: Sender<()>,
+    items_available_rx: RwLock<Receiver<()>>,
+}
+
+impl Default for Events {
+    fn default() -> Self {
+        let (items_available_tx, items_available_rx) = tokio::sync::mpsc::channel(1);
+        Events {
+            state: RwLock::new(EventsState::default()),
+            items_available_tx,
+            items_available_rx: RwLock::new(items_available_rx),
+        }
+    }
+}
+
+impl Events {
+    /// Wait for events to be available (if there are pending events, then do not wait)
+    /// and then send them to the PushAPI server.
+    async fn drain_events(&self) -> EventsState {
+        self.items_available_rx.write().await.recv().await;
+        self.state.write().await.drain_events()
+    }
+
+    async fn push_event(&self, event: TelemetryEvent) {
+        let is_first_event = self.state.write().await.push_event(event);
+        if is_first_event {
+            let _ = self.items_available_tx.send(()).await;
+        }
+    }
+}
+
+pub(crate) struct Inner {
+    sink: Option<Box<dyn Sink>>,
+    client_information: ClientInformation,
+    /// This channel is just used to signal there are new items available.
+    events: Events,
+    clock: Clock,
+    is_started: AtomicBool,
+}
+
+impl Inner {
+    pub fn is_disabled(&self) -> bool {
+        self.sink.is_none()
+    }
+
+    async fn create_telemetry_payload(&self) -> TelemetryPayload {
+        let events_state = self.events.drain_events().await;
+        TelemetryPayload {
+            client_information: self.client_information.clone(),
+            events: events_state.events,
+            num_dropped_events: events_state.num_dropped_events,
+        }
+    }
+
+    /// Wait for events to be available (if there are pending events, then do not wait)
+    /// and then send them to the PushAPI server.
+    ///
+    /// If the requests fails, it fails silently.
+    async fn send_pending_events(&self) {
+        if let Some(sink) = self.sink.as_ref() {
+            let payload = self.create_telemetry_payload().await;
+            sink.send_payload(payload).await;
+        }
+    }
+
+    async fn send(&self, event: TelemetryEvent) {
+        if self.is_disabled() {
+            return;
+        }
+        self.events.push_event(event).await;
+    }
+}
+
+pub struct TelemetrySender {
+    pub(crate) inner: Arc<Inner>,
+}
+
+pub enum TelemetryLoopHandle {
+    NoLoop,
+    WithLoop {
+        join_handle: JoinHandle<()>,
+        terminate_command_tx: oneshot::Sender<()>,
+    },
+}
+
+impl TelemetryLoopHandle {
+    /// Terminate telemetry will exit the telemetry loop
+    /// and possibly send the last request, possibly ignoring the
+    /// telemetry cooldown.
+    pub async fn terminate_telemetry(self) {
+        if let Self::WithLoop {
+            join_handle,
+            terminate_command_tx,
+        } = self
+        {
+            let _ = terminate_command_tx.send(());
+            let _ = tokio::time::timeout(LAST_REQUEST_TIMEOUT, join_handle).await;
+        }
+    }
+}
+
+impl TelemetrySender {
+    fn new<S: Sink>(sink_opt: Option<S>, clock: Clock) -> TelemetrySender {
+        let sink_opt: Option<Box<dyn Sink>> = if let Some(sink) = sink_opt {
+            Some(Box::new(sink))
+        } else {
+            None
+        };
+        TelemetrySender {
+            inner: Arc::new(Inner {
+                sink: sink_opt,
+                client_information: ClientInformation::default(),
+                events: Events::default(),
+                clock,
+                is_started: AtomicBool::new(false),
+            }),
+        }
+    }
+
+    pub fn start_loop(&self) -> TelemetryLoopHandle {
+        let (terminate_command_tx, mut terminate_command_rx) = oneshot::channel();
+        if self.inner.is_disabled() {
+            return TelemetryLoopHandle::NoLoop;
+        }
+
+        assert!(
+            self.inner
+                .is_started
+                .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+                .is_ok(),
+            "The telemetry loop is already started."
+        );
+
+        let inner = self.inner.clone();
+        let join_handle = tokio::task::spawn(async move {
+            // This channel is used to send the command to terminate telemetry.
+            loop {
+                let quit_loop = tokio::select! {
+                    _ = (&mut terminate_command_rx) => { true }
+                    _ = inner.clock.tick() => { false }
+                };
+                let _ = inner.send_pending_events().await;
+                if quit_loop {
+                    break;
+                }
+            }
+        });
+        TelemetryLoopHandle::WithLoop {
+            join_handle,
+            terminate_command_tx,
+        }
+    }
+
+    pub async fn send(&self, event: TelemetryEvent) {
+        self.inner.send(event).await;
+    }
+}
+
+fn create_http_client() -> Option<HttpClient> {
+    let telemetry_enabled = std::env::var_os(DISABLE_TELEMETRY_ENV_KEY).is_none();
+    // TODO add telemetry URL.
+    let client_opt = if telemetry_enabled {
+        HttpClient::try_new()
+    } else {
+        None
+    };
+    if let Some(client) = client_opt.as_ref() {
+        info!("telemetry to {} is enabled.", client.endpoint());
+    } else {
+        info!("telemetry to quickwit is disabled.");
+    }
+    client_opt
+}
+
+impl Default for TelemetrySender {
+    fn default() -> Self {
+        let http_client = create_http_client();
+        TelemetrySender::new(http_client, Clock::periodical(TELEMETRY_PUSH_COOLDOWN))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use std::env;
+
+    use super::*;
+
+    #[ignore]
+    #[test]
+    fn test_enabling_and_disabling_telemetry() {
+        // We group the two in a single test to ensure it happens on the same thread.
+        env::set_var(super::DISABLE_TELEMETRY_ENV_KEY, "");
+        assert_eq!(TelemetrySender::default().inner.is_disabled(), true);
+        env::remove_var(super::DISABLE_TELEMETRY_ENV_KEY);
+        assert_eq!(TelemetrySender::default().inner.is_disabled(), false);
+    }
+
+    #[tokio::test]
+    async fn test_telemetry_no_wait_for_first_event() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let (_clock_btn, clock) = Clock::manual().await;
+        let telemetry_sender = TelemetrySender::new(Some(tx), clock);
+        let loop_handler = telemetry_sender.start_loop();
+        telemetry_sender.send(TelemetryEvent::Create).await;
+        let payload_opt = rx.recv().await;
+        assert!(payload_opt.is_some());
+        let payload = payload_opt.unwrap();
+        assert_eq!(payload.events.len(), 1);
+        loop_handler.terminate_telemetry().await;
+    }
+
+    #[tokio::test]
+    async fn test_telemetry_two_events() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let (clock_btn, clock) = Clock::manual().await;
+        let telemetry_sender = TelemetrySender::new(Some(tx), clock);
+        let loop_handler = telemetry_sender.start_loop();
+        telemetry_sender.send(TelemetryEvent::Create).await;
+        {
+            let payload = rx.recv().await.unwrap();
+            assert_eq!(payload.events.len(), 1);
+        }
+        clock_btn.tick().await;
+        telemetry_sender.send(TelemetryEvent::Create).await;
+        {
+            let payload = rx.recv().await.unwrap();
+            assert_eq!(payload.events.len(), 1);
+        }
+        loop_handler.terminate_telemetry().await;
+    }
+
+    #[tokio::test]
+    async fn test_telemetry_cooldown_observed() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let (clock_btn, clock) = Clock::manual().await;
+        let telemetry_sender = TelemetrySender::new(Some(tx), clock);
+        let loop_handler = telemetry_sender.start_loop();
+        telemetry_sender.send(TelemetryEvent::Create).await;
+        {
+            let payload = rx.recv().await.unwrap();
+            assert_eq!(payload.events.len(), 1);
+        }
+        tokio::task::yield_now().await;
+        telemetry_sender.send(TelemetryEvent::Create).await;
+
+        let timeout_res = tokio::time::timeout(Duration::from_millis(1), rx.recv()).await;
+        assert!(timeout_res.is_err());
+
+        telemetry_sender.send(TelemetryEvent::Create).await;
+        clock_btn.tick().await;
+        {
+            let payload = rx.recv().await.unwrap();
+            assert_eq!(payload.events.len(), 2);
+        }
+        loop_handler.terminate_telemetry().await;
+    }
+
+    #[tokio::test]
+    async fn test_terminate_telemetry_sends_pending_events() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let (_clock_btn, clock) = Clock::manual().await;
+        let telemetry_sender = TelemetrySender::new(Some(tx), clock);
+        let loop_handler = telemetry_sender.start_loop();
+        telemetry_sender.send(TelemetryEvent::Create).await;
+        let payload = rx.recv().await.unwrap();
+        assert_eq!(payload.events.len(), 1);
+        telemetry_sender
+            .send(TelemetryEvent::EndCommand { return_code: 2i32 })
+            .await;
+        loop_handler.terminate_telemetry().await;
+        let payload = rx.recv().await.unwrap();
+        assert_eq!(payload.events.len(), 1);
+        assert!(matches!(
+            &payload.events[0].event,
+            &TelemetryEvent::EndCommand { .. }
+        ));
+    }
+}

--- a/quickwit-telemetry/src/sink.rs
+++ b/quickwit-telemetry/src/sink.rs
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2021 Quickwit Inc.
+ *
+ * Quickwit is offered under the AGPL v3.0 and as commercial software.
+ * For commercial licensing, contact us at hello@quickwit.io.
+ *
+ * AGPL:
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+use async_trait::async_trait;
+use reqwest::redirect::Policy;
+use reqwest::Client;
+use std::time::Duration;
+use tokio::sync::mpsc::UnboundedSender;
+
+use crate::payload::TelemetryPayload;
+
+/// Telemetry push API URL
+const DEFAULT_TELEMETRY_PUSH_API_URL: &str = "https://telemetry.quickwit.dev/";
+
+fn telemetry_push_api_url() -> String {
+    if let Some(push_api_url) = std::env::var_os("TELEMETRY_PUSH_API") {
+        push_api_url.to_string_lossy().to_string()
+    } else {
+        DEFAULT_TELEMETRY_PUSH_API_URL.to_string()
+    }
+}
+
+#[async_trait]
+pub trait Sink: Send + Sync + 'static {
+    async fn send_payload(&self, payload: TelemetryPayload);
+}
+pub struct HttpClient {
+    client: Client,
+    endpoint: String,
+}
+
+impl HttpClient {
+    pub fn try_new() -> Option<Self> {
+        let client = Client::builder()
+            .redirect(Policy::limited(3))
+            .timeout(Duration::from_secs(10))
+            .build()
+            .ok()?;
+        Some(HttpClient {
+            client,
+            endpoint: telemetry_push_api_url(),
+        })
+    }
+
+    pub fn endpoint(&self) -> &str {
+        &self.endpoint
+    }
+}
+
+#[async_trait]
+impl Sink for UnboundedSender<TelemetryPayload> {
+    async fn send_payload(&self, payload: TelemetryPayload) {
+        let _ = self.send(payload);
+    }
+}
+
+#[async_trait]
+impl Sink for HttpClient {
+    async fn send_payload(&self, payload: TelemetryPayload) {
+        // Note that we swallow the error if any
+        let _ = self.client.post(&self.endpoint).json(&payload).send().await;
+    }
+}


### PR DESCRIPTION
This PR adds a telemetry sender.

By design it cannot send more than 10 events a minute and do one request per minute.
The information that is being send can be eyeball in a single file.
If it fails, it does so silently.


### Checklist
*Remove or complete this list if required.*
- [x] tested locally
Using npx http-echo-server and by hardcoding the URL to http://localhost:3000
- [x] added unit tests
- [x] included documentation
