### PR TITLE
lint(quickstart): Invoke command with ./

### DIFF
--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -71,13 +71,13 @@ And here is the complete config:
 Now we can create the index with the command:
 
 ```bash
-quickwit new --index-uri file:///your-path-to-your-index/wikipedia --index-config-path ./wikipedia_index_config.json
+./quickwit new --index-uri file:///your-path-to-your-index/wikipedia --index-config-path ./wikipedia_index_config.json
 ```
 
 To simplify our command, we now assume that the index is to be created in the current directory and use `pwd` variable to specify the index uri:
 
 ```bash
-quickwit new --index-uri file:///$(pwd)/wikipedia --index-config-path ./wikipedia_index_config.json
+./quickwit new --index-uri file:///$(pwd)/wikipedia --index-config-path ./wikipedia_index_config.json
 ```
 
 Check that an empty directory `/$(pwd)/wikipedia` has been created, Quickwit will write index files here and a `quickwit.json` which contains the [index metadata](../overview/architecture.md#index-metadata).
@@ -101,13 +101,13 @@ Let's download [a bunch of wikipedia articles (10 000)](https://quickwit-dataset
 curl -o wiki-articles-10000.json https://quickwit-datasets-public.s3.amazonaws.com/wiki-articles-10000.json
 
 # Index our 10k documents.
-quickwit index --index-uri file:///$(pwd)/wikipedia --input-path wiki-articles-10000.json
+./quickwit index --index-uri file:///$(pwd)/wikipedia --input-path wiki-articles-10000.json
 ```
 
 Wait one second or two and check if it worked by using `search` command:
 
 ```bash
-quickwit search --index-uri file:///$(pwd)/wikipedia --query "barack AND obama"
+./quickwit search --index-uri file:///$(pwd)/wikipedia --query "barack AND obama"
 ```
 
 It should return 10 hits. Now you're ready to serve our search API.
@@ -118,7 +118,7 @@ It should return 10 hits. Now you're ready to serve our search API.
 The command `serve` starts an http server which provides a [REST API](../reference/search-api.md).
 
 ```bash
-quickwit serve --index-uri file:///$(pwd)/wikipedia
+./quickwit serve --index-uri file:///$(pwd)/wikipedia
 ```
 
 Check it's working with a simple GET request in the browser or via cURL:
@@ -148,7 +148,7 @@ Don't forget to encode correctly the query params to avoid bad request (status 4
 Let's do some cleanup by deleting the index:
 
 ```bash
-quickwit delete --index-uri file:///$(pwd)/wikipedia
+./quickwit delete --index-uri file:///$(pwd)/wikipedia
 ```
 
 Congrats! You can level up with the following tutorials to discover all Quickwit features.
@@ -158,11 +158,11 @@ Congrats! You can level up with the following tutorials to discover all Quickwit
 
 ```bash
 curl -o wikipedia_index_config.json https://raw.githubusercontent.com/quickwit-inc/quickwit/main/examples/index_configs/wikipedia_index_config.json
-quickwit new --index-uri file:///$(pwd)/wikipedia --index-config-path ./wikipedia_index_config.json
+./quickwit new --index-uri file:///$(pwd)/wikipedia --index-config-path ./wikipedia_index_config.json
 curl -o wiki-articles-10000.json https://quickwit-datasets-public.s3.amazonaws.com/wiki-articles-10000.json
-quickwit index --index-uri file:///$(pwd)/wikipedia --input-path wiki-articles-10000.json
-quickwit search --index-uri file:///$(pwd)/wikipedia --query "barack AND obama"
-quickwit delete --index-uri file:///$(pwd)/wikipedia
+./quickwit index --index-uri file:///$(pwd)/wikipedia --input-path wiki-articles-10000.json
+./quickwit search --index-uri file:///$(pwd)/wikipedia --query "barack AND obama"
+./quickwit delete --index-uri file:///$(pwd)/wikipedia
 ```
 
 


### PR DESCRIPTION
installer does not install in PATH
Closes #361


### How was this PR tested?
To be honest, it hasn't. Looked for a `make doc` or some kind of way to run the documentation localy without taking too much time and stopped here :)  I checked the output md was correct.

### Checklist
- [x] included documentation
