### PR TITLE
Add sleep for leaving the cluster.

### DIFF
--- a/quickwit-cluster/src/cluster.rs
+++ b/quickwit-cluster/src/cluster.rs
@@ -390,12 +390,12 @@ mod tests {
         cluster1.leave();
 
         // Wait for leaving the cluster.
-        thread::sleep(time::Duration::from_secs(1));
+        thread::sleep(time::Duration::from_millis(10));
 
         cluster2.leave();
 
         // Wait for leaving the cluster.
-        thread::sleep(time::Duration::from_secs(1));
+        thread::sleep(time::Duration::from_millis(10));
 
         cluster3.leave();
 

--- a/quickwit-cluster/src/cluster.rs
+++ b/quickwit-cluster/src/cluster.rs
@@ -388,7 +388,15 @@ mod tests {
         assert_eq!(members, expected);
 
         cluster1.leave();
+
+        // Wait for leaving the cluster.
+        thread::sleep(time::Duration::from_secs(1));
+
         cluster2.leave();
+
+        // Wait for leaving the cluster.
+        thread::sleep(time::Duration::from_secs(1));
+
         cluster3.leave();
 
         tmp_dir.close().unwrap();


### PR DESCRIPTION
### Context / purpose
https://github.com/quickwit-inc/quickwit/issues/333

### Description
Wait for a small amount of time that the message sent and received that the member left the cluster as a temporary fix. 

### How was this PR tested?
```
cargo test -- --nocapture  test_cluster_multiple_node
```

### Checklist
*Remove or complete this list if required.*
- [x] tested locally
