### PR TITLE
Automatically generate host key path.

### DIFF
--- a/quickwit-cli/src/cli.yaml
+++ b/quickwit-cli/src/cli.yaml
@@ -115,11 +115,11 @@ subcommands:
                 long: port
                 default_value: '8080'
                 value_name: PORT
-            - host-key-path:
-                help: Path to the host key file where the data that makes a host unique in the cluster is stored.
-                long: host-key-path
+            - host-key-path-prefix:
+                help: Path prefix to the host key file where the data that makes a host unique in the cluster is stored.
+                long: host-key-path-prefix
                 default_value: '/tmp/quickwit-host-key'
-                value_name: HOST KEY
+                value_name: HOST KEY PREFIX
             - peer-seeds:
                 help: Peer address the REST API server (e.g. 192.1.1.3:8080) to connect to form a cluster. (To specify more than one, separate with a comma.)
                 long: peer-seeds


### PR DESCRIPTION
### Context / purpose
Automatically generate host key path.
See #246.
Closes #246.

### Description
Automatically generate the host key path from `--host-key-path-prefix`, `--host` and `--port`.

When run `quickwit serve --host=0.0.0.0 --index-uris=file:///tmp/quickwit/indices/hdfslogs-idx --port=8080`, the host key file will be created at `/tmp/quickwit-host-key-0.0.0.0-8080`.

### How was this PR tested?
`cargo test -- --nocapture test_parse_serve_args`

### Checklist
*Remove or complete this list if required.*
- [x] tested locally
- [x] added unit tests
- [x] included documentation
