### PR TITLE
add retry mechanism

### DIFF
--- a/quickwit-cli/src/lib.rs
+++ b/quickwit-cli/src/lib.rs
@@ -108,7 +108,7 @@ pub struct IndexDataArgs {
     pub overwrite: bool,
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Default)]
 pub struct SearchIndexArgs {
     pub index_uri: String,
     pub query: String,
@@ -243,7 +243,7 @@ async fn create_document_source_from_args(
     }
 }
 
-pub async fn search_index_cli(args: SearchIndexArgs) -> anyhow::Result<()> {
+pub async fn search_index(args: SearchIndexArgs) -> anyhow::Result<SearchResult> {
     debug!(
         index_uri = %args.index_uri,
         query = %args.query,
@@ -271,6 +271,11 @@ pub async fn search_index_cli(args: SearchIndexArgs) -> anyhow::Result<()> {
     };
     let search_result: SearchResult =
         single_node_search(&search_request, &*metastore, storage_uri_resolver).await?;
+    Ok(search_result)
+}
+
+pub async fn search_index_cli(args: SearchIndexArgs) -> anyhow::Result<()> {
+    let search_result: SearchResult = search_index(args).await?;
 
     let search_result_json = SearchResultJson::from(search_result);
 

--- a/quickwit-cli/tests/cli.rs
+++ b/quickwit-cli/tests/cli.rs
@@ -28,7 +28,7 @@ use crate::helpers::{create_test_env, make_command, spawn_command};
 use anyhow::Result;
 use helpers::{TestEnv, TestStorageType};
 use predicates::prelude::*;
-use quickwit_cli::{create_index_cli, CreateIndexArgs};
+use quickwit_cli::{create_index_cli, search_index, CreateIndexArgs, SearchIndexArgs};
 use quickwit_common::extract_metastore_uri_and_index_id_from_index_uri;
 use quickwit_metastore::{MetastoreUriResolver, SplitState};
 use quickwit_storage::{localstack_region, S3CompatibleObjectStorage, Storage};
@@ -589,5 +589,41 @@ async fn test_all_with_s3_localstack_internal_api() -> Result<()> {
     let metadata_file_exist = object_storage.exists(Path::new("quickwit.json")).await?;
     assert_eq!(metadata_file_exist, false);
 
+    Ok(())
+}
+
+// TODO add failure test
+#[tokio::test]
+async fn test_failure_not() -> Result<()> {
+    let test_env = create_test_env(TestStorageType::LocalFileSystem)?;
+    create_logs_index(&test_env);
+
+    index_data(
+        &test_env.index_uri,
+        test_env.resource_files["logs"].as_path(),
+    );
+
+    // using piped input.
+    let log_path = test_env.resource_files["logs"].clone();
+    make_command(format!("index --index-uri {} ", test_env.index_uri).as_str())
+        .pipe_stdin(log_path)?
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Indexed"))
+        .stdout(predicate::str::contains("documents in"))
+        .stdout(predicate::str::contains(
+            "You can now query your index with",
+        ));
+
+    let args = SearchIndexArgs {
+        index_uri: test_env.index_uri.to_string(),
+        query: "level:info".to_string(),
+        max_hits: 10,
+        start_offset: 0,
+        ..Default::default()
+    };
+    let search_result = search_index(args).await.unwrap();
+
+    assert_eq!(search_result.num_hits, 4);
     Ok(())
 }

--- a/quickwit-proto/proto/search_api.proto
+++ b/quickwit-proto/proto/search_api.proto
@@ -79,6 +79,10 @@ message SearchResult {
   // Elapsed time to perform the request. This time is measured
   // server-side and expressed in microseconds.
   uint64 elapsed_time_micros = 3;
+
+  // The searcherrors that occured formatted as string.
+  repeated string errors = 4;
+
 }
 
 message SplitSearchError {
@@ -87,6 +91,9 @@ message SplitSearchError {
 
   // Split id that failed. 
   string split_id = 2;
+
+  // Flag to indicate if the error can be considered a retryable error
+  bool retryable_error = 3;
 }
 
 message LeafSearchRequest {

--- a/quickwit-proto/proto/search_api.proto
+++ b/quickwit-proto/proto/search_api.proto
@@ -146,7 +146,7 @@ message LeafSearchResult {
   // List of the best top-K candidates for the given leaf query.
   repeated PartialHit partial_hits = 2;
 
-  // The list of requests that failed. LeafSearchResult can be an aggregation of results, so there may be multiple.
+  // The list of splits that failed. LeafSearchResult can be an aggregation of results, so there may be multiple.
   repeated SplitSearchError failed_splits = 3;
 
   // Total number of splits the leaf(s) were in charge of.

--- a/quickwit-proto/proto/search_api.proto
+++ b/quickwit-proto/proto/search_api.proto
@@ -147,7 +147,7 @@ message LeafSearchResult {
   repeated PartialHit partial_hits = 2;
 
   // The list of requests that failed. LeafSearchResult can be an aggregation of results, so there may be multiple.
-  repeated SplitSearchError failed_requests = 3;
+  repeated SplitSearchError failed_splits = 3;
 
   // Total number of splits the leaf(s) were in charge of.
   // num_attempted_splits = num_successful_splits + num_failed_splits.

--- a/quickwit-proto/src/quickwit.rs
+++ b/quickwit-proto/src/quickwit.rs
@@ -43,6 +43,9 @@ pub struct SearchResult {
     /// server-side and expressed in microseconds.
     #[prost(uint64, tag = "3")]
     pub elapsed_time_micros: u64,
+    /// The searcherrors that occured formatted as string.
+    #[prost(string, repeated, tag = "4")]
+    pub errors: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -54,6 +57,9 @@ pub struct SplitSearchError {
     /// Split id that failed.
     #[prost(string, tag = "2")]
     pub split_id: ::prost::alloc::string::String,
+    /// Flag to indicate if the error can be considered a retryable error
+    #[prost(bool, tag = "3")]
+    pub retryable_error: bool,
 }
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]

--- a/quickwit-proto/src/quickwit.rs
+++ b/quickwit-proto/src/quickwit.rs
@@ -125,7 +125,7 @@ pub struct LeafSearchResult {
     /// List of the best top-K candidates for the given leaf query.
     #[prost(message, repeated, tag = "2")]
     pub partial_hits: ::prost::alloc::vec::Vec<PartialHit>,
-    /// The list of requests that failed. LeafSearchResult can be an aggregation of results, so there may be multiple.
+    /// The list of splits that failed. LeafSearchResult can be an aggregation of results, so there may be multiple.
     #[prost(message, repeated, tag = "3")]
     pub failed_splits: ::prost::alloc::vec::Vec<SplitSearchError>,
     /// Total number of splits the leaf(s) were in charge of.

--- a/quickwit-proto/src/quickwit.rs
+++ b/quickwit-proto/src/quickwit.rs
@@ -127,7 +127,7 @@ pub struct LeafSearchResult {
     pub partial_hits: ::prost::alloc::vec::Vec<PartialHit>,
     /// The list of requests that failed. LeafSearchResult can be an aggregation of results, so there may be multiple.
     #[prost(message, repeated, tag = "3")]
-    pub failed_requests: ::prost::alloc::vec::Vec<SplitSearchError>,
+    pub failed_splits: ::prost::alloc::vec::Vec<SplitSearchError>,
     /// Total number of splits the leaf(s) were in charge of.
     /// num_attempted_splits = num_successful_splits + num_failed_splits.
     #[prost(uint64, tag = "4")]

--- a/quickwit-search/src/client_pool.rs
+++ b/quickwit-search/src/client_pool.rs
@@ -49,6 +49,6 @@ pub trait ClientPool: Send + Sync + 'static {
     async fn assign_jobs(
         &self,
         jobs: Vec<Job>,
-        exclude_addresses: &Option<HashSet<SocketAddr>>,
+        exclude_addresses: &HashSet<SocketAddr>,
     ) -> anyhow::Result<Vec<(SearchServiceClient, Vec<Job>)>>;
 }

--- a/quickwit-search/src/client_pool.rs
+++ b/quickwit-search/src/client_pool.rs
@@ -44,9 +44,11 @@ pub struct Job {
 pub trait ClientPool: Send + Sync + 'static {
     /// Assign the given job to the clients.
     /// Returns a list of pair (SocketAddr, Vec<Job>)
+    ///
+    /// When exclude_addresses filters all clients it is ignored.
     async fn assign_jobs(
         &self,
         jobs: Vec<Job>,
-        address_whitelist: Option<HashSet<SocketAddr>>,
+        exclude_addresses: Option<HashSet<SocketAddr>>,
     ) -> anyhow::Result<Vec<(SearchServiceClient, Vec<Job>)>>;
 }

--- a/quickwit-search/src/client_pool.rs
+++ b/quickwit-search/src/client_pool.rs
@@ -21,6 +21,8 @@
 
 pub mod search_client_pool;
 
+use std::{collections::HashSet, net::SocketAddr};
+
 use async_trait::async_trait;
 
 use crate::SearchServiceClient;
@@ -45,5 +47,6 @@ pub trait ClientPool: Send + Sync + 'static {
     async fn assign_jobs(
         &self,
         jobs: Vec<Job>,
+        address_whitelist: Option<HashSet<SocketAddr>>,
     ) -> anyhow::Result<Vec<(SearchServiceClient, Vec<Job>)>>;
 }

--- a/quickwit-search/src/client_pool.rs
+++ b/quickwit-search/src/client_pool.rs
@@ -49,6 +49,6 @@ pub trait ClientPool: Send + Sync + 'static {
     async fn assign_jobs(
         &self,
         jobs: Vec<Job>,
-        exclude_addresses: Option<HashSet<SocketAddr>>,
+        exclude_addresses: &Option<HashSet<SocketAddr>>,
     ) -> anyhow::Result<Vec<(SearchServiceClient, Vec<Job>)>>;
 }

--- a/quickwit-search/src/client_pool/search_client_pool.rs
+++ b/quickwit-search/src/client_pool/search_client_pool.rs
@@ -147,7 +147,7 @@ impl ClientPool for SearchClientPool {
     async fn assign_jobs(
         &self,
         mut jobs: Vec<Job>,
-        mut exclude_addresses: Option<HashSet<SocketAddr>>,
+        mut exclude_addresses: &Option<HashSet<SocketAddr>>,
     ) -> anyhow::Result<Vec<(SearchServiceClient, Vec<Job>)>> {
         let mut splits_groups: HashMap<SocketAddr, Vec<Job>> = HashMap::new();
 
@@ -166,7 +166,7 @@ impl ClientPool for SearchClientPool {
                 .as_ref()
                 .map_or(false, |addresses| addresses.len() == clients.len())
             {
-                exclude_addresses = None;
+                exclude_addresses = &None;
             }
 
             for (grpc_addr, client) in clients.iter().filter(|(grpc_addr, _)| {
@@ -345,7 +345,7 @@ mod tests {
             },
         ];
 
-        let assigned_jobs = client_pool.assign_jobs(jobs, None).await?;
+        let assigned_jobs = client_pool.assign_jobs(jobs, &None).await?;
         println!("assigned_jobs={:?}", assigned_jobs);
 
         let expected = vec![(

--- a/quickwit-search/src/client_pool/search_client_pool.rs
+++ b/quickwit-search/src/client_pool/search_client_pool.rs
@@ -335,7 +335,7 @@ mod tests {
             },
         ];
 
-        let assigned_jobs = client_pool.assign_jobs(jobs).await?;
+        let assigned_jobs = client_pool.assign_jobs(jobs, None).await?;
         println!("assigned_jobs={:?}", assigned_jobs);
 
         let expected = vec![(

--- a/quickwit-search/src/collector.rs
+++ b/quickwit-search/src/collector.rs
@@ -315,7 +315,7 @@ fn merge_leaf_results(leaf_results: Vec<LeafSearchResult>, max_hits: usize) -> L
         .iter()
         .map(|leaf_result| leaf_result.num_hits)
         .sum();
-    let failed_requests = leaf_results
+    let failed_splits = leaf_results
         .iter()
         .flat_map(|res| res.failed_splits.iter().cloned())
         .collect_vec();
@@ -328,7 +328,7 @@ fn merge_leaf_results(leaf_results: Vec<LeafSearchResult>, max_hits: usize) -> L
     LeafSearchResult {
         num_hits,
         partial_hits: top_k_partial_hits,
-        failed_splits: failed_requests,
+        failed_splits,
         num_attempted_splits,
     }
 }

--- a/quickwit-search/src/collector.rs
+++ b/quickwit-search/src/collector.rs
@@ -213,7 +213,7 @@ impl SegmentCollector for QuickwitSegmentCollector {
         LeafSearchResult {
             num_hits: self.num_hits,
             partial_hits,
-            failed_requests: vec![],
+            failed_splits: vec![],
             num_attempted_splits: 1,
         }
     }
@@ -317,7 +317,7 @@ fn merge_leaf_results(leaf_results: Vec<LeafSearchResult>, max_hits: usize) -> L
         .sum();
     let failed_requests = leaf_results
         .iter()
-        .flat_map(|res| res.failed_requests.iter().cloned())
+        .flat_map(|res| res.failed_splits.iter().cloned())
         .collect_vec();
     let all_partial_hits: Vec<PartialHit> = leaf_results
         .into_iter()
@@ -328,7 +328,7 @@ fn merge_leaf_results(leaf_results: Vec<LeafSearchResult>, max_hits: usize) -> L
     LeafSearchResult {
         num_hits,
         partial_hits: top_k_partial_hits,
-        failed_requests,
+        failed_splits: failed_requests,
         num_attempted_splits,
     }
 }

--- a/quickwit-search/src/error.rs
+++ b/quickwit-search/src/error.rs
@@ -49,8 +49,8 @@ pub fn parse_grpc_error(grpc_error: &tonic::Status) -> SearchError {
 }
 
 impl From<TantivyError> for SearchError {
-    fn from(any_err: TantivyError) -> Self {
-        SearchError::InternalError(format!("{}", any_err))
+    fn from(tantivy_err: TantivyError) -> Self {
+        SearchError::InternalError(format!("{}", tantivy_err))
     }
 }
 

--- a/quickwit-search/src/error.rs
+++ b/quickwit-search/src/error.rs
@@ -19,6 +19,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 use serde::{Deserialize, Serialize};
+use tantivy::TantivyError;
 use thiserror::Error;
 use tokio::task::JoinError;
 
@@ -44,6 +45,12 @@ pub fn parse_grpc_error(grpc_error: &tonic::Status) -> SearchError {
     match serde_json::from_str(grpc_error.message()) {
         Ok(search_error) => search_error,
         Err(_) => SearchError::InternalError(grpc_error.message().to_string()),
+    }
+}
+
+impl From<TantivyError> for SearchError {
+    fn from(any_err: TantivyError) -> Self {
+        SearchError::InternalError(format!("{}", any_err))
     }
 }
 

--- a/quickwit-search/src/leaf.rs
+++ b/quickwit-search/src/leaf.rs
@@ -18,12 +18,12 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use crate::collector::QuickwitCollector;
+use crate::{collector::QuickwitCollector, SearchError};
 use anyhow::Context;
 use futures::future::try_join_all;
 use itertools::Itertools;
 use quickwit_directories::{CachingDirectory, HotDirectory, StorageDirectory, HOTCACHE_FILENAME};
-use quickwit_proto::LeafSearchResult;
+use quickwit_proto::{LeafSearchResult, SplitSearchError};
 use quickwit_storage::Storage;
 use std::collections::BTreeMap;
 use std::path::Path;
@@ -125,7 +125,7 @@ async fn leaf_search_single_split(
     query: &dyn Query,
     quickwit_collector: QuickwitCollector,
     storage: Arc<dyn Storage>,
-) -> anyhow::Result<LeafSearchResult> {
+) -> crate::Result<LeafSearchResult> {
     let index = open_index(storage).await?;
     let reader = index
         .reader_builder()
@@ -148,29 +148,36 @@ pub async fn leaf_search(
     collector: QuickwitCollector,
     split_ids: &[String],
     storage: Arc<dyn Storage>,
-) -> anyhow::Result<LeafSearchResult> {
+) -> Result<LeafSearchResult, SearchError> {
     let leaf_search_single_split_futures: Vec<_> = split_ids
         .iter()
         .map(|split_id| {
             let split_storage: Arc<dyn Storage> =
                 quickwit_storage::add_prefix_to_storage(storage.clone(), split_id);
             let collector_for_split = collector.for_split(split_id.clone());
-            async move { leaf_search_single_split(query, collector_for_split, split_storage).await }
+            async move {
+                leaf_search_single_split(query, collector_for_split, split_storage)
+                    .await
+                    .map_err(|err| (split_id.to_string(), err))
+            }
         })
         .collect();
-    // TODO avoid failing all for one issue. We could be more resilient on storage failures.
     let split_search_results = futures::future::join_all(leaf_search_single_split_futures).await;
 
-    let (search_results, _errors): (Vec<_>, Vec<_>) =
+    let (search_results, errors): (Vec<_>, Vec<_>) =
         split_search_results.into_iter().partition(Result::is_ok);
     let search_results: Vec<_> = search_results.into_iter().map(Result::unwrap).collect();
-    //let errors: Vec<_> = errors.into_iter().map(Result::unwrap_err).collect();
+    let errors: Vec<_> = errors.into_iter().map(Result::unwrap_err).collect();
 
-    let merged_search_results = spawn_blocking(move || collector.merge_fruits(search_results))
+    let mut merged_search_results = spawn_blocking(move || collector.merge_fruits(search_results))
         .await
         .with_context(|| "Merging search on split results failed")??;
 
-    // TODO save error, but switch away from anyhow first
-    //merged_search_results.failed_requests.extend(errors.iter());
+    merged_search_results
+        .failed_requests
+        .extend(errors.iter().map(|(split_id, err)| SplitSearchError {
+            split_id: split_id.to_string(),
+            error: format!("{:?}", err),
+        }));
     Ok(merged_search_results)
 }

--- a/quickwit-search/src/leaf.rs
+++ b/quickwit-search/src/leaf.rs
@@ -178,6 +178,7 @@ pub async fn leaf_search(
         .extend(errors.iter().map(|(split_id, err)| SplitSearchError {
             split_id: split_id.to_string(),
             error: format!("{:?}", err),
+            retryable_error: true,
         }));
     Ok(merged_search_results)
 }

--- a/quickwit-search/src/leaf.rs
+++ b/quickwit-search/src/leaf.rs
@@ -174,7 +174,7 @@ pub async fn leaf_search(
         .with_context(|| "Merging search on split results failed")??;
 
     merged_search_results
-        .failed_requests
+        .failed_splits
         .extend(errors.iter().map(|(split_id, err)| SplitSearchError {
             split_id: split_id.to_string(),
             error: format!("{:?}", err),

--- a/quickwit-search/src/lib.rs
+++ b/quickwit-search/src/lib.rs
@@ -171,6 +171,7 @@ pub async fn single_node_search(
         num_hits: leaf_search_result.num_hits,
         hits: fetch_docs_result.hits,
         elapsed_time_micros: elapsed.as_micros() as u64,
+        errors: vec![],
     })
 }
 

--- a/quickwit-search/src/lib.rs
+++ b/quickwit-search/src/lib.rs
@@ -35,6 +35,10 @@ mod root;
 mod search_result_json;
 mod service;
 
+///
+/// Refer to this as `crate::Result<T>`.
+pub type Result<T> = std::result::Result<T, SearchError>;
+
 use std::cmp::Reverse;
 use std::net::SocketAddr;
 use std::ops::Range;
@@ -143,7 +147,7 @@ pub async fn single_node_search(
     search_request: &SearchRequest,
     metastore: &dyn Metastore,
     storage_resolver: StorageUriResolver,
-) -> Result<SearchResult, SearchError> {
+) -> Result<SearchResult> {
     let start_instant = tokio::time::Instant::now();
     let index_metadata = metastore.index_metadata(&search_request.index_id).await?;
     let storage = storage_resolver.resolve(&index_metadata.index_uri)?;

--- a/quickwit-search/src/root.rs
+++ b/quickwit-search/src/root.rs
@@ -273,12 +273,13 @@ pub async fn root_search(
             result_per_node_addr.remove(&err_addr);
         }
         // Remove partial, retryable errors
+        // In this step we have only retryable errors, since it aborts with non-retryable errors, so we can just replace them.
         for result in result_per_node_addr.values_mut().flatten() {
-            let failed_splits: Vec<SplitSearchError> = vec![];
-            result.failed_splits = failed_splits
-                .into_iter()
-                .filter(|err| !err.retryable_error)
-                .collect_vec();
+            let contains_non_retryable_errors =
+                result.failed_splits.iter().any(|err| !err.retryable_error);
+            assert!(!contains_non_retryable_errors, "Result still contains non-retryable errors, but logic expects to have aborted with non-retryable errors. (this may change if we add partial results) ");
+
+            result.failed_splits = vec![];
         }
 
         for (addr, new_result) in result_per_node_addr_new {

--- a/quickwit-search/src/root.rs
+++ b/quickwit-search/src/root.rs
@@ -446,6 +446,7 @@ mod tests {
             size_in_bytes: 256,
             time_range: None,
             generation: 1,
+            update_timestamp: 0,
         }
     }
 

--- a/quickwit-search/src/root.rs
+++ b/quickwit-search/src/root.rs
@@ -353,7 +353,7 @@ pub async fn root_search(
         .collect_vec();
     let exclude_addresses = analyze_result
         .map(|retry_action| retry_action.nodes_to_avoid)
-        .unwrap_or(Default::default());
+        .unwrap_or_default();
 
     let doc_fetch_jobs = client_pool
         .assign_jobs(fetch_docs_req_jobs, &exclude_addresses)

--- a/quickwit-serve/src/rest.rs
+++ b/quickwit-serve/src/rest.rs
@@ -320,6 +320,7 @@ mod tests {
                 hits: Vec::new(),
                 num_hits: 10,
                 elapsed_time_micros: 16,
+                errors: vec![],
             })
         });
         let rest_search_api_handler = super::search_handler(Arc::new(mock_search_service));


### PR DESCRIPTION
add retry mechnism for failed splits
Retry nodes are either all nodes in case all requests failed or only the (partial successfull) nodes.
When there are issue regarding caching, this retry logic may not work well. When a node partially fails, the split will choose the same node again, because the same algorithm (rendezvous hashing) is used.

### Context / purpose
Describe the context and purpose of this PR. Link related issue(s) if any.

### Description
Describe the proposed changes made in this PR.

### How was this PR tested?
Describe how you tested this PR.

### Checklist
*Remove or complete this list if required.*
- [x] tested locally
- [x] added unit tests
- [x] included documentation
