### PR TITLE
Upgrade to Rust 1.54

### DIFF
--- a/quickwit-core/src/index.rs
+++ b/quickwit-core/src/index.rs
@@ -43,7 +43,7 @@ pub async fn create_index(
     index_metadata: IndexMetadata,
 ) -> anyhow::Result<()> {
     let metastore = MetastoreUriResolver::default()
-        .resolve(&metastore_uri)
+        .resolve(metastore_uri)
         .await?;
     metastore.create_index(index_metadata).await?;
     Ok(())
@@ -63,7 +63,7 @@ pub async fn delete_index(
     dry_run: bool,
 ) -> anyhow::Result<Vec<FileEntry>> {
     let metastore = MetastoreUriResolver::default()
-        .resolve(&metastore_uri)
+        .resolve(metastore_uri)
         .await?;
     let storage_resolver = StorageUriResolver::default();
 
@@ -110,7 +110,7 @@ pub async fn garbage_collect_index(
     dry_run: bool,
 ) -> anyhow::Result<Vec<FileEntry>> {
     let metastore = MetastoreUriResolver::default()
-        .resolve(&metastore_uri)
+        .resolve(metastore_uri)
         .await?;
     let storage_resolver = StorageUriResolver::default();
 

--- a/quickwit-core/src/indexing/document_indexer.rs
+++ b/quickwit-core/src/indexing/document_indexer.rs
@@ -45,7 +45,7 @@ pub async fn index_documents(
     let timestamp_field = index_metadata.index_config.timestamp_field();
 
     let mut current_split = Split::create(
-        &params,
+        params,
         storage_resolver.clone(),
         metastore.clone(),
         schema.clone(),
@@ -77,7 +77,7 @@ pub async fn index_documents(
             let split = std::mem::replace(
                 &mut current_split,
                 Split::create(
-                    &params,
+                    params,
                     storage_resolver.clone(),
                     metastore.clone(),
                     schema.clone(),

--- a/quickwit-core/src/test_utils.rs
+++ b/quickwit-core/src/test_utils.rs
@@ -55,7 +55,7 @@ impl TestSandbox {
         };
         let storage_uri_resolver = StorageUriResolver::default();
         let metastore = MetastoreUriResolver::with_storage_resolver(storage_uri_resolver.clone())
-            .resolve(&metastore_uri)
+            .resolve(metastore_uri)
             .await?;
         metastore.create_index(index_metadata).await?;
         Ok(TestSandbox {

--- a/quickwit-directories/src/caching_directory.rs
+++ b/quickwit-directories/src/caching_directory.rs
@@ -215,9 +215,7 @@ mod tests {
             CachingDirectory::new_with_capacity_in_bytes(debug_proxy_directory.clone(), 10_000);
         caching_directory.atomic_read(test_path)?;
         caching_directory.atomic_read(test_path)?;
-        let records: Vec<crate::ReadOperation> =
-            debug_proxy_directory.drain_read_operations().collect();
-        assert_eq!(records.len(), 1);
+        assert_eq!(debug_proxy_directory.drain_read_operations().count(), 1);
         Ok(())
     }
 }

--- a/quickwit-directories/src/hot_directory.rs
+++ b/quickwit-directories/src/hot_directory.rs
@@ -674,25 +674,25 @@ mod tests {
 
         let mut directory_cache_builder = StaticDirectoryCacheBuilder::default();
         directory_cache_builder
-            .add_file(&one_path, 100)
+            .add_file(one_path, 100)
             .add_bytes(b" happy t", 5);
         directory_cache_builder
-            .add_file(&two_path, 200)
+            .add_file(two_path, 200)
             .add_bytes(b"my name", 0);
-        directory_cache_builder.add_file(&three_path, 300);
+        directory_cache_builder.add_file(three_path, 300);
 
         let mut buffer = Vec::new();
         directory_cache_builder.write(&mut buffer)?;
         let directory_cache = StaticDirectoryCache::open(OwnedBytes::new(buffer))?;
 
-        assert_eq!(directory_cache.get_file_length(&one_path), Some(100));
-        assert_eq!(directory_cache.get_file_length(&two_path), Some(200));
-        assert_eq!(directory_cache.get_file_length(&three_path), Some(300));
-        assert_eq!(directory_cache.get_file_length(&four_path), None);
+        assert_eq!(directory_cache.get_file_length(one_path), Some(100));
+        assert_eq!(directory_cache.get_file_length(two_path), Some(200));
+        assert_eq!(directory_cache.get_file_length(three_path), Some(300));
+        assert_eq!(directory_cache.get_file_length(four_path), None);
 
         assert_eq!(
             directory_cache
-                .get_slice(&one_path)
+                .get_slice(one_path)
                 .try_read_bytes(6..11)
                 .unwrap()
                 .as_ref(),
@@ -700,7 +700,7 @@ mod tests {
         );
         assert_eq!(
             directory_cache
-                .get_slice(&two_path)
+                .get_slice(two_path)
                 .try_read_bytes(3..7)
                 .unwrap()
                 .as_ref(),

--- a/quickwit-index-config/src/default_index_config/default_config.rs
+++ b/quickwit-index-config/src/default_index_config/default_config.rs
@@ -72,14 +72,14 @@ impl DefaultIndexConfigBuilder {
                 bail!("Duplicated default search field: `{}`", field_name)
             }
             schema
-                .get_field(&field_name)
+                .get_field(field_name)
                 .with_context(|| format!("Unknown default search field: `{}`", field_name))?;
             default_search_field_names.push(field_name.clone());
         }
         // Resolve timestamp field
         if let Some(ref timestamp_field_name) = self.timestamp_field {
             let timestamp_field = schema
-                .get_field(&timestamp_field_name)
+                .get_field(timestamp_field_name)
                 .with_context(|| format!("Unknown timestamp field: `{}`", timestamp_field_name))?;
 
             let timestamp_field_entry = schema.get_field_entry(timestamp_field);

--- a/quickwit-index-config/src/default_index_config/field_mapping_entry.rs
+++ b/quickwit-index-config/src/default_index_config/field_mapping_entry.rs
@@ -117,16 +117,16 @@ impl FieldMappingEntry {
                 self.parse_text(json_value, options, cardinality)
             }
             FieldMappingType::I64(options, cardinality) => {
-                self.parse_i64(&json_value, options, cardinality)
+                self.parse_i64(json_value, options, cardinality)
             }
             FieldMappingType::F64(options, cardinality) => {
-                self.parse_f64(&json_value, options, cardinality)
+                self.parse_f64(json_value, options, cardinality)
             }
             FieldMappingType::Date(options, cardinality) => {
-                self.parse_date(&json_value, options, cardinality)
+                self.parse_date(json_value, options, cardinality)
             }
             FieldMappingType::Bytes(options, cardinality) => {
-                self.parse_bytes(&json_value, options, cardinality)
+                self.parse_bytes(json_value, options, cardinality)
             }
             FieldMappingType::Object(field_mappings) => {
                 self.parse_object(json_value, field_mappings)
@@ -147,7 +147,7 @@ impl FieldMappingEntry {
                 }
                 array
                     .iter()
-                    .map(|element| self.parse_text(&element, options, cardinality))
+                    .map(|element| self.parse_text(element, options, cardinality))
                     .collect::<Result<Vec<_>, _>>()?
                     .into_iter()
                     .flatten()
@@ -185,7 +185,7 @@ impl FieldMappingEntry {
                 }
                 array
                     .iter()
-                    .map(|element| self.parse_i64(&element, options, cardinality))
+                    .map(|element| self.parse_i64(element, options, cardinality))
                     .collect::<Result<Vec<_>, _>>()?
                     .into_iter()
                     .flatten()
@@ -233,7 +233,7 @@ impl FieldMappingEntry {
                 }
                 array
                     .iter()
-                    .map(|element| self.parse_f64(&element, options, cardinality))
+                    .map(|element| self.parse_f64(element, options, cardinality))
                     .collect::<Result<Vec<_>, _>>()?
                     .into_iter()
                     .flatten()
@@ -284,7 +284,7 @@ impl FieldMappingEntry {
                 }
                 array
                     .iter()
-                    .map(|element| self.parse_date(&element, options, cardinality))
+                    .map(|element| self.parse_date(element, options, cardinality))
                     .collect::<Result<Vec<_>, _>>()?
                     .into_iter()
                     .flatten()
@@ -335,7 +335,7 @@ impl FieldMappingEntry {
                 }
                 array
                     .iter()
-                    .map(|element| self.parse_bytes(&element, options, cardinality))
+                    .map(|element| self.parse_bytes(element, options, cardinality))
                     .collect::<Result<Vec<_>, _>>()?
                     .into_iter()
                     .flatten()

--- a/quickwit-index-config/src/query_builder.rs
+++ b/quickwit-index-config/src/query_builder.rs
@@ -71,7 +71,7 @@ fn resolve_fields(schema: &Schema, field_names: &[String]) -> anyhow::Result<Vec
     let mut fields = vec![];
     for field_name in field_names {
         let field = schema
-            .get_field(&field_name)
+            .get_field(field_name)
             .ok_or_else(|| TantivyQueryParserError::FieldDoesNotExist(field_name.clone()))?;
         fields.push(field);
     }

--- a/quickwit-metastore/src/metastore/single_file_metastore.rs
+++ b/quickwit-metastore/src/metastore/single_file_metastore.rs
@@ -315,8 +315,7 @@ impl Metastore for SingleFileMetastore {
         let metadata_set = self.get_index(index_id).await?;
         let splits = metadata_set
             .splits
-            .into_iter()
-            .map(|(_, split_metadata)| split_metadata)
+            .into_values()
             .filter(|split_metadata| {
                 split_metadata.split_state == state && time_range_filter(split_metadata)
             })
@@ -328,8 +327,7 @@ impl Metastore for SingleFileMetastore {
         let metadata_set = self.get_index(index_id).await?;
         let splits = metadata_set
             .splits
-            .into_iter()
-            .map(|(_, split_metadata)| split_metadata)
+            .into_values()
             .collect();
         Ok(splits)
     }

--- a/quickwit-metastore/src/metastore/single_file_metastore.rs
+++ b/quickwit-metastore/src/metastore/single_file_metastore.rs
@@ -325,10 +325,7 @@ impl Metastore for SingleFileMetastore {
 
     async fn list_all_splits(&self, index_id: &str) -> MetastoreResult<Vec<SplitMetadata>> {
         let metadata_set = self.get_index(index_id).await?;
-        let splits = metadata_set
-            .splits
-            .into_values()
-            .collect();
+        let splits = metadata_set.splits.into_values().collect();
         Ok(splits)
     }
 

--- a/quickwit-metastore/src/metastore_resolver.rs
+++ b/quickwit-metastore/src/metastore_resolver.rs
@@ -94,7 +94,7 @@ impl MetastoreUriResolver {
 
         let storage = self
             .default_storage_resolver
-            .resolve(&uri)
+            .resolve(uri)
             .map_err(|err| match err {
                 StorageResolverError::InvalidUri { message } => {
                     MetastoreResolverError::InvalidUri(message)

--- a/quickwit-search/src/client_pool/search_client_pool.rs
+++ b/quickwit-search/src/client_pool/search_client_pool.rs
@@ -253,8 +253,7 @@ mod tests {
 
         let mut addrs: Vec<SocketAddr> = clients
             .clone()
-            .into_iter()
-            .map(|(addr, _client)| addr)
+            .into_keys()
             .collect();
         addrs.sort_by_key(|addr| addr.to_string());
         println!("addrs={:?}", addrs);
@@ -290,8 +289,7 @@ mod tests {
 
         let mut addrs: Vec<SocketAddr> = clients1
             .clone()
-            .into_iter()
-            .map(|(addr, _client)| addr)
+            .into_keys()
             .collect();
         addrs.sort();
         println!("addrs={:?}", addrs);

--- a/quickwit-search/src/client_pool/search_client_pool.rs
+++ b/quickwit-search/src/client_pool/search_client_pool.rs
@@ -251,10 +251,7 @@ mod tests {
 
         let clients = client_pool.clients.read().await;
 
-        let mut addrs: Vec<SocketAddr> = clients
-            .clone()
-            .into_keys()
-            .collect();
+        let mut addrs: Vec<SocketAddr> = clients.clone().into_keys().collect();
         addrs.sort_by_key(|addr| addr.to_string());
         println!("addrs={:?}", addrs);
 
@@ -287,10 +284,7 @@ mod tests {
 
         let clients1 = client_pool1.clients.read().await;
 
-        let mut addrs: Vec<SocketAddr> = clients1
-            .clone()
-            .into_keys()
-            .collect();
+        let mut addrs: Vec<SocketAddr> = clients1.clone().into_keys().collect();
         addrs.sort();
         println!("addrs={:?}", addrs);
 

--- a/quickwit-search/src/collector.rs
+++ b/quickwit-search/src/collector.rs
@@ -81,7 +81,7 @@ fn resolve_sort_by(
 ) -> tantivy::Result<SortingFieldComputer> {
     match sort_by {
         SortBy::SortByFastField { field_name, order } => {
-            if let Some(field) = segment_reader.schema().get_field(&field_name) {
+            if let Some(field) = segment_reader.schema().get_field(field_name) {
                 let fast_field_reader = segment_reader.fast_fields().u64_lenient(field)?;
                 Ok(SortingFieldComputer::SortByFastField {
                     fast_field_reader,

--- a/quickwit-search/src/leaf.rs
+++ b/quickwit-search/src/leaf.rs
@@ -21,7 +21,7 @@
 use crate::{collector::QuickwitCollector, SearchError};
 use anyhow::Context;
 use futures::future::try_join_all;
-use itertools::Itertools;
+use itertools::{Either, Itertools};
 use quickwit_directories::{CachingDirectory, HotDirectory, StorageDirectory, HOTCACHE_FILENAME};
 use quickwit_proto::{LeafSearchResult, SplitSearchError};
 use quickwit_storage::Storage;
@@ -112,7 +112,7 @@ async fn warm_up_terms(searcher: &Searcher, query: &dyn Query) -> anyhow::Result
             for (term, position_needed) in terms.iter().cloned() {
                 let inv_idx_clone = inv_idx.clone();
                 warm_up_futures
-                    .push(async move { inv_idx_clone.warm_postings(&term, position_needed).await });
+                    .push(async move { inv_idx_clone.warm_postings(term, position_needed).await });
             }
         }
     }
@@ -164,10 +164,13 @@ pub async fn leaf_search(
         .collect();
     let split_search_results = futures::future::join_all(leaf_search_single_split_futures).await;
 
-    let (search_results, errors): (Vec<_>, Vec<_>) =
-        split_search_results.into_iter().partition(Result::is_ok);
-    let search_results: Vec<_> = search_results.into_iter().map(Result::unwrap).collect();
-    let errors: Vec<_> = errors.into_iter().map(Result::unwrap_err).collect();
+    let (search_results, errors): (Vec<LeafSearchResult>, Vec<(String, SearchError)>) =
+        split_search_results
+            .into_iter()
+            .partition_map(|split_search_res| match split_search_res {
+                Ok(search_res) => Either::Left(search_res),
+                Err(err) => Either::Right(err),
+            });
 
     let mut merged_search_results = spawn_blocking(move || collector.merge_fruits(search_results))
         .await

--- a/quickwit-serve/src/lib.rs
+++ b/quickwit-serve/src/lib.rs
@@ -90,7 +90,7 @@ async fn create_index_to_metastore_router(
         }
         let metastore = get_from_cache_or_create_metastore(
             &mut metastore_cache,
-            &metastore_resolver,
+            metastore_resolver,
             metastore_uri,
         )
         .await?;
@@ -110,14 +110,14 @@ fn display_help_message(
     // No-color if we are not in a terminal.
     let mut stdout = StandardStream::stdout(ColorChoice::Auto);
     write!(&mut stdout, "Server started on ")?;
-    stdout.set_color(&ColorSpec::new().set_fg(Some(Color::Green)))?;
+    stdout.set_color(ColorSpec::new().set_fg(Some(Color::Green)))?;
     writeln!(&mut stdout, "http://{}/", &rest_socket_addr)?;
     stdout.set_color(&ColorSpec::new())?;
     writeln!(
         &mut stdout,
         "\nYou can test it using the following command:"
     )?;
-    stdout.set_color(&ColorSpec::new().set_fg(Some(Color::Blue)))?;
+    stdout.set_color(ColorSpec::new().set_fg(Some(Color::Blue)))?;
     writeln!(
         &mut stdout,
         "curl 'http://{}/api/v1/{}/search?query=my+query'",

--- a/quickwit-storage/src/cache/in_ram_slice_cache.rs
+++ b/quickwit-storage/src/cache/in_ram_slice_cache.rs
@@ -149,22 +149,22 @@ mod tests {
         {
             let data = Bytes::from_static(&b"abc"[..]);
             cache.put(PathBuf::from("3"), 0..3, data);
-            assert_eq!(cache.get(&Path::new("3"), 0..3).unwrap(), &b"abc"[..]);
+            assert_eq!(cache.get(Path::new("3"), 0..3).unwrap(), &b"abc"[..]);
         }
         {
             let data = Bytes::from_static(&b"de"[..]);
             cache.put(PathBuf::from("2"), 0..2, data);
             // our first entry should still be here.
-            assert_eq!(cache.get(&Path::new("3"), 0..3).unwrap(), &b"abc"[..]);
-            assert_eq!(cache.get(&Path::new("2"), 0..2).unwrap(), &b"de"[..]);
+            assert_eq!(cache.get(Path::new("3"), 0..3).unwrap(), &b"abc"[..]);
+            assert_eq!(cache.get(Path::new("2"), 0..2).unwrap(), &b"de"[..]);
         }
         {
             let data = Bytes::from_static(&b"fghij"[..]);
             cache.put(PathBuf::from("5"), 0..5, data);
-            assert_eq!(cache.get(&Path::new("5"), 0..5).unwrap(), &b"fghij"[..]);
+            assert_eq!(cache.get(Path::new("5"), 0..5).unwrap(), &b"fghij"[..]);
             // our two first entries should have be removed from the cache
-            assert!(cache.get(&Path::new("2"), 0..2).is_none());
-            assert!(cache.get(&Path::new("3"), 0..3).is_none());
+            assert!(cache.get(Path::new("2"), 0..2).is_none());
+            assert!(cache.get(Path::new("3"), 0..3).is_none());
         }
         {
             let data = Bytes::from_static(&b"klmnop"[..]);
@@ -187,19 +187,19 @@ mod tests {
         {
             let data = Bytes::from_static(&b"de"[..]);
             cache.put(PathBuf::from("2"), 0..2, data);
-            assert_eq!(cache.get(&Path::new("3"), 0..3).unwrap(), &b"abc"[..]);
-            assert_eq!(cache.get(&Path::new("2"), 0..2).unwrap(), &b"de"[..]);
+            assert_eq!(cache.get(Path::new("3"), 0..3).unwrap(), &b"abc"[..]);
+            assert_eq!(cache.get(Path::new("2"), 0..2).unwrap(), &b"de"[..]);
         }
     }
 
     #[test]
     fn test_cache() {
         let cache = SliceCache::with_capacity_in_bytes(10_000);
-        assert!(cache.get(&Path::new("hello.seg"), 1..3).is_none());
+        assert!(cache.get(Path::new("hello.seg"), 1..3).is_none());
         let data = Bytes::from_static(&b"werwer"[..]);
         cache.put(PathBuf::from("hello.seg"), 1..3, data);
         assert_eq!(
-            cache.get(&Path::new("hello.seg"), 1..3).unwrap(),
+            cache.get(Path::new("hello.seg"), 1..3).unwrap(),
             &b"werwer"[..]
         );
     }

--- a/quickwit-storage/src/cache/storage_with_cache.rs
+++ b/quickwit-storage/src/cache/storage_with_cache.rs
@@ -56,7 +56,7 @@ impl Storage for StorageWithCache {
     }
 
     async fn get_all(&self, path: &Path) -> StorageResult<Bytes> {
-        if let Some(bytes) = self.cache.get_all(&path).await {
+        if let Some(bytes) = self.cache.get_all(path).await {
             Ok(bytes)
         } else {
             let bytes = self.storage.get_all(path).await?;


### PR DESCRIPTION
### Description
Following the release of Rust 1.54, I fixed a bunch of new Clippy warnings and replaced some calls to `map` with `into_keys()` or `into_values()` wherever possible.

I suspect this will PR will require an update of the builder image to pass CI.