### PR TITLE
add wrapped client with socket_addr

### DIFF
--- a/quickwit-search/src/client_pool.rs
+++ b/quickwit-search/src/client_pool.rs
@@ -23,8 +23,8 @@ pub mod search_client_pool;
 
 use anyhow::Result;
 use async_trait::async_trait;
-use quickwit_proto::search_service_client::SearchServiceClient;
-use tonic::transport::Channel;
+
+use crate::client::WrappedSearchServiceClient;
 
 /// Job.
 /// The unit in which distributed search is performed.
@@ -46,5 +46,5 @@ pub trait ClientPool: Send + Sync + 'static {
     async fn assign_jobs(
         &self,
         jobs: Vec<Job>,
-    ) -> Result<Vec<(SearchServiceClient<Channel>, Vec<Job>)>>;
+    ) -> Result<Vec<(WrappedSearchServiceClient, Vec<Job>)>>;
 }

--- a/quickwit-search/src/client_pool/search_client_pool.rs
+++ b/quickwit-search/src/client_pool/search_client_pool.rs
@@ -28,13 +28,11 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use tokio::sync::RwLock;
 use tokio_stream::StreamExt;
-use tonic::transport::Channel;
 use tracing::*;
 
 use quickwit_cluster::cluster::Cluster;
-use quickwit_proto::search_service_client::SearchServiceClient;
 
-use crate::client::create_search_service_client;
+use crate::client::{create_search_service_client, WrappedSearchServiceClient};
 use crate::client_pool::{ClientPool, Job};
 use crate::rendezvous_hasher::{sort_by_rendez_vous_hash, Node};
 use crate::swim_addr_to_grpc_addr;
@@ -45,7 +43,7 @@ pub struct SearchClientPool {
     /// Search clients.
     /// A hash map with gRPC's SocketAddr as the key and SearchServiceClient as the value.
     /// It is not the cluster listen address.
-    pub clients: Arc<RwLock<HashMap<SocketAddr, SearchServiceClient<Channel>>>>,
+    pub clients: Arc<RwLock<HashMap<SocketAddr, WrappedSearchServiceClient>>>,
 }
 
 impl SearchClientPool {
@@ -117,12 +115,12 @@ impl ClientPool for SearchClientPool {
     async fn assign_jobs(
         &self,
         mut jobs: Vec<Job>,
-    ) -> anyhow::Result<Vec<(SearchServiceClient<Channel>, Vec<Job>)>> {
+    ) -> anyhow::Result<Vec<(WrappedSearchServiceClient, Vec<Job>)>> {
         let mut splits_groups: HashMap<SocketAddr, Vec<Job>> = HashMap::new();
 
         // Distribute using rendez-vous hashing
         let mut nodes: Vec<Node> = Vec::new();
-        let mut socket_to_client: HashMap<SocketAddr, SearchServiceClient<Channel>> =
+        let mut socket_to_client: HashMap<SocketAddr, WrappedSearchServiceClient> =
             Default::default();
 
         {

--- a/quickwit-search/src/root.rs
+++ b/quickwit-search/src/root.rs
@@ -101,6 +101,7 @@ pub async fn root_search(
         let mut search_client_clone = search_client.clone();
         let handle = tokio::spawn(async move {
             search_client_clone
+                .client()
                 .leaf_search(leaf_search_request)
                 .await
                 .map(|resp| resp.into_inner())
@@ -157,7 +158,11 @@ pub async fn root_search(
                 };
                 let mut search_client_clone = search_client.clone();
                 let handle = tokio::spawn(async move {
-                    match search_client_clone.fetch_docs(fetch_docs_request).await {
+                    match search_client_clone
+                        .client()
+                        .fetch_docs(fetch_docs_request)
+                        .await
+                    {
                         Ok(resp) => Ok(resp.into_inner()),
                         Err(err) => Err(anyhow::anyhow!("Failed to fetch docs due to {:?}", err)),
                     }


### PR DESCRIPTION
### Context / purpose
add wrapped client with socket_addr to always have the context to which a client connects to.


### Checklist
*Remove or complete this list if required.*
- [x] included documentation
