### PR TITLE
Add garce-period flag to gc command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2738,6 +2738,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "chrono",
  "mockall 0.9.1",
  "quickwit-index-config",
  "quickwit-storage",

--- a/quickwit-cli/Cargo.toml
+++ b/quickwit-cli/Cargo.toml
@@ -36,7 +36,7 @@ once_cell = "1"
 serde_json = "1.0"
 tempfile = "3"
 json_comments = "0.2"
-chrono = "0.4.19"
+chrono = "0.4"
 
 [dev-dependencies]
 assert_cmd = "1"

--- a/quickwit-cli/src/cli.yaml
+++ b/quickwit-cli/src/cli.yaml
@@ -93,7 +93,7 @@ subcommands:
                 value_name: INDEX URI
                 required: true
             - grace-period:
-                help: Threshold period after which an intermediate file can be collected.
+                help: Threshold period after which intermediate files can be garbage collected.
                 long: grace-period
                 value_name: GRACE PERIOD
                 default_value: '1h'

--- a/quickwit-cli/src/cli.yaml
+++ b/quickwit-cli/src/cli.yaml
@@ -92,6 +92,11 @@ subcommands:
                 long: index-uri
                 value_name: INDEX URI
                 required: true
+            - grace-period:
+                help: Threshold period after which an intermediate file can be collected.
+                long: grace-period
+                value_name: GRACE PERIOD
+                default_value: '1h'
             - dry-run:
                 help: Executes the command in dry run mode and displays the list of files to remove
                 long: dry-run

