### PR TITLE
Fix Quickwit domain name

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -30,7 +30,7 @@ output:
 ```
 quickwit help
 Quickwit 0.1.0
-Quickwit, Inc. <hello@quickwit.com>
+Quickwit, Inc. <hello@quickwit.io>
 Indexing your large dataset on object storage & making it searchable from the command line.
 Telemetry enabled
 [...]

--- a/docs/reference/telemetry.md
+++ b/docs/reference/telemetry.md
@@ -15,7 +15,7 @@ Look at `quickwit help` command output to check whether telemetry is enabled or 
 ```bash
 quickwit help
 Quickwit 0.1.0
-Quickwit, Inc. <hello@quickwit.com>
+Quickwit, Inc. <hello@quickwit.io>
 Indexing your large dataset on object storage & making it searchable from the command line.
 Telemetry enabled
 ```

--- a/quickwit-cli/src/cli.yaml
+++ b/quickwit-cli/src/cli.yaml
@@ -1,6 +1,6 @@
 name: Quickwit
 about: Index and search structured or unstructured data
-author: Quickwit, Inc. <hello@quickwit.com>
+author: Quickwit, Inc. <hello@quickwit.io>
 
 subcommands:
     - new:


### PR DESCRIPTION
I wish we owned `quickwit.com` but for now, we'll have to do with `.io` :)