### PR TITLE
Clean up code in field mapping parsing functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2719,6 +2719,7 @@ dependencies = [
  "base64",
  "chrono",
  "dyn-clone",
+ "itertools 0.10.1",
  "matches",
  "mockall 0.9.1",
  "once_cell",

--- a/quickwit-index-config/Cargo.toml
+++ b/quickwit-index-config/Cargo.toml
@@ -11,17 +11,18 @@ documentation = "https://quickwit.io/docs/"
 
 [dependencies]
 anyhow = "1"
-regex = "1"
-tantivy = { git= "https://github.com/quickwit-inc/tantivy", rev="c1d1d84" }
-serde_json = "1.0"
-thiserror = "1.0"
-serde = { version = "1.0", features = ["derive"] }
-typetag = "0.1"
-dyn-clone = "1.0.4"
-once_cell = "1.4"
-tantivy-query-grammar = { git= "https://github.com/quickwit-inc/tantivy/", rev="c1d1d84" }
 base64 = "0.13"
 chrono = "0.4"
+dyn-clone = "1.0.4"
+itertools = '0.10'
+once_cell = "1.4"
+regex = "1"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+tantivy = { git= "https://github.com/quickwit-inc/tantivy", rev="c1d1d84" }
+tantivy-query-grammar = { git= "https://github.com/quickwit-inc/tantivy/", rev="c1d1d84" }
+thiserror = "1.0"
+typetag = "0.1"
 
 [dependencies.quickwit-proto]
 path = '../quickwit-proto'

--- a/quickwit-index-config/src/default_index_config/default_config.rs
+++ b/quickwit-index-config/src/default_index_config/default_config.rs
@@ -453,7 +453,7 @@ mod tests {
             error,
             DocParsingError::ValueError(
                 "body".to_owned(),
-                "expected json string, got '1'.".to_owned()
+                "Expected JSON string, got '1'.".to_owned()
             )
         );
         Ok(())

--- a/quickwit-index-config/src/default_index_config/field_mapping_type.rs
+++ b/quickwit-index-config/src/default_index_config/field_mapping_type.rs
@@ -30,13 +30,13 @@ use super::FieldMappingEntry;
 pub enum FieldMappingType {
     /// String mapping type configuration.
     Text(TextOptions, Cardinality),
-    /// Signed 64-bits integers mapping type configuration.
+    /// Signed 64-bit integer mapping type configuration.
     I64(IntOptions, Cardinality),
-    /// Unsigned 64-bits integers mapping type configuration.
+    /// Unsigned 64-bit integer mapping type configuration.
     U64(IntOptions, Cardinality),
-    /// 64-bits floats mapping type configuration.
+    /// 64-bit float mapping type configuration.
     F64(IntOptions, Cardinality),
-    /// Signed 64-bits Date 64 mapping type configuration,
+    /// RFC 3339 date mapping type configuration.
     Date(IntOptions, Cardinality),
     /// Bytes mapping type configuration.
     Bytes(BytesOptions, Cardinality),


### PR DESCRIPTION
### Context / purpose
Code cleanup

### Description
I am not a fan of the following pattern, which needlessly creates an intermediate vector for error handling purposes:
```rust
values
.iter()
.map(...)
.collect::<Result<Vec<_>, _>>()?
.into_inter()
.flatten()
.collect()
```
Instead, let's rely on `process_results` from `itertools`. I also fixed some documentation along the way.

### How was this PR tested?
No functional changes were made in this PR.
