### PR TITLE
Deserialize error coming from grpc and fail if any split fails

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2840,6 +2840,7 @@ dependencies = [
  "quickwit-cluster",
  "quickwit-common",
  "quickwit-directories",
+ "quickwit-index-config",
  "quickwit-metastore",
  "quickwit-proto",
  "quickwit-search",

--- a/quickwit-search/src/service.rs
+++ b/quickwit-search/src/service.rs
@@ -108,10 +108,12 @@ impl SearchService for SearchServiceImpl {
                 index_id: search_request.index_id.clone(),
             })?;
 
-        let search_result =
-            root_search(&search_request, metastore.as_ref(), &self.client_pool).await?;
-
-        Ok(search_result)
+        root_search(&search_request, metastore.as_ref(), &self.client_pool)
+            .await
+            .map_err(|error| match error.downcast::<SearchError>() {
+                Ok(error) => error,
+                Err(other) => SearchError::InternalError(other),
+            })
     }
 
     async fn leaf_search(

--- a/quickwit-serve/Cargo.toml
+++ b/quickwit-serve/Cargo.toml
@@ -18,6 +18,7 @@ quickwit-common = {path="../quickwit-common"}
 quickwit-metastore = {path="../quickwit-metastore"}
 quickwit-telemetry = {path="../quickwit-telemetry"}
 quickwit-directories = {path="../quickwit-directories"}
+quickwit-index-config = {path="../quickwit-index-config"}
 thiserror = "1"
 tonic = "0.4"
 async-trait = "0.1"

--- a/quickwit-serve/src/grpc_adapter.rs
+++ b/quickwit-serve/src/grpc_adapter.rs
@@ -83,7 +83,7 @@ fn convert_error_to_tonic_status(search_error: SearchError) -> tonic::Status {
     match search_error {
         SearchError::IndexDoesNotExist { index_id } => tonic::Status::new(
             tonic::Code::NotFound,
-            format!("Index not found {}", index_id),
+            format!("Index not found: {}", index_id),
         ),
         SearchError::InternalError(error) => tonic::Status::new(
             tonic::Code::Internal,
@@ -91,7 +91,7 @@ fn convert_error_to_tonic_status(search_error: SearchError) -> tonic::Status {
         ),
         SearchError::StorageResolverError(storage_resolver_error) => tonic::Status::new(
             tonic::Code::Internal,
-            format!("Failed to resolve storage uri {:?}", storage_resolver_error),
+            format!("Storage resolver error: {:?}", storage_resolver_error),
         ),
         SearchError::InvalidQuery(query_error) => tonic::Status::new(
             tonic::Code::InvalidArgument,


### PR DESCRIPTION
This is linked to issue #269 which we cannot ignore for the release.

SearchError are deserialized to make sure that the server answers correctly to the client. For example, a error in the query parsing should return a 400. 
