### PR TITLE
Automate Binary Build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ on:
   push:
     tags:
       - '*'
-
+      
 jobs:
   publish:
     name: Publish for ${{ matrix.os }}
@@ -85,12 +85,90 @@ jobs:
           command: build
           args: --release --target x86_64-unknown-linux-musl
       - name: Rename artifact
-        run: mv target/x86_64-unknown-linux-musl/release/quickwit-cli quickwit-cli-aarch64-unknown-linux-musl
+        run: mv target/x86_64-unknown-linux-musl/release/quickwit-cli quickwit-cli-x86_64-unknown-linux-musl
+      - name: Upload artifact
+        uses: quickwit-inc/upload-to-github-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          file: quickwit-cli-x86_64-unknown-linux-musl
+          overwrite: true
+          tag_name: latest-draft-release
+
+  aarch64-linux-musl:
+    name: publish aarch64-linux-musl
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: aarch64-unknown-linux-musl
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: build
+          args: --release --target aarch64-unknown-linux-musl
+      - name: Rename artifact
+        run: mv target/aarch64-unknown-linux-musl/release/quickwit-cli quickwit-cli-aarch64-unknown-linux-musl
       - name: Upload artifact
         uses: quickwit-inc/upload-to-github-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           file: quickwit-cli-aarch64-unknown-linux-musl
+          overwrite: true
+          tag_name: latest-draft-release
+
+  armv7-linux-gnueabihf:
+    name: publish armv7-linux-gnueabihf
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: armv7-unknown-linux-gnueabihf
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: build
+          args: --release --target armv7-unknown-linux-gnueabihf
+      - name: Rename artifact
+        run: mv target/armv7-unknown-linux-gnueabihf/release/quickwit-cli quickwit-cli-armv7-unknown-linux-gnueabihf
+      - name: Upload artifact
+        uses: quickwit-inc/upload-to-github-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          file: quickwit-cli-armv7-unknown-linux-gnueabihf
+          overwrite: true
+          tag_name: latest-draft-release
+
+  armv7-linux-musleabihf:
+    name: publish armv7-linux-musleabihf
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: armv7-unknown-linux-musleabihf
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: build
+          args: --release --target armv7-unknown-linux-musleabihf
+      - name: Rename artifact
+        run: mv target/armv7-unknown-linux-musleabihf/release/quickwit-cli quickwit-cli-armv7-unknown-linux-musleabihf
+      - name: Upload artifact
+        uses: quickwit-inc/upload-to-github-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          file: quickwit-cli-armv7-unknown-linux-musleabihf
           overwrite: true
           tag_name: latest-draft-release

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,11 +19,12 @@ jobs:
           - build: macos
             os: macos-latest
             artifact_name: quickwit-cli
-            asset_name: quickwit-cli-x86_64-apple-darwin         
-          - build: windows
-            os: windows-latest
-            artifact_name: quickwit-cli.exe
-            asset_name: quickwit-cli-x86_64-pc-windows.exe
+            asset_name: quickwit-cli-x86_64-apple-darwin
+          # TODO: uncomment this when windows is fully supported.         
+          # - build: windows
+          #   os: windows-latest
+          #   artifact_name: quickwit-cli.exe
+          #   asset_name: quickwit-cli-x86_64-pc-windows.exe
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,96 @@
+name: PUBLISH
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  publish:
+    name: Publish for ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - build: linux
+            os: ubuntu-latest
+            artifact_name: quickwit-cli
+            asset_name: quickwit-cli-x86_64-unknown-linux-gnu
+          - build: macos
+            os: macos-latest
+            artifact_name: quickwit-cli
+            asset_name: quickwit-cli-x86_64-apple-darwin         
+          - build: windows
+            os: windows-latest
+            artifact_name: quickwit-cli.exe
+            asset_name: quickwit-cli-x86_64-pc-windows.exe
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - name: Build binary
+        run: cargo build --release
+      - name: Rename artifact
+        run: mv target/release/${{ matrix.artifact_name }} ${{ matrix.asset_name }}
+      - name: Upload artifact
+        uses: quickwit-inc/upload-to-github-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          file: ${{ matrix.asset_name }}
+          overwrite: true
+          tag_name: latest-draft-release
+
+  aarch64-linux-gnu:
+    name: publish aarch64-linux-gnu
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: aarch64-unknown-linux-gnu
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: build 
+          args: --release --target aarch64-unknown-linux-gnu
+      - name: Rename artifact
+        run: mv target/aarch64-unknown-linux-gnu/release/quickwit-cli quickwit-cli-aarch64-unknown-linux-gnu
+      - name: Upload artifact
+        uses: quickwit-inc/upload-to-github-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          file: quickwit-cli-aarch64-unknown-linux-gnu
+          overwrite: true
+          tag_name: latest-draft-release
+
+  x86_64-linux-musl:
+    name: publish x86_64-linux-musl
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: x86_64-unknown-linux-musl
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: build
+          args: --release --target x86_64-unknown-linux-musl
+      - name: Rename artifact
+        run: mv target/x86_64-unknown-linux-musl/release/quickwit-cli quickwit-cli-aarch64-unknown-linux-musl
+      - name: Upload artifact
+        uses: quickwit-inc/upload-to-github-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          file: quickwit-cli-aarch64-unknown-linux-musl
+          overwrite: true
+          tag_name: latest-draft-release

--- a/installer
+++ b/installer
@@ -69,7 +69,9 @@ install_from_archive() {
 
     local _binary_arch=""
     case "$_arch" in
-        x86_64-apple-darwin | aarch64-apple-darwin)
+        # Add `| aarch64-apple-darwin` when M1 is fully supported.
+        # Note that M1 binary can still be built from source.
+        x86_64-apple-darwin)  
             _binary_arch=$_arch
             ;;
         x86_64-*linux*-gnu)

--- a/quickwit-telemetry/Cargo.toml
+++ b/quickwit-telemetry/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2018"
 [dependencies]
 once_cell = "1.8.0"
 reqwest = { version = "0.11", default-features=false, features = ["json", "rustls-tls"] }
-openssl = { version = '0.10', features = ["vendored"] }
 tokio = {version = "1", features = ["full"]}
 anyhow = "1"
 serde = {version="1", features = ["derive"]}

--- a/quickwit-telemetry/Cargo.toml
+++ b/quickwit-telemetry/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 [dependencies]
 once_cell = "1.8.0"
 reqwest = { version = "0.11", default-features=false, features = ["json", "rustls-tls"] }
+openssl = { version = '0.10', features = ["vendored"] }
 tokio = {version = "1", features = ["full"]}
 anyhow = "1"
 serde = {version="1", features = ["derive"]}


### PR DESCRIPTION
### Context / purpose
We need to automate building Quickwit binaries build. [See](https://github.com/quickwit-inc/quickwit/issues/168)

### Description
using CI and `quickwit-inc/upload-to-github-release@v1` to upload the binaries.

### How was this PR tested?
Testing the resulting binaries on platforms I have: macos-10.15, ubuntu-20.04

### Checklist
- [x] add step to build for other architectures
- [x] tested locally on each platform (macos-10.15, ubuntu-20.04)