--- a/quickwit-cli/src/lib.rs
+++ b/quickwit-cli/src/lib.rs
@@ -128,6 +128,7 @@ pub struct DeleteIndexArgs {
 #[derive(Debug, PartialEq, Eq)]
 pub struct GarbageCollectIndexArgs {
     pub index_uri: String,
+    pub grace_period: Duration,
     pub dry_run: bool,
 }
 
@@ -312,6 +313,7 @@ pub async fn delete_index_cli(args: DeleteIndexArgs) -> anyhow::Result<()> {
 pub async fn garbage_collect_index_cli(args: GarbageCollectIndexArgs) -> anyhow::Result<()> {
     debug!(
         index_uri = %args.index_uri,
+        grace_period = ?args.grace_period,
         dry_run = args.dry_run,
         "garbage-collect-index"
     );
@@ -319,7 +321,8 @@ pub async fn garbage_collect_index_cli(args: GarbageCollectIndexArgs) -> anyhow:
 
     let (metastore_uri, index_id) =
         extract_metastore_uri_and_index_id_from_index_uri(&args.index_uri)?;
-    let deleted_files = garbage_collect_index(metastore_uri, index_id, args.dry_run).await?;
+    let deleted_files =
+        garbage_collect_index(metastore_uri, index_id, args.grace_period, args.dry_run).await?;
     if deleted_files.is_empty() {
         println!("No dangling files to garbage collect.");
         return Ok(());

--- a/quickwit-cli/src/main.rs
+++ b/quickwit-cli/src/main.rs
@@ -206,7 +206,7 @@ impl CliCommand {
         let grace_period = matches
             .value_of("grace-period")
             .map(parse_duration_with_unit)
-            .context("'index-uri' is a required arg")??;
+            .context("'grace-period' should have default")??;
         let dry_run = matches.is_present("dry-run");
         Ok(CliCommand::GarbageCollect(GarbageCollectIndexArgs {
             index_uri,
@@ -282,7 +282,8 @@ fn about_text() -> String {
     about_text
 }
 
-/// Parse duration with specified unit.
+/// Parse duration with unit.
+/// examples: 1s 2m 3h 5d
 pub fn parse_duration_with_unit(duration: &str) -> anyhow::Result<Duration> {
     let mut value = "".to_string();
     let mut unit = "".to_string();

--- a/quickwit-cli/src/main.rs
+++ b/quickwit-cli/src/main.rs
@@ -32,6 +32,7 @@ use std::env;
 use std::net::SocketAddr;
 use std::path::Path;
 use std::path::PathBuf;
+use std::time::Duration;
 use tracing::Level;
 use tracing_subscriber::fmt::Subscriber;
 #[derive(Debug, PartialEq)]
@@ -202,9 +203,14 @@ impl CliCommand {
             .value_of("index-uri")
             .context("'index-uri' is a required arg")?
             .to_string();
+        let grace_period = matches
+            .value_of("grace-period")
+            .map(parse_duration_with_unit)
+            .context("'index-uri' is a required arg")??;
         let dry_run = matches.is_present("dry-run");
         Ok(CliCommand::GarbageCollect(GarbageCollectIndexArgs {
             index_uri,
+            grace_period,
             dry_run,
         }))
     }
@@ -276,17 +282,42 @@ fn about_text() -> String {
     about_text
 }
 
+/// Parse duration with specified unit.
+pub fn parse_duration_with_unit(duration: &str) -> anyhow::Result<Duration> {
+    let mut value = "".to_string();
+    let mut unit = "".to_string();
+    for character in duration.chars() {
+        if character.is_numeric() {
+            value.push(character);
+        } else {
+            unit.push(character);
+        }
+    }
+
+    match value.parse::<u64>() {
+        Ok(value) => match unit.as_str() {
+            "s" => Ok(Duration::from_secs(value)),
+            "m" => Ok(Duration::from_secs(value * 60)),
+            "h" => Ok(Duration::from_secs(value * 60 * 60)),
+            "d" => Ok(Duration::from_secs(value * 60 * 60 * 24)),
+            _ => Err(anyhow::anyhow!("Invalid duration format: `[0-9]+[smhd]`")),
+        },
+        Err(err) => Err(anyhow::anyhow!(err)),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::{
-        CliCommand, CreateIndexArgs, DeleteIndexArgs, GarbageCollectIndexArgs, IndexDataArgs,
-        SearchIndexArgs,
+        parse_duration_with_unit, CliCommand, CreateIndexArgs, DeleteIndexArgs,
+        GarbageCollectIndexArgs, IndexDataArgs, SearchIndexArgs,
     };
     use clap::{load_yaml, App, AppSettings};
     use quickwit_common::to_socket_addr;
     use quickwit_serve::ServeArgs;
     use std::io::Write;
     use std::path::{Path, PathBuf};
+    use std::time::Duration;
     use tempfile::NamedTempFile;
 
     #[test]
@@ -513,8 +544,9 @@ mod tests {
             command,
             Ok(CliCommand::GarbageCollect(GarbageCollectIndexArgs {
                 index_uri,
+                grace_period,
                 dry_run: false
-            })) if &index_uri == "file:///indexes/wikipedia"
+            })) if &index_uri == "file:///indexes/wikipedia" && grace_period == Duration::from_secs(60 * 60)
         ));
 
         let yaml = load_yaml!("cli.yaml");
@@ -523,6 +555,8 @@ mod tests {
             "gc",
             "--index-uri",
             "file:///indexes/wikipedia",
+            "--grace-period",
+            "5m",
             "--dry-run",
         ])?;
         let command = CliCommand::parse_cli_args(&matches);
@@ -530,8 +564,9 @@ mod tests {
             command,
             Ok(CliCommand::GarbageCollect(GarbageCollectIndexArgs {
                 index_uri,
+                grace_period,
                 dry_run: true
-            })) if &index_uri == "file:///indexes/wikipedia"
+            })) if &index_uri == "file:///indexes/wikipedia" && grace_period == Duration::from_secs(5 * 60)
         ));
         Ok(())
     }
@@ -611,6 +646,26 @@ mod tests {
             })) if index_uris == vec!["file:///indexes/wikipedia".to_string(), "file:///indexes/hdfslogs".to_string()] && rest_socket_addr == to_socket_addr("127.0.0.1:9090").unwrap() && host_key_path == Path::new("/etc/quickwit-host-key-127.0.0.1-9090").to_path_buf() && peer_socket_addrs == vec![to_socket_addr("192.168.1.13:9090").unwrap(), to_socket_addr("192.168.1.14:9090").unwrap()]
         ));
 
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_duration_with_unit() -> anyhow::Result<()> {
+        assert_eq!(parse_duration_with_unit("8s")?, Duration::from_secs(8));
+        assert_eq!(parse_duration_with_unit("5m")?, Duration::from_secs(5 * 60));
+        assert_eq!(
+            parse_duration_with_unit("2h")?,
+            Duration::from_secs(2 * 60 * 60)
+        );
+        assert_eq!(
+            parse_duration_with_unit("3d")?,
+            Duration::from_secs(3 * 60 * 60 * 24)
+        );
+
+        assert!(parse_duration_with_unit("").is_err());
+        assert!(parse_duration_with_unit("a2d").is_err());
+        assert!(parse_duration_with_unit("3 d").is_err());
+        assert!(parse_duration_with_unit("3").is_err());
         Ok(())
     }
 }

