### PR TITLE
Add gc (garbage collect) command

### DIFF
--- a/quickwit-cli/src/cli.yaml
+++ b/quickwit-cli/src/cli.yaml
@@ -92,6 +92,9 @@ subcommands:
                 long: index-uri
                 value_name: INDEX URI
                 required: true
+            - dry-run:
+                help: Executes the command in dry run mode and displays the list of files to delete
+                long: dry-run
     - delete:
         about: Deletes an index
         args:

--- a/quickwit-cli/src/cli.yaml
+++ b/quickwit-cli/src/cli.yaml
@@ -84,6 +84,14 @@ subcommands:
                 help: Filters out documents after that timestamp (time-series indexes only)
                 long: end-timestamp
                 value_name: TIMESTAMP
+    - clean:
+        about: Removes danglings files from an index
+        args:
+            - index-uri:
+                help: Location of the target index
+                long: index-uri
+                value_name: INDEX URI
+                required: true
     - delete:
         about: Deletes an index
         args:

--- a/quickwit-cli/src/cli.yaml
+++ b/quickwit-cli/src/cli.yaml
@@ -85,7 +85,7 @@ subcommands:
                 long: end-timestamp
                 value_name: TIMESTAMP
     - gc:
-        about: Removes danglings files from an index
+        about: Garbage collects danglings files from an index
         args:
             - index-uri:
                 help: Location of the target index

--- a/quickwit-cli/src/cli.yaml
+++ b/quickwit-cli/src/cli.yaml
@@ -84,7 +84,7 @@ subcommands:
                 help: Filters out documents after that timestamp (time-series indexes only)
                 long: end-timestamp
                 value_name: TIMESTAMP
-    - clean:
+    - gc:
         about: Removes danglings files from an index
         args:
             - index-uri:

--- a/quickwit-cli/src/cli.yaml
+++ b/quickwit-cli/src/cli.yaml
@@ -93,7 +93,7 @@ subcommands:
                 value_name: INDEX URI
                 required: true
             - dry-run:
-                help: Executes the command in dry run mode and displays the list of files to delete
+                help: Executes the command in dry run mode and displays the list of files to remove
                 long: dry-run
     - delete:
         about: Deletes an index

--- a/quickwit-cli/src/lib.rs
+++ b/quickwit-cli/src/lib.rs
@@ -312,14 +312,14 @@ pub async fn garbage_collect_index_cli(args: GarbageCollectIndexArgs) -> anyhow:
 
     let (metastore_uri, index_id) =
         extract_metastore_uri_and_index_id_from_index_uri(&args.index_uri)?;
-    let affected_files = garbage_collect_index(metastore_uri, index_id).await?;
+    let deleted_files = garbage_collect_index(metastore_uri, index_id).await?;
 
