### PR TITLE
Rename and document environment variables

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -326,3 +326,13 @@ quickwit gc --index-uri s3://quickwit-indexes/catalog --dry-run
 ```bash
 quickwit gc --index-uri s3://quickwit-indexes/catalog --grace-period 5m
 ```
+
+## Environment Variables
+
+### QUICKWIT_ENV
+
+Specifies the nature of the current working environment. Currently, this environment variable is used exclusively for testing purposes, and `LOCAL` is the only supported value.
+
+### QUICKWIT_DISABLE_TELEMETRY
+
+Disables [telemetry](telemetry.md) when set to any non-empty value.

--- a/docs/reference/telemetry.md
+++ b/docs/reference/telemetry.md
@@ -6,9 +6,9 @@ position: 5
 Quickwit Inc. collects anonymous data regarding general usage to help us drive our development. Privacy and transparency are at the heart of Quickwit values and we only collect the minimal useful data and don't use any third party tool for the collection.
 
 ## Disabling data collection
-Data collection are opt-out. To disable them, just set the environment variable `DISABLE_QUICKWIT_TELEMETRY` to whatever value.
+Data collection are opt-out. To disable them, just set the environment variable `QUICKWIT_DISABLE_TELEMETRY` to whatever value.
 ```bash
-export DISABLE_QUICKWIT_TELEMETRY=1
+export QUICKWIT_DISABLE_TELEMETRY=1
 ```
 
 Look at `quickwit help` command output to check whether telemetry is enabled or not:

--- a/quickwit-telemetry/src/lib.rs
+++ b/quickwit-telemetry/src/lib.rs
@@ -55,4 +55,4 @@ pub async fn send_telemetry_event(event: TelemetryEvent) {
 }
 
 /// This environment variable can be set to disable sending telemetry events.
-pub const DISABLE_TELEMETRY_ENV_KEY: &str = "DISABLE_QUICKWIT_TELEMETRY";
+pub const DISABLE_TELEMETRY_ENV_KEY: &str = "QUICKWIT_DISABLE_TELEMETRY";


### PR DESCRIPTION
### Description
- Rename `DISABLE_QUICKWIT_TELEMETRY` env variable to `QUICKWIT_DISABLE_TELEMETRY`
- Document env variables in CLI reference