--- a/quickwit-cli/tests/cli.rs
+++ b/quickwit-cli/tests/cli.rs
@@ -266,16 +266,22 @@ async fn test_cmd_garbage_collect() -> Result<()> {
     metastore
         .mark_splits_as_deleted(index_id, split_ids)
         .await?;
-    make_command(format!("gc --index-uri {} --dry-run", test_env.index_uri).as_str())
-        .assert()
-        .success()
-        .stdout(predicate::str::contains(
-            "The following files will be garbage collected.",
-        ))
-        .stdout(predicate::str::contains("/hotcache"))
-        .stdout(predicate::str::contains("/.manifest"));
+    make_command(
+        format!(
+            "gc --index-uri {} --dry-run --grace-period 10m",
+            test_env.index_uri
+        )
+        .as_str(),
+    )
+    .assert()
+    .success()
+    .stdout(predicate::str::contains(
+        "The following files will be garbage collected.",
+    ))
+    .stdout(predicate::str::contains("/hotcache"))
+    .stdout(predicate::str::contains("/.manifest"));
 
-    make_command(format!("gc --index-uri {}", test_env.index_uri).as_str())
+    make_command(format!("gc --index-uri {} --grace-period 10m", test_env.index_uri).as_str())
         .assert()
         .success()
         .stdout(predicate::str::contains(

--- a/quickwit-cli/tests/cli.rs
+++ b/quickwit-cli/tests/cli.rs
@@ -30,7 +30,7 @@ use helpers::{TestEnv, TestStorageType};
 use predicates::prelude::*;
 use quickwit_cli::{create_index_cli, CreateIndexArgs};
 use quickwit_common::extract_metastore_uri_and_index_id_from_index_uri;
-use quickwit_metastore::MetastoreUriResolver;
+use quickwit_metastore::{MetastoreUriResolver, SplitState};
 use quickwit_storage::{localstack_region, S3CompatibleObjectStorage, Storage};
 use serde_json::{Number, Value};
 use serial_test::serial;
@@ -280,6 +280,7 @@ async fn test_cmd_garbage_collect() -> Result<()> {
     ))
     .stdout(predicate::str::contains("/hotcache"))
     .stdout(predicate::str::contains("/.manifest"));
+    assert_eq!(split_path.exists(), true);
 
     make_command(format!("gc --index-uri {} --grace-period 10m", test_env.index_uri).as_str())
         .assert()
@@ -298,6 +299,83 @@ async fn test_cmd_garbage_collect() -> Result<()> {
         .assert()
         .success();
     assert_eq!(test_env.local_directory_path.exists(), false);
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_cmd_garbage_collect_spares_files_within_grace_period() -> Result<()> {
+    let test_env = create_test_env(TestStorageType::LocalFileSystem)?;
+    create_logs_index(&test_env);
+    index_data(
+        &test_env.index_uri,
+        test_env.resource_files["logs"].as_path(),
+    );
+
+    let (metastore_uri, index_id) =
+        extract_metastore_uri_and_index_id_from_index_uri(&test_env.index_uri)?;
+    let metastore = MetastoreUriResolver::default()
+        .resolve(metastore_uri)
+        .await?;
+    let splits = metastore.list_all_splits(index_id).await?;
+    assert_eq!(splits.len(), 1);
+    make_command(format!("gc --index-uri {}", test_env.index_uri).as_str())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "No dangling files to garbage collect",
+        ));
+
+    let split_path = test_env
+        .local_directory_path
+        .join(splits[0].split_id.as_str());
+    assert_eq!(split_path.exists(), true);
+
+    // The following is a hack to turn a published split into a staged one
+    // without deleting the files
+    let split_ids = vec![splits[0].split_id.as_str()];
+    metastore
+        .mark_splits_as_deleted(index_id, split_ids.clone())
+        .await?;
+    metastore.delete_splits(index_id, split_ids).await?;
+    assert_eq!(split_path.exists(), true);
+    let mut meta = splits[0].clone();
+    meta.split_state = SplitState::New;
+    metastore.stage_split(index_id, meta).await?;
+
+    make_command(format!("gc --index-uri {} --grace-period 2s", test_env.index_uri).as_str())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "No dangling files to garbage collect",
+        ));
+    assert_eq!(split_path.exists(), true);
+
+    // wait for grace period
+    sleep(Duration::from_secs(3)).await;
+    make_command(
+        format!(
+            "gc --index-uri {} --dry-run --grace-period 2s",
+            test_env.index_uri
+        )
+        .as_str(),
+    )
+    .assert()
+    .success()
+    .stdout(predicate::str::contains(
+        "The following files will be garbage collected.",
+    ))
+    .stdout(predicate::str::contains("/hotcache"))
+    .stdout(predicate::str::contains("/.manifest"));
+    assert_eq!(split_path.exists(), true);
+
+    make_command(format!("gc --index-uri {} --grace-period 2s", test_env.index_uri).as_str())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Index successfully garbage collected",
+        ));
+    assert_eq!(split_path.exists(), false);
+
     Ok(())
 }
 

