### PR TITLE
Using telemetry.quickwit.io instead of telemetry.quickwit.dev

### DIFF
--- a/quickwit-telemetry/src/sink.rs
+++ b/quickwit-telemetry/src/sink.rs
@@ -27,7 +27,7 @@ use tokio::sync::mpsc::UnboundedSender;
 use crate::payload::TelemetryPayload;
 
 /// Telemetry push API URL
-const DEFAULT_TELEMETRY_PUSH_API_URL: &str = "https://telemetry.quickwit.dev/";
+const DEFAULT_TELEMETRY_PUSH_API_URL: &str = "https://telemetry.quickwit.io/";
 
 fn telemetry_push_api_url() -> String {
     if let Some(push_api_url) = std::env::var_os("TELEMETRY_PUSH_API") {


### PR DESCRIPTION
It may be difficult for users to identify quickwit.dev as one of our official domain.
The telemetry domain should lead to our official domain.