### PR TITLE
Display CLI metadata

### DIFF
--- a/quickwit-cli/src/main.rs
+++ b/quickwit-cli/src/main.rs
@@ -211,11 +211,13 @@ fn setup_logger(default_level: Level) {
 #[tokio::main]
 async fn main() {
     let telemetry_handle = quickwit_telemetry::start_telemetry_loop();
+    let about_text = about_text();
 
     let yaml = load_yaml!("cli.yaml");
     let app = App::from(yaml)
         .setting(AppSettings::ArgRequiredElseHelp)
-        .version(env!("CARGO_PKG_VERSION"));
+        .version(env!("CARGO_PKG_VERSION"))
+        .about(about_text.as_str());
     let matches = app.get_matches();
 
     let command = match CliCommand::parse_cli_args(&matches) {
@@ -248,6 +250,15 @@ async fn main() {
     telemetry_handle.terminate_telemetry().await;
 
     std::process::exit(return_code);
+}
+
+/// Return the about text with telemetry info.
+fn about_text() -> String {
+    let mut about_text = String::from("Indexing your large dataset on object storage & making it searchable from the command line.\n");
+    if quickwit_telemetry::is_telemetry_enabled() {
+        about_text += "Telemetry Enabled";
+    }
+    about_text
 }
 
 #[cfg(test)]

--- a/quickwit-telemetry/src/lib.rs
+++ b/quickwit-telemetry/src/lib.rs
@@ -28,6 +28,8 @@ use crate::payload::TelemetryEvent;
 use crate::sender::{TelemetryLoopHandle, TelemetrySender};
 use once_cell::sync::OnceCell;
 
+pub use crate::sender::is_telemetry_enabled;
+
 pub fn start_telemetry_loop() -> TelemetryLoopHandle {
     get_telemetry_sender_singleton().start_loop()
 }

--- a/quickwit-telemetry/src/sender.rs
+++ b/quickwit-telemetry/src/sender.rs
@@ -280,10 +280,14 @@ impl TelemetrySender {
     }
 }
 
+/// Check to see if telemetry is enabled.
+pub fn is_telemetry_enabled() -> bool {
+    std::env::var_os(DISABLE_TELEMETRY_ENV_KEY).is_none()
+}
+
 fn create_http_client() -> Option<HttpClient> {
-    let telemetry_enabled = std::env::var_os(DISABLE_TELEMETRY_ENV_KEY).is_none();
     // TODO add telemetry URL.
-    let client_opt = if telemetry_enabled {
+    let client_opt = if is_telemetry_enabled() {
         HttpClient::try_new()
     } else {
         None


### PR DESCRIPTION
### Context / purpose
Closes https://github.com/quickwit-inc/quickwit/issues/253

### Description
- Added about text to the CLI that also make mention of the telemetry if enabled
```
./quickwit
Quickwit CLI 0.1.0
Quickwit, Inc. <hello@quickwit.com>
Indexing your large dataset on object storage & making it searchable from the command line.
Telemetry Enabled

USAGE:
...
```

### Checklist
- [x] tested locally
- [ ] added unit tests
- [ ] included documentation
