### PR TITLE
Try to guess AWS_REGION from ec2 instance metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,6 +592,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "chunked_transfer"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fff857943da45f546682664a79488be82e69e43c1a7a2307679ab9afb3a66d2e"
+
+[[package]]
 name = "clap"
 version = "2.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -653,6 +659,33 @@ name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
+name = "cookie"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03a5d7b21829bc7b4bf4754a978a241ae54ea55a40f92bb20216e54096f4b951"
+dependencies = [
+ "percent-encoding",
+ "time 0.2.27",
+ "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3818dfca4b0cb5211a659bbcbb94225b7127407b2b135e650d717bfb78ab10d3"
+dependencies = [
+ "cookie",
+ "idna",
+ "log",
+ "publicsuffix",
+ "serde",
+ "serde_json",
+ "time 0.2.27",
+ "url",
+]
 
 [[package]]
 name = "core-foundation"
@@ -992,6 +1025,16 @@ name = "dyn-clone"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee2626afccd7561a06cf1367e2950c4718ea04565e20fb5029b6c7d8ad09abcf"
+
+[[package]]
+name = "ec2_instance_metadata"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09e6c7cd17abc12088c36a718be748fd1d9914a2dc310a28babccc6a657c284b"
+dependencies = [
+ "json",
+ "ureq",
+]
 
 [[package]]
 name = "ed25519"
@@ -1693,6 +1736,12 @@ checksum = "83bdfbace3a0e81a4253f73b49e960b053e396a11012cbd49b9b74d6a2b67062"
 dependencies = [
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "json"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
 
 [[package]]
 name = "json_comments"
@@ -2599,6 +2648,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "publicsuffix"
+version = "1.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95b4ce31ff0a27d93c8de1849cf58162283752f065a90d508f1105fa6c9a213f"
+dependencies = [
+ "idna",
+ "url",
+]
+
+[[package]]
+name = "qstring"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d464fae65fff2680baf48019211ce37aaec0c78e9264c84a3e484717f965104e"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2833,6 +2901,7 @@ dependencies = [
  "async-trait",
  "base64",
  "bytes 1.0.1",
+ "ec2_instance_metadata",
  "futures",
  "lru",
  "md5",
@@ -4388,6 +4457,25 @@ name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "ureq"
+version = "1.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b8b063c2d59218ae09f22b53c42eaad0d53516457905f5235ca4bc9e99daa71"
+dependencies = [
+ "base64",
+ "chunked_transfer",
+ "cookie",
+ "cookie_store",
+ "log",
+ "once_cell",
+ "qstring",
+ "rustls",
+ "url",
+ "webpki",
+ "webpki-roots",
+]
 
 [[package]]
 name = "url"

--- a/quickwit-storage/Cargo.toml
+++ b/quickwit-storage/Cargo.toml
@@ -24,6 +24,7 @@ thiserror = '1'
 rand = '0.8'
 lru = "0.6"
 serde = { version = "1.0", features = ["derive"] }
+ec2_instance_metadata = "0.3"
 
 [dependencies.rusoto_core]
 version = '0.46'

--- a/quickwit-storage/src/object_storage/s3_compatible_storage_uri_resolver.rs
+++ b/quickwit-storage/src/object_storage/s3_compatible_storage_uri_resolver.rs
@@ -20,7 +20,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-use std::sync::Arc;
+use std::{str::FromStr, sync::Arc};
 
 pub use rusoto_core::Region;
 
@@ -45,7 +45,10 @@ impl S3CompatibleObjectStorageFactory {
 
 impl Default for S3CompatibleObjectStorageFactory {
     fn default() -> Self {
-        S3CompatibleObjectStorageFactory::new(Region::default(), "s3")
+        let client = ec2_instance_metadata::InstanceMetadataClient::new();
+        let region_str = client.get().map(|e| e.region).unwrap_or_default();
+        let region = Region::from_str(region_str).unwrap_or(Region::default());
+        S3CompatibleObjectStorageFactory::new(region, "s3")
     }
 }
 


### PR DESCRIPTION
### Context / purpose
When running quickwit on an EC2, we still need to indicate the region `AWS_REGION` in order to properly use the IAM role associated with the EC2 machine. 
This PR, leverage the ec2 instance metadata to get the `AWS_REGION` automatically when running on EC2. 

### Description
Describe the proposed changes made in this PR.

### How was this PR tested?
We tested this PR on our EC2 instances that are running quickwit. We unset all the environment variables related to `AWS` and we try to Index data to `S3`

### Checklist
*Remove or complete this list if required.*
- [ X ] tested locally
- [ ] added unit tests
- [ ] included documentation
