### PR TITLE
Change credential timeout.

### DIFF
--- a/quickwit-storage/src/object_storage/s3_compatible_storage.rs
+++ b/quickwit-storage/src/object_storage/s3_compatible_storage.rs
@@ -33,11 +33,11 @@ use futures::stream;
 use futures::StreamExt;
 use once_cell::sync::OnceCell;
 use regex::Regex;
-use rusoto_core::credential::{AutoRefreshingProvider, ChainProvider};
 use tokio::fs::File;
 use tokio_util::io::ReaderStream;
 use tracing::warn;
 
+use rusoto_core::credential::{AutoRefreshingProvider, ChainProvider};
 use rusoto_core::{ByteStream, HttpClient, HttpConfig, Region, RusotoError};
 use rusoto_s3::{
     AbortMultipartUploadRequest, CompleteMultipartUploadRequest, CompletedMultipartUpload,

--- a/quickwit-storage/src/object_storage/s3_compatible_storage.rs
+++ b/quickwit-storage/src/object_storage/s3_compatible_storage.rs
@@ -59,7 +59,7 @@ use crate::{StorageError, StorageResult};
 const CREDENTIAL_TIMEOUT: u64 = 5;
 
 /// An timeout for idle sockets being kept-alive.
-const POOL_IDIE_TIMEOUT: u64 = 10;
+const POOL_IDLE_TIMEOUT: u64 = 10;
 
 /// S3 Compatible object storage implementation.
 pub struct S3CompatibleObjectStorage {
@@ -87,7 +87,7 @@ fn create_s3_client(region: Region) -> anyhow::Result<S3Client> {
     let mut http_config: HttpConfig = HttpConfig::default();
     // We experience an issue similar to https://github.com/hyperium/hyper/issues/2312.
     // It seems like the setting below solved it.
-    http_config.pool_idle_timeout(std::time::Duration::from_secs(POOL_IDIE_TIMEOUT));
+    http_config.pool_idle_timeout(std::time::Duration::from_secs(POOL_IDLE_TIMEOUT));
     let http_client = HttpClient::new_with_config(http_config)
         .with_context(|| "failed to create request dispatcher")?;
     Ok(S3Client::new_with(


### PR DESCRIPTION
### Context / purpose
https://github.com/quickwit-inc/quickwit/issues/259

### Description
Change credential timeout to 5secs from the default (30secs).

### How was this PR tested?
Rename the credential file to a different name, and then run the following command:
```
cargo r new --index-uri s3://quickwit-dev/my-hdfs --index-config-path ./hdfslogs_index_config.json --overwrite
```

### Checklist
*Remove or complete this list if required.*
- [x] tested locally


Closes #259 