### PR TITLE
Rename CLI option to singular.

### DIFF
--- a/quickwit-cli/src/cli.yaml
+++ b/quickwit-cli/src/cli.yaml
@@ -98,10 +98,10 @@ subcommands:
     - serve:
         about: Serve a REST API to search an index
         args:
-            - index-uris:
-                help: Location of the target indices. (To specify more than one, separate with a comma.)
-                long: index-uris
-                value_name: INDEX URIS
+            - index-uri:
+                help: Location of the target index.
+                long: index-uri
+                value_name: INDEX URI
                 multiple: true
                 use_delimiter: true
                 required: true
@@ -120,9 +120,9 @@ subcommands:
                 long: host-key-path-prefix
                 default_value: '/tmp/quickwit-host-key'
                 value_name: HOST KEY PREFIX
-            - peer-seeds:
-                help: Peer address the REST API server (e.g. 192.1.1.3:8080) to connect to form a cluster. (To specify more than one, separate with a comma.)
-                long: peer-seeds
-                value_name: PEER SEEDS
+            - peer-seed:
+                help: Peer address the REST API server (e.g. 192.1.1.3:8080) to connect to form a cluster.
+                long: peer-seed
+                value_name: PEER SEED
                 multiple: true
                 use_delimiter: true

--- a/quickwit-cli/tests/cli.rs
+++ b/quickwit-cli/tests/cli.rs
@@ -311,7 +311,7 @@ async fn test_all_with_s3_localstack_cli() -> Result<()> {
     // serve & api-search
     let mut server_process = spawn_command(
         format!(
-            "serve --index-uris {} --host 127.0.0.1 --port 8182",
+            "serve --index-uri {} --host 127.0.0.1 --port 8182",
             test_env.index_uri
         )
         .as_str(),
@@ -393,7 +393,7 @@ async fn test_all_with_s3_localstack_internal_api() -> Result<()> {
     // serve & api-search
     let mut server_process = spawn_command(
         format!(
-            "serve --index-uris {} --host 127.0.0.1 --port 8182",
+            "serve --index-uri {} --host 127.0.0.1 --port 8182",
             test_env.index_uri
         )
         .as_str(),


### PR DESCRIPTION
### Context / purpose
Rename CLI option to singular.

### Description
See #245.

### How was this PR tested?
`cargo test -- --nocapture test_parse_serve_args`

### Checklist
*Remove or complete this list if required.*
- [x] tested locally
- [x] added unit tests
- [x] included documentation

Closes #245 