### PR TITLE
Fixing topK collection in QuickwitCollector #272

### DIFF
--- a/quickwit-index-config/src/default_index_config/default_config.rs
+++ b/quickwit-index-config/src/default_index_config/default_config.rs
@@ -23,7 +23,7 @@
 use super::{default_as_true, SOURCE_FIELD_NAME};
 use super::{field_mapping_entry::DocParsingError, FieldMappingEntry, FieldMappingType};
 use crate::query_builder::build_query;
-use crate::{IndexConfig, QueryParserError};
+use crate::{IndexConfig, QueryParserError, SortBy, SortOrder};
 use anyhow::{bail, Context};
 use quickwit_proto::SearchRequest;
 use serde::{Deserialize, Serialize};
@@ -234,6 +234,17 @@ impl IndexConfig for DefaultIndexConfig {
 
     fn timestamp_field_name(&self) -> Option<String> {
         self.timestamp_field_name.clone()
+    }
+
+    fn default_sort_by(&self) -> crate::SortBy {
+        if let Some(timestamp_fieldname) = self.timestamp_field_name() {
+            SortBy::SortByFastField {
+                field_name: timestamp_fieldname,
+                order: SortOrder::Desc,
+            }
+        } else {
+            SortBy::DocId
+        }
     }
 }
 

--- a/quickwit-search/src/collector.rs
+++ b/quickwit-search/src/collector.rs
@@ -104,7 +104,7 @@ struct PartialHitHeapItem {
 
 impl PartialOrd for PartialHitHeapItem {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(other.cmp(self))
+        Some(self.cmp(other))
     }
 }
 
@@ -152,14 +152,14 @@ impl QuickwitSegmentCollector {
     }
 
     fn collect_top_k(&mut self, doc_id: DocId) {
-        let sorting_field: u64 = self.sort_by.compute_sorting_field(doc_id);
+        let sorting_field_value: u64 = self.sort_by.compute_sorting_field(doc_id);
         if self.at_capacity() {
             if let Some(limit_sorting_field) = self.hits.peek().map(|head| head.sorting_field_value)
             {
                 // In case of a tie, we keep the document with a lower `DocId`.
-                if limit_sorting_field < sorting_field {
+                if limit_sorting_field < sorting_field_value {
                     if let Some(mut head) = self.hits.peek_mut() {
-                        head.sorting_field_value = sorting_field;
+                        head.sorting_field_value = sorting_field_value;
                         head.doc_id = doc_id;
                     }
                 }
@@ -168,7 +168,7 @@ impl QuickwitSegmentCollector {
             // we have not reached capacity yet, so we can just push the
             // element.
             self.hits.push(PartialHitHeapItem {
-                sorting_field_value: sorting_field,
+                sorting_field_value,
                 doc_id,
             });
         }

--- a/quickwit-search/src/service.rs
+++ b/quickwit-search/src/service.rs
@@ -29,6 +29,7 @@ use quickwit_proto::{
     SearchResult,
 };
 use quickwit_storage::StorageUriResolver;
+use tracing::info;
 
 use crate::fetch_docs;
 use crate::leaf_search;
@@ -120,6 +121,7 @@ impl SearchService for SearchServiceImpl {
         let search_request = leaf_search_request
             .search_request
             .ok_or_else(|| SearchError::InternalError(anyhow::anyhow!("No search request.")))?;
+        info!(index=?search_request.index_id, splits=?leaf_search_request.split_ids, "leaf_search");
         let metastore = self
             .metastore_router
             .get(&search_request.index_id)


### PR DESCRIPTION
Closes #272 

The ordering was inverted in the Order trait, but inverted again in the PartialOrder trait too.