### PR TITLE
Update Docker Hub workflow

### DIFF
--- a/.github/workflows/dockerhub.yaml
+++ b/.github/workflows/dockerhub.yaml
@@ -21,11 +21,11 @@ jobs:
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@v2
         with:
           context: ./docker/
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/quickwit:latest, ${{ secrets.DOCKERHUB_USERNAME }}/quickwit:${{ env.ASSET_VERSION }}
+          tags: quickwit/quickwit:latest, quickwit/quickwit:${{ env.ASSET_VERSION }}


### PR DESCRIPTION
### Context / purpose
Moving to the `quickwit` org on Docker Hub.

### Description
You can't create an access token at the org level on Docker Hub, so `DOCKERHUB_USERNAME` is actually my personal Docker Hub username... and the publish step pushes on the `quickwit/quickit` repo.