--- a/quickwit-core/src/index.rs
+++ b/quickwit-core/src/index.rs
@@ -20,11 +20,14 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+use std::time::Duration;
+
 use futures::StreamExt;
 use quickwit_metastore::{
     IndexMetadata, Metastore, MetastoreUriResolver, SplitMetadata, SplitState,
 };
 use quickwit_storage::StorageUriResolver;
+use tantivy::chrono::Utc;
 use tracing::warn;
 
 use crate::indexing::{remove_split_files_from_storage, FileEntry};
@@ -112,11 +115,13 @@ pub async fn delete_index(
 ///
 /// * `metastore_uri` - The metastore Uri for accessing the metastore.
 /// * `index_id` - The target index Id.
+/// * `grace_period` -  Threshold period after which a staged split can be garbage collected.
 /// * `dry_run` - Should this only return a list of affected files without performing deletion.
 ///
 pub async fn garbage_collect_index(
     metastore_uri: &str,
     index_id: &str,
+    grace_period: Duration,
     dry_run: bool,
 ) -> anyhow::Result<Vec<FileEntry>> {
     let metastore = MetastoreUriResolver::default()
@@ -125,9 +130,14 @@ pub async fn garbage_collect_index(
     let storage_resolver = StorageUriResolver::default();
 
     //TODO: consider prunning newly staged split as they might be a work in-progress
+    let grace_period_timestamp = Utc::now().timestamp() - grace_period.as_secs() as i64;
     let staged_splits = metastore
         .list_splits(index_id, SplitState::Staged, None)
-        .await?;
+        .await?
+        .into_iter()
+        .filter(|split_meta| split_meta.update_timestamp < grace_period_timestamp)
+        .collect::<Vec<_>>();
+
     if dry_run {
         let mut scheduled_for_delete_splits = metastore
             .list_splits(index_id, SplitState::ScheduledForDeletion, None)

--- a/quickwit-core/src/index.rs
+++ b/quickwit-core/src/index.rs
@@ -129,7 +129,7 @@ pub async fn garbage_collect_index(
         .await?;
     let storage_resolver = StorageUriResolver::default();
 
-    //TODO: consider prunning newly staged split as they might be a work in-progress
+    // We don't consider staged splits that are not older than the `grace_period`
     let grace_period_timestamp = Utc::now().timestamp() - grace_period.as_secs() as i64;
     let staged_splits = metastore
         .list_splits(index_id, SplitState::Staged, None)

--- a/quickwit-core/src/index.rs
+++ b/quickwit-core/src/index.rs
@@ -129,7 +129,7 @@ pub async fn garbage_collect_index(
         .await?;
     let storage_resolver = StorageUriResolver::default();
 
-    // We don't consider staged splits that are not older than the `grace_period`
+    // Prune staged splits that are not older than the `grace_period`
     let grace_period_timestamp = Utc::now().timestamp() - grace_period.as_secs() as i64;
     let staged_splits = metastore
         .list_splits(index_id, SplitState::Staged, None)

--- a/quickwit-metastore/Cargo.toml
+++ b/quickwit-metastore/Cargo.toml
@@ -19,6 +19,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"
 tokio = {version="1.6", features=["full"]}
+chrono = "0.4"
 
 
 [dependencies.mockall]

--- a/quickwit-metastore/src/metastore.rs
+++ b/quickwit-metastore/src/metastore.rs
@@ -69,7 +69,7 @@ pub struct SplitMetadata {
     /// Number of merges this segment has been subjected to during its lifetime.
     pub generation: usize,
 
-    /// Timestamp specifying when the split was last modified.
+    /// Timestamp for tracking when the split was last modified.
     pub update_timestamp: i64,
 }
 

--- a/quickwit-metastore/src/metastore.rs
+++ b/quickwit-metastore/src/metastore.rs
@@ -27,6 +27,7 @@ use std::fmt::Debug;
 use std::ops::Range;
 
 use async_trait::async_trait;
+use chrono::Utc;
 use quickwit_index_config::IndexConfig;
 use serde::{Deserialize, Serialize};
 
@@ -67,6 +68,9 @@ pub struct SplitMetadata {
 
     /// Number of merges this segment has been subjected to during its lifetime.
     pub generation: usize,
+
+    /// Timestamp specifying when the split was last modified.
+    pub update_timestamp: i64,
 }
 
 impl SplitMetadata {
@@ -79,6 +83,7 @@ impl SplitMetadata {
             size_in_bytes: 0,
             time_range: None,
             generation: 0,
+            update_timestamp: Utc::now().timestamp(),
         }
     }
 }

--- a/quickwit-search/src/root.rs
+++ b/quickwit-search/src/root.rs
@@ -351,6 +351,7 @@ mod tests {
                     size_in_bytes: 256,
                     time_range: None,
                     generation: 1,
+                    update_timestamp: 0,
                 }])
             },
         );
@@ -466,6 +467,7 @@ mod tests {
                         size_in_bytes: 256,
                         time_range: None,
                         generation: 1,
+                        update_timestamp: 0,
                     },
                     SplitMetadata {
                         split_id: "split2".to_string(),
@@ -474,6 +476,7 @@ mod tests {
                         size_in_bytes: 256,
                         time_range: None,
                         generation: 1,
+                        update_timestamp: 0,
                     },
                 ])
             },


### PR DESCRIPTION
### Context / purpose
Closes https://github.com/quickwit-inc/quickwit/issues/320

### Description
- Added `update_timestamp`  member to `SplitMetadata` for tracking when the split was last updated in the metastore
- Added a `grace-period` flag to the `gc` command (default is `1h` 1 hour)
- Supported grace-period format: `[0-9]+[smhd]`
  - 2s -> 2 seconds (Not sure allowing seconds, but it was useful for testing)
  - 2m -> 2 minutes
  - 2h -> 2 hours
  - 2d -> 2 days

### How was this PR tested?
Run the gc command while poking around the metastore file
`./quickwit gc --index-uri file://home/evance/quickwit/data --grace-period 10m` 

### Checklist
- [x] tested locally
- [x] added unit tests
- [ ] included documentation (https://github.com/quickwit-inc/quickwit/issues/312)
