### PR TITLE
Improves Error handling and different bugs.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2875,6 +2875,7 @@ dependencies = [
  "regex",
  "rusoto_core",
  "rusoto_s3",
+ "serde",
  "tempfile",
  "thiserror",
  "tokio",

--- a/quickwit-index-config/src/error.rs
+++ b/quickwit-index-config/src/error.rs
@@ -23,7 +23,7 @@ use thiserror::Error;
 // TODO improve me and my error messages :)
 
 #[derive(Error, Debug)]
-#[error("QueryParserError(`{0}`)")]
+#[error("Invalid query syntax: `{0}`")]
 
 /// Failed to parse query.
 pub struct QueryParserError(#[from] anyhow::Error);

--- a/quickwit-metastore/src/metastore_resolver.rs
+++ b/quickwit-metastore/src/metastore_resolver.rs
@@ -96,17 +96,17 @@ impl MetastoreUriResolver {
             .default_storage_resolver
             .resolve(&uri)
             .map_err(|err| match err {
-                StorageResolverError::InvalidUri(err_msg) => {
-                    MetastoreResolverError::InvalidUri(err_msg)
+                StorageResolverError::InvalidUri { message } => {
+                    MetastoreResolverError::InvalidUri(message)
                 }
-                StorageResolverError::ProtocolUnsupported(err_msg) => {
-                    MetastoreResolverError::ProtocolUnsupported(err_msg)
+                StorageResolverError::ProtocolUnsupported { protocol } => {
+                    MetastoreResolverError::ProtocolUnsupported(protocol)
                 }
-                StorageResolverError::FailedToOpenStorage(err) => {
+                StorageResolverError::FailedToOpenStorage { kind, message } => {
                     MetastoreResolverError::FailedToOpenMetastore(MetastoreError::InternalError {
                         message: "Failed to open storage hosting the single file metastore."
                             .to_string(),
-                        cause: anyhow::anyhow!(err),
+                        cause: anyhow::anyhow!("StorageError {:?}: {}.", kind, message),
                     })
                 }
             })?;

--- a/quickwit-search/src/client_pool.rs
+++ b/quickwit-search/src/client_pool.rs
@@ -21,10 +21,10 @@
 
 pub mod search_client_pool;
 
-use std::net::SocketAddr;
-
 use anyhow::Result;
 use async_trait::async_trait;
+use quickwit_proto::search_service_client::SearchServiceClient;
+use tonic::transport::Channel;
 
 /// Job.
 /// The unit in which distributed search is performed.
@@ -43,5 +43,8 @@ pub struct Job {
 pub trait ClientPool: Send + Sync + 'static {
     /// Assign the given job to the clients.
     /// Returns a list of pair (SocketAddr, Vec<Job>)
-    async fn assign_jobs(&self, jobs: Vec<Job>) -> Result<Vec<(SocketAddr, Vec<Job>)>>;
+    async fn assign_jobs(
+        &self,
+        jobs: Vec<Job>,
+    ) -> Result<Vec<(SearchServiceClient<Channel>, Vec<Job>)>>;
 }

--- a/quickwit-search/src/client_pool/search_client_pool.rs
+++ b/quickwit-search/src/client_pool/search_client_pool.rs
@@ -114,15 +114,29 @@ impl SearchClientPool {
 impl ClientPool for SearchClientPool {
     /// Assign the given job to the clients.
     /// Returns a list of pair (SocketAddr, Vec<Job>)
-    async fn assign_jobs(&self, mut jobs: Vec<Job>) -> anyhow::Result<Vec<(SocketAddr, Vec<Job>)>> {
+    async fn assign_jobs(
+        &self,
+        mut jobs: Vec<Job>,
+    ) -> anyhow::Result<Vec<(SearchServiceClient<Channel>, Vec<Job>)>> {
         let mut splits_groups: HashMap<SocketAddr, Vec<Job>> = HashMap::new();
 
         // Distribute using rendez-vous hashing
-        let clients = self.clients.read().await;
-        let mut nodes: Vec<Node> = clients
-            .iter()
-            .map(|(grpc_addr, _client)| Node::new(*grpc_addr, 0))
-            .collect();
+        let mut nodes: Vec<Node> = Vec::new();
+        let mut socket_to_client: HashMap<SocketAddr, SearchServiceClient<Channel>> =
+            Default::default();
+
+        {
+            // restricting the lock guard lifetime.
+
+            // TODO optimize the case where there are few jobs and many clients.
+            let clients = self.clients.read().await;
+
+            for (grpc_addr, client) in clients.iter() {
+                let node = Node::new(*grpc_addr, 0);
+                nodes.push(node);
+                socket_to_client.insert(*grpc_addr, client.clone());
+            }
+        }
 
         // Sort job
         jobs.sort_by(|left, right| {
@@ -156,8 +170,14 @@ impl ClientPool for SearchClientPool {
                 .push(job);
         }
 
-        Ok(splits_groups
-            .into_iter()
-            .collect::<Vec<(SocketAddr, Vec<Job>)>>())
+        let mut client_to_jobs = Vec::new();
+        for (socket_addr, jobs) in splits_groups {
+            if let Some(client) = socket_to_client.remove(&socket_addr) {
+                client_to_jobs.push((client, jobs));
+            } else {
+                error!("Missing client. This should never happen! Please report");
+            }
+        }
+        Ok(client_to_jobs)
     }
 }

--- a/quickwit-search/src/error.rs
+++ b/quickwit-search/src/error.rs
@@ -21,20 +21,41 @@
 use quickwit_index_config::QueryParserError;
 use quickwit_metastore::MetastoreError;
 use quickwit_storage::StorageResolverError;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
+use tokio::task::JoinError;
 
 /// Possible SearchError
 #[allow(missing_docs)]
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Serialize, Deserialize)]
 pub enum SearchError {
-    #[error("IndexDoesNotExist(`{index_id}`)")]
+    #[error("Index `{index_id}` does not exist.")]
     IndexDoesNotExist { index_id: String },
-    #[error("InternalError(`{0}`)")]
-    InternalError(#[from] anyhow::Error),
-    #[error("StorageResolverError(`{0}`)")]
+    #[error("Internal error: `{0}`.")]
+    InternalError(String),
+    #[error("Storage not found: `{0}`)")]
     StorageResolverError(#[from] StorageResolverError),
-    #[error("InvalidQuery(`{0}`)")]
-    InvalidQuery(#[from] QueryParserError),
+    #[error("Invalid query: {0}")]
+    InvalidQuery(String),
+}
+
+pub fn parse_grpc_error(grpc_error: &tonic::Status) -> SearchError {
+    match serde_json::from_str(grpc_error.message()) {
+        Ok(search_error) => search_error,
+        Err(_) => SearchError::InternalError(grpc_error.message().to_string()),
+    }
+}
+
+impl From<anyhow::Error> for SearchError {
+    fn from(any_err: anyhow::Error) -> Self {
+        SearchError::InternalError(format!("{}", any_err))
+    }
+}
+
+impl From<QueryParserError> for SearchError {
+    fn from(query_parser_error: QueryParserError) -> Self {
+        SearchError::InvalidQuery(format!("{}", query_parser_error))
+    }
 }
 
 impl From<MetastoreError> for SearchError {
@@ -43,7 +64,13 @@ impl From<MetastoreError> for SearchError {
             MetastoreError::IndexDoesNotExist { index_id } => {
                 SearchError::IndexDoesNotExist { index_id }
             }
-            _ => SearchError::InternalError(From::from(metastore_error)),
+            _ => SearchError::InternalError(format!("{}", metastore_error)),
         }
+    }
+}
+
+impl From<JoinError> for SearchError {
+    fn from(join_error: JoinError) -> SearchError {
+        SearchError::InternalError(format!("Spawned task in root join failed: {}", join_error))
     }
 }

--- a/quickwit-search/src/service.rs
+++ b/quickwit-search/src/service.rs
@@ -120,7 +120,7 @@ impl SearchService for SearchServiceImpl {
     ) -> Result<LeafSearchResult, SearchError> {
         let search_request = leaf_search_request
             .search_request
-            .ok_or_else(|| SearchError::InternalError(anyhow::anyhow!("No search request.")))?;
+            .ok_or_else(|| SearchError::InternalError("No search request.".to_string()))?;
         info!(index=?search_request.index_id, splits=?leaf_search_request.split_ids, "leaf_search");
         let metastore = self
             .metastore_router

--- a/quickwit-serve/src/error.rs
+++ b/quickwit-serve/src/error.rs
@@ -28,13 +28,13 @@ use quickwit_search::SearchError;
 
 #[derive(Debug, Error)]
 pub enum ApiError {
-    #[error("InvalidArgument(`{0}`)")]
+    #[error("InvalidArgument: {0}.")]
     InvalidArgument(String),
     // TODO rely on some an error serialization in the messsage
     // to rebuild a structured SearchError, (the tonic Code is pretty useless)
     // and build a meaningful ApiError instead of this
     // silly wrapping.
-    #[error("SearchError(`{0}`)")]
+    #[error("Search error. {0}.")]
     SearchError(#[from] SearchError),
     #[error("Route not found")]
     NotFound,
@@ -56,7 +56,7 @@ impl ApiError {
 
     pub fn message(&self) -> String {
         // TODO fixme
-        format!("{:?}", self)
+        format!("{}", self)
     }
 }
 

--- a/quickwit-storage/Cargo.toml
+++ b/quickwit-storage/Cargo.toml
@@ -19,6 +19,7 @@ regex = '1'
 thiserror = '1'
 rand = '0.8'
 lru = "0.6"
+serde = { version = "1.0", features = ["derive"] }
 
 [dependencies.rusoto_core]
 version = '0.46'


### PR DESCRIPTION
Closes #269.

SearchError are JSON serialized automatically by the grpc adapter.
Upon one leaf failure the whole request now fails (before it was just ignore the single leaf error).
We do not hold the search pool lock forever in the root and in the assign_client method.