-    let deleted_bytes: u64 = affected_files
-        .iter()
-        .map(|entry| entry.file_size_in_bytes)
-        .sum();
+    if !deleted_files.is_empty() {
+        let deleted_bytes: u64 = deleted_files
+            .iter()
+            .map(|entry| entry.file_size_in_bytes)
+            .sum();
 
-    if deleted_bytes > 0 {
         println!(
             "{}MB of storage garbage collected.",
             deleted_bytes / 1_000_000

--- a/quickwit-cli/src/lib.rs
+++ b/quickwit-cli/src/lib.rs
@@ -123,6 +123,7 @@ pub struct DeleteIndexArgs {
 #[derive(Debug, PartialEq, Eq)]
 pub struct GarbageCollectIndexArgs {
     pub index_uri: String,
+    pub dry_run: bool,
 }
 
 pub async fn create_index_cli(args: CreateIndexArgs) -> anyhow::Result<()> {
@@ -306,27 +307,35 @@ pub async fn delete_index_cli(args: DeleteIndexArgs) -> anyhow::Result<()> {
 pub async fn garbage_collect_index_cli(args: GarbageCollectIndexArgs) -> anyhow::Result<()> {
     debug!(
         index_uri = %args.index_uri,
+        dry_run = args.dry_run,
         "garbage-collect-index"
     );
     quickwit_telemetry::send_telemetry_event(TelemetryEvent::GarbageCollect).await;
 
     let (metastore_uri, index_id) =
         extract_metastore_uri_and_index_id_from_index_uri(&args.index_uri)?;
-    let deleted_files = garbage_collect_index(metastore_uri, index_id).await?;
-
-    if !deleted_files.is_empty() {
-        let deleted_bytes: u64 = deleted_files
-            .iter()
-            .map(|entry| entry.file_size_in_bytes)
-            .sum();
-
-        println!(
-            "{}MB of storage garbage collected.",
-            deleted_bytes / 1_000_000
-        );
-    } else {
+    let deleted_files = garbage_collect_index(metastore_uri, index_id, args.dry_run).await?;
+    if deleted_files.is_empty() {
         println!("No dangling files to garbage collect.");
+        return Ok(());
     }
+
+    if args.dry_run {
+        println!("The following files will be garbage collected.");
+        for file_entry in deleted_files {
+            println!(" - {}", file_entry.file_name);
+        }
+        return Ok(());
+    }
+
+    let deleted_bytes: u64 = deleted_files
+        .iter()
+        .map(|entry| entry.file_size_in_bytes)
+        .sum();
+    println!(
+        "{}MB of storage garbage collected.",
+        deleted_bytes / 1_000_000
+    );
     println!(
         "Index successfully garbage collected at `{}`",
         args.index_uri

--- a/quickwit-cli/src/main.rs
+++ b/quickwit-cli/src/main.rs
@@ -202,8 +202,10 @@ impl CliCommand {
             .value_of("index-uri")
             .context("'index-uri' is a required arg")?
             .to_string();
+        let dry_run = matches.is_present("dry-run");
         Ok(CliCommand::GarbageCollect(GarbageCollectIndexArgs {
             index_uri,
+            dry_run,
         }))
     }
 }
@@ -510,19 +512,25 @@ mod tests {
         assert!(matches!(
             command,
             Ok(CliCommand::GarbageCollect(GarbageCollectIndexArgs {
-                index_uri
+                index_uri,
+                dry_run: false
             })) if &index_uri == "file:///indexes/wikipedia"
         ));
 
         let yaml = load_yaml!("cli.yaml");
         let app = App::from(yaml).setting(AppSettings::NoBinaryName);
-        let matches =
-            app.get_matches_from_safe(vec!["gc", "--index-uri", "file:///indexes/wikipedia"])?;
+        let matches = app.get_matches_from_safe(vec![
+            "gc",
+            "--index-uri",
+            "file:///indexes/wikipedia",
+            "--dry-run",
+        ])?;
         let command = CliCommand::parse_cli_args(&matches);
         assert!(matches!(
             command,
             Ok(CliCommand::GarbageCollect(GarbageCollectIndexArgs {
-                index_uri
+                index_uri,
+                dry_run: true
             })) if &index_uri == "file:///indexes/wikipedia"
         ));
         Ok(())

--- a/quickwit-cli/tests/cli.rs
+++ b/quickwit-cli/tests/cli.rs
@@ -235,7 +235,7 @@ fn test_cmd_delete() -> Result<()> {
 }
 
 #[tokio::test]
-async fn test_cmd_garbae_collect() -> Result<()> {
+async fn test_cmd_garbage_collect() -> Result<()> {
     let test_env = create_test_env(TestStorageType::LocalFileSystem)?;
     create_logs_index(&test_env);
     index_data(
@@ -257,6 +257,9 @@ async fn test_cmd_garbae_collect() -> Result<()> {
             "No dangling files to garbage collect",
         ));
 
+    let split_path = test_env.local_directory_path.join(splits[0].split_id.as_str());
+    assert_eq!(split_path.exists(), true);
+
     let split_ids = vec![splits[0].split_id.as_str()];
     metastore
         .mark_splits_as_deleted(index_id, split_ids)
@@ -277,6 +280,7 @@ async fn test_cmd_garbae_collect() -> Result<()> {
             "Index successfully garbage collected",
         ));
 
+    assert_eq!(split_path.exists(), false);
     let metastore = MetastoreUriResolver::default()
         .resolve(metastore_uri)
         .await?;

--- a/quickwit-cli/tests/cli.rs
+++ b/quickwit-cli/tests/cli.rs
@@ -257,7 +257,9 @@ async fn test_cmd_garbage_collect() -> Result<()> {
             "No dangling files to garbage collect",
         ));
 
-    let split_path = test_env.local_directory_path.join(splits[0].split_id.as_str());
+    let split_path = test_env
+        .local_directory_path
+        .join(splits[0].split_id.as_str());
     assert_eq!(split_path.exists(), true);
 
     let split_ids = vec![splits[0].split_id.as_str()];

--- a/quickwit-cli/tests/cli.rs
+++ b/quickwit-cli/tests/cli.rs
@@ -217,6 +217,13 @@ fn test_cmd_delete() -> Result<()> {
         test_env.resource_files["logs"].as_path(),
     );
 
+    make_command(format!("gc --index-uri {}", test_env.index_uri).as_str())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "No dangling files to garbage collect",
+        ));
+
     make_command(format!("delete --index-uri {} ", test_env.index_uri).as_str())
         .assert()
         .success();
@@ -245,6 +252,13 @@ async fn test_cmd_dry_run_delete_on_s3_localstack() -> Result<()> {
         &test_env.index_uri,
         test_env.resource_files["logs"].as_path(),
     );
+
+    make_command(format!("gc --index-uri {}", test_env.index_uri).as_str())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "No dangling files to garbage collect",
+        ));
 
     make_command(format!("delete --index-uri {} --dry-run", test_env.index_uri).as_str())
         .assert()

--- a/quickwit-core/src/index.rs
+++ b/quickwit-core/src/index.rs
@@ -197,7 +197,7 @@ pub async fn delete_garbage_files(
     Ok(file_entries)
 }
 
-/// list the files for a list of splits.
+/// list the files for a list of split.
 async fn list_splits_files(
     splits: Vec<SplitMetadata>,
     index_uri: String,

--- a/quickwit-core/src/index.rs
+++ b/quickwit-core/src/index.rs
@@ -197,33 +197,7 @@ pub async fn delete_garbage_files(
     Ok(file_entries)
 }
 
-// async fn list_index_files(
-//     metastore: &dyn Metastore,
-//     index_id: &str,
-//     storage_resolver: StorageUriResolver,
-// ) -> anyhow::Result<Vec<FileEntry>> {
-//     let all_splits = metastore.list_all_splits(index_id).await?;
-
-//     let index_uri = metastore.index_metadata(index_id).await?.index_uri;
-
-//     let mut list_stream = tokio_stream::iter(all_splits)
-//         .map(|split_meta| {
-//             let moved_storage_resolver = storage_resolver.clone();
-//             let split_uri = format!("{}/{}", index_uri, split_meta.split_id);
-//             async move {
-//                 remove_split_files_from_storage(&split_uri, moved_storage_resolver, true).await
-//             }
-//         })
-//         .buffer_unordered(crate::indexing::MAX_CONCURRENT_SPLIT_TASKS);
-
-//     let mut file_entries = vec![];
-//     while let Some(list_result) = list_stream.next().await {
-//         file_entries.extend(list_result?);
-//     }
-
-//     Ok(file_entries)
-// }
-
+/// list the files for a list of splits.
 async fn list_splits_files(
     splits: Vec<SplitMetadata>,
     index_uri: String,

--- a/quickwit-core/src/indexing/index.rs
+++ b/quickwit-core/src/indexing/index.rs
@@ -29,7 +29,7 @@ use tempfile::TempDir;
 use tokio::sync::mpsc::channel;
 use tracing::warn;
 
-use crate::index::garbage_remove;
+use crate::index::delete_garbage_files;
 use crate::indexing::split_finalizer::finalize_split;
 use crate::indexing::{document_indexer::index_documents, split::Split};
 use crate::DocumentSource;
@@ -120,7 +120,7 @@ async fn reset_index(
         .mark_splits_as_deleted(index_id, split_ids.clone())
         .await?;
 
-    let garbage_removal_result = garbage_remove(metastore, index_id, storage_resolver).await;
+    let garbage_removal_result = delete_garbage_files(metastore, index_id, storage_resolver).await;
     if garbage_removal_result.is_err() {
         warn!(metastore_uri = %metastore.uri(), "All split files could not be removed during garbage collection.");
     }

--- a/quickwit-core/src/indexing/index.rs
+++ b/quickwit-core/src/indexing/index.rs
@@ -29,7 +29,7 @@ use tempfile::TempDir;
 use tokio::sync::mpsc::channel;
 use tracing::warn;
 
-use crate::index::garbage_collect;
+use crate::index::garbage_remove;
 use crate::indexing::split_finalizer::finalize_split;
 use crate::indexing::{document_indexer::index_documents, split::Split};
 use crate::DocumentSource;
@@ -120,8 +120,8 @@ async fn reset_index(
         .mark_splits_as_deleted(index_id, split_ids.clone())
         .await?;
 
-    let garbage_collection_result = garbage_collect(metastore, index_id, storage_resolver).await;
-    if garbage_collection_result.is_err() {
+    let garbage_removal_result = garbage_remove(metastore, index_id, storage_resolver).await;
+    if garbage_removal_result.is_err() {
         warn!(metastore_uri = %metastore.uri(), "All split files could not be removed during garbage collection.");
     }
 

--- a/quickwit-core/src/indexing/mod.rs
+++ b/quickwit-core/src/indexing/mod.rs
@@ -30,6 +30,6 @@ mod statistics;
 
 pub use document_source::{test_document_source, DocumentSource};
 pub use index::{index_data, IndexDataParams};
-pub use split::remove_split_files_from_storage;
+pub use split::{remove_split_files_from_storage, FileEntry};
 pub use split_finalizer::MAX_CONCURRENT_SPLIT_TASKS;
 pub use statistics::IndexingStatistics;

--- a/quickwit-core/src/indexing/split.rs
+++ b/quickwit-core/src/indexing/split.rs
@@ -351,6 +351,13 @@ pub async fn remove_split_files_from_storage(
     let storage = storage_resolver.resolve(split_uri)?;
 
     let manifest_file = Path::new(".manifest");
+    // Removing a non-existing split is considered ok.
+    // A split can be listed by the metastore when it doesn't in fact exist on disk for some reasons:
+    // - split was staged but failed to upload.
+    // - operation canceled by the user right in the middle.
+    if !storage.exists(manifest_file).await? {
+        return Ok(vec![]);
+    }
     let data = storage.get_all(manifest_file).await?;
     let manifest: Manifest = serde_json::from_slice(&data)?;
 

--- a/quickwit-core/src/lib.rs
+++ b/quickwit-core/src/lib.rs
@@ -34,7 +34,7 @@ mod index;
 mod indexing;
 mod test_utils;
 
-pub use index::{create_index, delete_index, search_index};
+pub use index::{clean_index, create_index, delete_index, search_index};
 pub use indexing::{
     index_data, test_document_source, DocumentSource, IndexDataParams, IndexingStatistics,
 };

--- a/quickwit-core/src/lib.rs
+++ b/quickwit-core/src/lib.rs
@@ -34,7 +34,7 @@ mod index;
 mod indexing;
 mod test_utils;
 
-pub use index::{clean_index, create_index, delete_index, search_index};
+pub use index::{create_index, delete_index, garbage_collect_index, search_index};
 pub use indexing::{
     index_data, test_document_source, DocumentSource, IndexDataParams, IndexingStatistics,
 };

--- a/quickwit-telemetry/src/payload.rs
+++ b/quickwit-telemetry/src/payload.rs
@@ -70,8 +70,8 @@ pub enum TelemetryEvent {
     IndexStart,
     /// Delete command
     Delete,
-    /// Clean command
-    Clean,
+    /// Garbage Collect command
+    GarbageCollect,
     /// Serve command is called.
     Serve(ServeEvent),
     /// EndCommand (with the return code)

--- a/quickwit-telemetry/src/payload.rs
+++ b/quickwit-telemetry/src/payload.rs
@@ -70,6 +70,8 @@ pub enum TelemetryEvent {
     IndexStart,
     /// Delete command
     Delete,
+    /// Clean command
+    Clean,
     /// Serve command is called.
     Serve(ServeEvent),
     /// EndCommand (with the return code)


### PR DESCRIPTION
### Context / purpose
Closes https://github.com/quickwit-inc/quickwit/issues/207

### Description
Add `gc` command that removes old staged and deleted split files from the index.

### How was this PR tested?
- Changing manually some split state from the metastore file and running the `gc` command.

### Checklist
- [x] tested locally
- [x] updated tests
- [ ] included documentation (todo in https://github.com/quickwit-inc/quickwit/issues/312)
