### PR TITLE
Index Uri error message

### DIFF
--- a/quickwit-common/src/lib.rs
+++ b/quickwit-common/src/lib.rs
@@ -36,8 +36,17 @@ use regex::Regex;
 pub fn extract_metastore_uri_and_index_id_from_index_uri(
     index_uri: &str,
 ) -> anyhow::Result<(&str, &str)> {
+    static INDEX_URI_PATTERN: Lazy<Regex> = Lazy::new(|| Regex::new(r"^.+://.+/.+$").unwrap());
     static INDEX_ID_PATTERN: Lazy<Regex> =
         Lazy::new(|| Regex::new(r"^[a-zA-Z][a-zA-Z0-9_\-]*$").unwrap());
+
+    if !INDEX_URI_PATTERN.is_match(index_uri) {
+        anyhow::bail!(
+            "Invalid index uri `{}`. Expected format is: `protocol://bucket/path-to-target`.",
+            index_uri
+        );
+    }
+
     let parts: Vec<&str> = index_uri.rsplitn(2, '/').collect();
     if parts.len() != 2 {
         anyhow::bail!("Failed to parse the uri into a metastore_uri and an index_id.");

--- a/quickwit-common/src/lib.rs
+++ b/quickwit-common/src/lib.rs
@@ -32,7 +32,6 @@ use regex::Regex;
 /// \--------------------------------------------/ \------/
 ///        metastore_uri                           index_id
 ///
-/// TODO force the presence of a protocol and a specific format using a regex?
 pub fn extract_metastore_uri_and_index_id_from_index_uri(
     index_uri: &str,
 ) -> anyhow::Result<(&str, &str)> {

--- a/quickwit-storage/src/object_storage/s3_compatible_storage.rs
+++ b/quickwit-storage/src/object_storage/s3_compatible_storage.rs
@@ -137,15 +137,16 @@ pub fn parse_uri(uri: &str) -> Option<(String, PathBuf)> {
             Regex::new(r"s3(\+[^:]+)?://(?P<bucket>[^/]+)/(?P<path>.+)").unwrap()
         })
         .captures(uri)
-        .and_then(|cap| match cap.name("bucket") {
-            Some(bucket_match) => Some((
-                bucket_match.as_str().to_string(),
-                cap.name("path").map_or_else(
-                    || PathBuf::from(""),
-                    |path_match| PathBuf::from(path_match.as_str()),
-                ),
-            )),
-            _ => None,
+        .and_then(|cap| {
+            cap.name("bucket").map(|bucket_match| {
+                (
+                    bucket_match.as_str().to_string(),
+                    cap.name("path").map_or_else(
+                        || PathBuf::from(""),
+                        |path_match| PathBuf::from(path_match.as_str()),
+                    ),
+                )
+            })
         })
 }
 

--- a/quickwit-storage/src/object_storage/s3_compatible_storage.rs
+++ b/quickwit-storage/src/object_storage/s3_compatible_storage.rs
@@ -100,7 +100,7 @@ impl S3CompatibleObjectStorage {
 
     /// Creates an object storage given a region and an uri.
     pub fn from_uri(region: Region, uri: &str) -> crate::StorageResult<S3CompatibleObjectStorage> {
-        let (bucket, path) = parse_split_uri(uri).ok_or_else(|| {
+        let (bucket, path) = parse_uri(uri).ok_or_else(|| {
             crate::StorageErrorKind::Io.with_error(anyhow::anyhow!("Invalid uri: {}", uri))
         })?;
         let s3_compatible_storage = S3CompatibleObjectStorage::new(region, &bucket)
@@ -129,18 +129,21 @@ impl S3CompatibleObjectStorage {
     }
 }
 
-pub fn parse_split_uri(split_uri: &str) -> Option<(String, PathBuf)> {
-    static SPLIT_URI_PTN: OnceCell<Regex> = OnceCell::new();
-    SPLIT_URI_PTN
+pub fn parse_uri(uri: &str) -> Option<(String, PathBuf)> {
+    static URI_PTN: OnceCell<Regex> = OnceCell::new();
+    URI_PTN
         .get_or_init(|| {
-            // s3://bucket/path/to/split or s3+localstack://bucket/path/to/split
-            Regex::new(r"s3(\+[^:]+)?://(?P<bucket>[^/]+)/(?P<path>.*)").unwrap()
+            // s3://bucket/path/to/object or s3+localstack://bucket/path/to/object
+            Regex::new(r"s3(\+[^:]+)?://(?P<bucket>[^/]+)/(?P<path>.+)").unwrap()
         })
-        .captures(split_uri)
-        .and_then(|cap| match (cap.name("bucket"), cap.name("path")) {
-            (Some(bucket_match), Some(path_match)) => Some((
+        .captures(uri)
+        .and_then(|cap| match cap.name("bucket") {
+            Some(bucket_match) => Some((
                 bucket_match.as_str().to_string(),
-                PathBuf::from(path_match.as_str()),
+                cap.name("path").map_or_else(
+                    || PathBuf::from(""),
+                    |path_match| PathBuf::from(path_match.as_str()),
+                ),
             )),
             _ => None,
         })
@@ -605,13 +608,24 @@ mod tests {
         assert_eq!(split_range_into_chunks(0, 1), vec![]);
     }
 
-    use super::parse_split_uri;
+    use super::parse_uri;
 
     #[test]
-    fn test_parse_split_uri() {
+    fn test_parse_uri() {
         assert_eq!(
-            parse_split_uri("s3://bucket/path/to/object"),
+            parse_uri("s3://bucket/path/to/object"),
             Some(("bucket".to_string(), PathBuf::from("path/to/object")))
         );
+        assert_eq!(
+            parse_uri("s3://bucket/path"),
+            Some(("bucket".to_string(), PathBuf::from("path")))
+        );
+        assert_eq!(
+            parse_uri("s3+localstack://bucket/path/to/object"),
+            Some(("bucket".to_string(), PathBuf::from("path/to/object")))
+        );
+        assert_eq!(parse_uri("s3://bucket/"), None);
+        assert_eq!(parse_uri("s3://bucket"), None);
+        assert_eq!(parse_uri("mem://bucket/path/to"), None);
     }
 }

--- a/quickwit-storage/src/object_storage/s3_compatible_storage.rs
+++ b/quickwit-storage/src/object_storage/s3_compatible_storage.rs
@@ -134,7 +134,7 @@ pub fn parse_uri(uri: &str) -> Option<(String, PathBuf)> {
     URI_PTN
         .get_or_init(|| {
             // s3://bucket/path/to/object or s3+localstack://bucket/path/to/object
-            Regex::new(r"s3(\+[^:]+)?://(?P<bucket>[^/]+)/(?P<path>.+)").unwrap()
+            Regex::new(r"s3(\+[^:]+)?://(?P<bucket>[^/]+)(/(?P<path>.+))?").unwrap()
         })
         .captures(uri)
         .and_then(|cap| {
@@ -625,8 +625,14 @@ mod tests {
             parse_uri("s3+localstack://bucket/path/to/object"),
             Some(("bucket".to_string(), PathBuf::from("path/to/object")))
         );
-        assert_eq!(parse_uri("s3://bucket/"), None);
-        assert_eq!(parse_uri("s3://bucket"), None);
+        assert_eq!(
+            parse_uri("s3://bucket/"),
+            Some(("bucket".to_string(), PathBuf::from("")))
+        );
+        assert_eq!(
+            parse_uri("s3://bucket"),
+            Some(("bucket".to_string(), PathBuf::from("")))
+        );
         assert_eq!(parse_uri("mem://bucket/path/to"), None);
     }
 }


### PR DESCRIPTION
### Context / purpose
Fix invalid index uri error message [See](https://github.com/quickwit-inc/quickwit/issues/132)

### Description
Implemented validation enforcing index uri format.
refactored s3Compatible `parse_split_uri` to `parse_uri` 

### Checklist
- [x] tested locally
- [x] added unit tests
