### PR TITLE
Only keep the footer offsets in the metastore

### DIFF
--- a/quickwit-core/src/index.rs
+++ b/quickwit-core/src/index.rs
@@ -24,7 +24,7 @@ use std::time::Duration;
 
 use futures::StreamExt;
 use quickwit_metastore::{
-    SplitMetadataAndFooterOffsets, IndexMetadata, Metastore, MetastoreUriResolver, SplitState,
+    IndexMetadata, Metastore, MetastoreUriResolver, SplitMetadataAndFooterOffsets, SplitState,
 };
 use quickwit_storage::StorageUriResolver;
 use tantivy::chrono::Utc;

--- a/quickwit-core/src/index.rs
+++ b/quickwit-core/src/index.rs
@@ -24,7 +24,7 @@ use std::time::Duration;
 
 use futures::StreamExt;
 use quickwit_metastore::{
-    BundleAndSplitMetadata, IndexMetadata, Metastore, MetastoreUriResolver, SplitState,
+    SplitMetadataAndFooterOffsets, IndexMetadata, Metastore, MetastoreUriResolver, SplitState,
 };
 use quickwit_storage::StorageUriResolver;
 use tantivy::chrono::Utc;
@@ -195,7 +195,7 @@ pub async fn delete_garbage_files(
 
 /// list the files for a list of split.
 async fn list_splits_files(
-    splits: Vec<BundleAndSplitMetadata>,
+    splits: Vec<SplitMetadataAndFooterOffsets>,
     index_uri: String,
     storage_resolver: StorageUriResolver,
 ) -> anyhow::Result<Vec<FileEntry>> {

--- a/quickwit-core/src/indexing/split.rs
+++ b/quickwit-core/src/indexing/split.rs
@@ -28,9 +28,9 @@ use crate::indexing::manifest::Manifest;
 use anyhow::{self, Context};
 use quickwit_common::HOTCACHE_FILENAME;
 use quickwit_directories::write_hotcache;
-use quickwit_metastore::SplitMetadataAndFooterOffsets;
 use quickwit_metastore::Metastore;
 use quickwit_metastore::SplitMetadata;
+use quickwit_metastore::SplitMetadataAndFooterOffsets;
 use quickwit_storage::{PutPayload, Storage, StorageUriResolver};
 use std::sync::Arc;
 use std::time::Instant;
@@ -232,7 +232,7 @@ impl Split {
     pub async fn stage(&self) -> anyhow::Result<String> {
         let metadata = SplitMetadataAndFooterOffsets {
             split_metadata: self.metadata.clone(),
-            footer_offsets: (1000..2000)
+            footer_offsets: 1000..2000,
         };
         self.metastore.stage_split(&self.index_id, metadata).await?;
         Ok(self.id.to_string())

--- a/quickwit-core/src/indexing/split.rs
+++ b/quickwit-core/src/indexing/split.rs
@@ -28,7 +28,7 @@ use crate::indexing::manifest::Manifest;
 use anyhow::{self, Context};
 use quickwit_common::HOTCACHE_FILENAME;
 use quickwit_directories::write_hotcache;
-use quickwit_metastore::BundleAndSplitMetadata;
+use quickwit_metastore::SplitMetadataAndFooterOffsets;
 use quickwit_metastore::Metastore;
 use quickwit_metastore::SplitMetadata;
 use quickwit_storage::{PutPayload, Storage, StorageUriResolver};
@@ -230,7 +230,7 @@ impl Split {
 
     /// Stage a split in the metastore.
     pub async fn stage(&self) -> anyhow::Result<String> {
-        let metadata = BundleAndSplitMetadata {
+        let metadata = SplitMetadataAndFooterOffsets {
             split_metadata: self.metadata.clone(),
             bundle_offsets: Default::default(),
         };

--- a/quickwit-core/src/indexing/split.rs
+++ b/quickwit-core/src/indexing/split.rs
@@ -232,7 +232,7 @@ impl Split {
     pub async fn stage(&self) -> anyhow::Result<String> {
         let metadata = SplitMetadataAndFooterOffsets {
             split_metadata: self.metadata.clone(),
-            bundle_offsets: Default::default(),
+            footer_offsets: (1000..2000)
         };
         self.metastore.stage_split(&self.index_id, metadata).await?;
         Ok(self.id.to_string())

--- a/quickwit-index/src/actors/packager.rs
+++ b/quickwit-index/src/actors/packager.rs
@@ -18,7 +18,10 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::path::Path;
+use std::fs::File;
+use std::io;
+use std::io::Write;
+use std::ops::Range;
 use std::path::PathBuf;
 
 use crate::models::IndexedSplit;
@@ -30,14 +33,13 @@ use quickwit_actors::ActorContext;
 use quickwit_actors::Mailbox;
 use quickwit_actors::QueueCapacity;
 use quickwit_actors::SyncActor;
-use quickwit_common::HOTCACHE_FILENAME;
 use quickwit_directories::write_hotcache;
 use quickwit_storage::BundleStorageBuilder;
-use quickwit_storage::BundleStorageOffsets;
 use quickwit_storage::BUNDLE_FILENAME;
+use tantivy::common::CountingWriter;
 use tantivy::SegmentId;
 use tantivy::SegmentMeta;
-use tracing::{debug, info};
+use tracing::info;
 
 pub struct Packager {
     uploader_mailbox: Mailbox<PackagedSplit>,
@@ -98,10 +100,7 @@ fn list_split_files(
     segment_metas: &[SegmentMeta],
     scratch_directory: &ScratchDirectory,
 ) -> Vec<PathBuf> {
-    let mut index_files = vec![
-        scratch_directory.path().join("meta.json"),
-        scratch_directory.path().join(HOTCACHE_FILENAME),
-    ];
+    let mut index_files = vec![scratch_directory.path().join("meta.json")];
 
     // list the segment files
     for segment_meta in segment_metas {
@@ -118,16 +117,17 @@ fn list_split_files(
     index_files
 }
 
+/// Create the file bundle.
+///
+/// Returns the range of the file offsets metadata (required to open the bundle.)
 fn create_file_bundle(
     segment_metas: &[SegmentMeta],
     scratch_dir: &ScratchDirectory,
-) -> anyhow::Result<BundleStorageOffsets> {
+    split_file: &mut impl io::Write,
+) -> anyhow::Result<Range<u64>> {
     // create bundle
-    let bundle_path = scratch_dir.path().join(BUNDLE_FILENAME);
-    debug!(bundle_path=?bundle_path,  segment_metas=?segment_metas, "Creating Bundle");
-
     // List the split files that will be packaged into the bundle.
-    let mut bundle_storage_builder = BundleStorageBuilder::new(&bundle_path)?;
+    let mut bundle_storage_builder = BundleStorageBuilder::new(split_file)?;
 
     for split_file in list_split_files(segment_metas, scratch_dir) {
         bundle_storage_builder.add_file(&split_file)?;
@@ -161,12 +161,13 @@ fn merge_segments_if_required(
     Ok(segment_metas_after_merge)
 }
 
-fn build_hotcache(path: &Path) -> anyhow::Result<()> {
+fn build_hotcache<W: io::Write>(
+    scratch_dir: &ScratchDirectory,
+    split_file: &mut W,
+) -> anyhow::Result<()> {
     info!("build-hotcache");
-    let hotcache_path = path.join(HOTCACHE_FILENAME);
-    let mut hotcache_file = std::fs::File::create(&hotcache_path)?;
-    let mmap_directory = tantivy::directory::MmapDirectory::open(path)?;
-    write_hotcache(mmap_directory, &mut hotcache_file)?;
+    let mmap_directory = tantivy::directory::MmapDirectory::open(scratch_dir.path())?;
+    write_hotcache(mmap_directory, split_file)?;
     Ok(())
 }
 
@@ -175,21 +176,39 @@ fn create_packaged_split(
     split: IndexedSplit,
 ) -> anyhow::Result<PackagedSplit> {
     info!("create-packaged-split");
+
+    let split_filepath = split.split_scratch_directory.path().join(BUNDLE_FILENAME); // TODO rename <split_id>.split
+    let mut split_file = CountingWriter::wrap(File::create(split_filepath)?);
+
+    let Range {
+        start: footer_start,
+        end: _,
+    } = create_file_bundle(
+        segment_metas,
+        &split.split_scratch_directory,
+        &mut split_file,
+    )?;
+
     let num_docs = segment_metas
         .iter()
         .map(|segment_meta| segment_meta.num_docs() as u64)
         .sum();
+
     let segment_ids: Vec<SegmentId> = segment_metas
         .iter()
         .map(|segment_meta| segment_meta.id())
         .collect();
-    let bundle_offsets = create_file_bundle(segment_metas, &split.split_scratch_directory)
-        .with_context(|| {
-            format!(
-                "Failed to identify files for upload in packaging for split `{}`.",
-                split.split_id
-            )
-        })?;
+
+    let hotcache_offset_start = split_file.written_bytes();
+    build_hotcache(&split.split_scratch_directory, &mut split_file)?;
+    let hotcache_offset_end = split_file.written_bytes();
+    let hotcache_num_bytes = hotcache_offset_end - hotcache_offset_start;
+
+    split_file.write_all(&hotcache_num_bytes.to_le_bytes())?;
+    split_file.flush()?;
+
+    let footer_end = split_file.written_bytes();
+
     let packaged_split = PackagedSplit {
         index_id: split.index_id,
         split_id: split.split_id.to_string(),
@@ -199,7 +218,7 @@ fn create_packaged_split(
         segment_ids,
         time_range: split.time_range,
         size_in_bytes: split.docs_size_in_bytes,
-        bundle_offsets,
+        footer_offsets: footer_start..footer_end,
     };
     Ok(packaged_split)
 }
@@ -212,7 +231,6 @@ impl SyncActor for Packager {
     ) -> Result<(), quickwit_actors::ActorExitStatus> {
         commit_split(&mut split, ctx)?;
         let segment_metas = merge_segments_if_required(&mut split, ctx)?;
-        build_hotcache(split.split_scratch_directory.path())?;
         let packaged_split = create_packaged_split(&segment_metas[..], split)?;
         ctx.send_message_blocking(&self.uploader_mailbox, packaged_split)?;
         Ok(())

--- a/quickwit-index/src/actors/publisher.rs
+++ b/quickwit-index/src/actors/publisher.rs
@@ -136,7 +136,7 @@ mod tests {
                         split_id: "split2".to_string(),
                         ..Default::default()
                     },
-                    bundle_offsets: Default::default()
+                    footer_offsets: (1000..1200)
                 },
                 checkpoint_delta: CheckpointDelta::from(3..7),
             })
@@ -149,7 +149,7 @@ mod tests {
                         split_id: "split1".to_string(),
                         ..Default::default()
                     },
-                    bundle_offsets: Default::default()
+                    footer_offsets: Default::default()
                 },
                 checkpoint_delta: CheckpointDelta::from(1..3),
             })

--- a/quickwit-index/src/actors/publisher.rs
+++ b/quickwit-index/src/actors/publisher.rs
@@ -89,7 +89,7 @@ mod tests {
     use super::*;
     use quickwit_actors::Universe;
     use quickwit_metastore::checkpoint::CheckpointDelta;
-    use quickwit_metastore::{SplitMetadataAndFooterOffsets, MockMetastore, SplitMetadata};
+    use quickwit_metastore::{MockMetastore, SplitMetadata, SplitMetadataAndFooterOffsets};
     use tokio::sync::oneshot;
 
     #[tokio::test]
@@ -136,7 +136,7 @@ mod tests {
                         split_id: "split2".to_string(),
                         ..Default::default()
                     },
-                    footer_offsets: (1000..1200)
+                    footer_offsets: 1000..1200
                 },
                 checkpoint_delta: CheckpointDelta::from(3..7),
             })
@@ -149,7 +149,7 @@ mod tests {
                         split_id: "split1".to_string(),
                         ..Default::default()
                     },
-                    footer_offsets: Default::default()
+                    footer_offsets: 1000..1200
                 },
                 checkpoint_delta: CheckpointDelta::from(1..3),
             })

--- a/quickwit-index/src/actors/publisher.rs
+++ b/quickwit-index/src/actors/publisher.rs
@@ -89,7 +89,7 @@ mod tests {
     use super::*;
     use quickwit_actors::Universe;
     use quickwit_metastore::checkpoint::CheckpointDelta;
-    use quickwit_metastore::{BundleAndSplitMetadata, MockMetastore, SplitMetadata};
+    use quickwit_metastore::{SplitMetadataAndFooterOffsets, MockMetastore, SplitMetadata};
     use tokio::sync::oneshot;
 
     #[tokio::test]
@@ -131,7 +131,7 @@ mod tests {
         assert!(split_future_tx2
             .send(UploadedSplit {
                 index_id: "index".to_string(),
-                metadata: BundleAndSplitMetadata {
+                metadata: SplitMetadataAndFooterOffsets {
                     split_metadata: SplitMetadata {
                         split_id: "split2".to_string(),
                         ..Default::default()
@@ -144,7 +144,7 @@ mod tests {
         assert!(split_future_tx1
             .send(UploadedSplit {
                 index_id: "index".to_string(),
-                metadata: BundleAndSplitMetadata {
+                metadata: SplitMetadataAndFooterOffsets {
                     split_metadata: SplitMetadata {
                         split_id: "split1".to_string(),
                         ..Default::default()

--- a/quickwit-index/src/actors/uploader.rs
+++ b/quickwit-index/src/actors/uploader.rs
@@ -129,7 +129,7 @@ async fn put_split_files_to_storage(
     let elapsed_secs = start.elapsed().as_secs();
     let elapsed_ms = start.elapsed().as_millis();
     let file_statistics = split.file_statistics.clone();
-    let split_size_in_megabytes = split.bundle_offsets.bundle_file_size / 1000000;
+    let split_size_in_megabytes = split.footer_offsets.end / 1000000;
     let throughput_mb_s = split_size_in_megabytes as f32 / (elapsed_ms as f32 / 1000.0);
     info!(
         min_file_size_in_bytes = %file_statistics.min_file_size_in_bytes,
@@ -155,9 +155,8 @@ fn create_split_metadata(split: &PackagedSplit) -> SplitMetadataAndFooterOffsets
             split_state: SplitState::New,
             update_timestamp: Utc::now().timestamp(),
             tags: vec![], // TODO: handle tags collection and attaching to split
-            bundle_offsets: split.bundle_offsets.clone(),
         },
-        bundle_offsets: split.bundle_offsets.clone(),
+        footer_offsets: split.footer_offsets.clone(),
     }
 }
 
@@ -226,7 +225,6 @@ mod tests {
     use quickwit_actors::Universe;
     use quickwit_metastore::checkpoint::CheckpointDelta;
     use quickwit_metastore::MockMetastore;
-    use quickwit_storage::BundleStorageOffsets;
     use quickwit_storage::RamStorage;
 
     use super::*;
@@ -272,11 +270,7 @@ mod tests {
                     checkpoint_delta: CheckpointDelta::from(3..15),
                     time_range: Some(1_628_203_589i64..=1_628_203_640i64),
                     size_in_bytes: 1_000,
-                    bundle_offsets: BundleStorageOffsets {
-                        footer_offsets: 400..500,
-                        hotcache_offset_start: 300,
-                        bundle_file_size: 500,
-                    },
+                    footer_offsets: (1000..2000),
                     file_statistics: Default::default(),
                     segment_ids,
                     split_scratch_directory,

--- a/quickwit-index/src/actors/uploader.rs
+++ b/quickwit-index/src/actors/uploader.rs
@@ -34,7 +34,7 @@ use quickwit_actors::ActorExitStatus;
 use quickwit_actors::AsyncActor;
 use quickwit_actors::Mailbox;
 use quickwit_actors::QueueCapacity;
-use quickwit_metastore::BundleAndSplitMetadata;
+use quickwit_metastore::SplitMetadataAndFooterOffsets;
 use quickwit_metastore::Metastore;
 use quickwit_metastore::SplitMetadata;
 use quickwit_metastore::SplitState;
@@ -144,8 +144,8 @@ async fn put_split_files_to_storage(
     Ok(manifest)
 }
 
-fn create_split_metadata(split: &PackagedSplit) -> BundleAndSplitMetadata {
-    BundleAndSplitMetadata {
+fn create_split_metadata(split: &PackagedSplit) -> SplitMetadataAndFooterOffsets {
+    SplitMetadataAndFooterOffsets {
         split_metadata: SplitMetadata {
             split_id: split.split_id.clone(),
             num_records: split.num_docs as usize,

--- a/quickwit-index/src/models/packaged_split.rs
+++ b/quickwit-index/src/models/packaged_split.rs
@@ -21,7 +21,6 @@
 use crate::models::ScratchDirectory;
 use quickwit_metastore::checkpoint::CheckpointDelta;
 use std::ops::{Range, RangeInclusive};
-use std::ops::RangeInclusive;
 use tantivy::SegmentId;
 
 #[derive(Debug)]

--- a/quickwit-index/src/models/packaged_split.rs
+++ b/quickwit-index/src/models/packaged_split.rs
@@ -20,8 +20,8 @@
 
 use crate::models::ScratchDirectory;
 use quickwit_metastore::checkpoint::CheckpointDelta;
-use quickwit_storage::{BundleStorageOffsets, FileStatistics};
-use std::ops::RangeInclusive;
+use quickwit_storage::FileStatistics;
+use std::ops::{Range, RangeInclusive};
 use tantivy::SegmentId;
 
 #[derive(Debug)]
@@ -32,7 +32,7 @@ pub struct PackagedSplit {
     pub time_range: Option<RangeInclusive<i64>>,
     pub size_in_bytes: u64,
 
-    pub bundle_offsets: BundleStorageOffsets,
+    pub footer_offsets: Range<u64>,
     pub file_statistics: FileStatistics,
 
     pub segment_ids: Vec<SegmentId>,

--- a/quickwit-index/src/models/packaged_split.rs
+++ b/quickwit-index/src/models/packaged_split.rs
@@ -20,8 +20,8 @@
 
 use crate::models::ScratchDirectory;
 use quickwit_metastore::checkpoint::CheckpointDelta;
-use quickwit_storage::FileStatistics;
 use std::ops::{Range, RangeInclusive};
+use std::ops::RangeInclusive;
 use tantivy::SegmentId;
 
 #[derive(Debug)]
@@ -31,10 +31,7 @@ pub struct PackagedSplit {
     pub checkpoint_delta: CheckpointDelta,
     pub time_range: Option<RangeInclusive<i64>>,
     pub size_in_bytes: u64,
-
     pub footer_offsets: Range<u64>,
-    pub file_statistics: FileStatistics,
-
     pub segment_ids: Vec<SegmentId>,
     pub split_scratch_directory: ScratchDirectory,
     pub num_docs: u64,

--- a/quickwit-index/src/models/uploaded_split.rs
+++ b/quickwit-index/src/models/uploaded_split.rs
@@ -19,11 +19,11 @@
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use quickwit_metastore::checkpoint::CheckpointDelta;
-use quickwit_metastore::BundleAndSplitMetadata;
+use quickwit_metastore::SplitMetadataAndFooterOffsets;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct UploadedSplit {
     pub index_id: String,
-    pub metadata: BundleAndSplitMetadata,
+    pub metadata: SplitMetadataAndFooterOffsets,
     pub checkpoint_delta: CheckpointDelta,
 }

--- a/quickwit-metastore/src/lib.rs
+++ b/quickwit-metastore/src/lib.rs
@@ -36,7 +36,7 @@ mod metastore_resolver;
 pub use error::{MetastoreError, MetastoreResolverError, MetastoreResult};
 pub use metastore::single_file_metastore::SingleFileMetastore;
 pub use metastore::{
-    SplitMetadataAndFooterOffsets, IndexMetadata, MetadataSet, Metastore, SplitMetadata, SplitState,
+    IndexMetadata, MetadataSet, Metastore, SplitMetadata, SplitMetadataAndFooterOffsets, SplitState,
 };
 pub use metastore_resolver::{MetastoreFactory, MetastoreUriResolver};
 

--- a/quickwit-metastore/src/lib.rs
+++ b/quickwit-metastore/src/lib.rs
@@ -36,7 +36,7 @@ mod metastore_resolver;
 pub use error::{MetastoreError, MetastoreResolverError, MetastoreResult};
 pub use metastore::single_file_metastore::SingleFileMetastore;
 pub use metastore::{
-    BundleAndSplitMetadata, IndexMetadata, MetadataSet, Metastore, SplitMetadata, SplitState,
+    SplitMetadataAndFooterOffsets, IndexMetadata, MetadataSet, Metastore, SplitMetadata, SplitState,
 };
 pub use metastore_resolver::{MetastoreFactory, MetastoreUriResolver};
 

--- a/quickwit-metastore/src/metastore.rs
+++ b/quickwit-metastore/src/metastore.rs
@@ -220,8 +220,10 @@ pub trait Metastore: Send + Sync + 'static {
 
     /// Lists the splits without filtering.
     /// Returns a list of all splits currently known to the metastore regardless of their state.
-    async fn list_all_splits(&self, index_id: &str)
-        -> MetastoreResult<Vec<SplitMetadataAndFooterOffsets>>;
+    async fn list_all_splits(
+        &self,
+        index_id: &str,
+    ) -> MetastoreResult<Vec<SplitMetadataAndFooterOffsets>>;
 
     /// Marks a list of splits as deleted.
     /// This API will change the state to `ScheduledForDeletion` so that it is not referenced by the client.

--- a/quickwit-metastore/src/metastore.rs
+++ b/quickwit-metastore/src/metastore.rs
@@ -51,7 +51,7 @@ pub struct IndexMetadata {
 
 /// Carries split and bundle offsets for single read metadata.
 #[derive(Clone, Eq, PartialEq, Default, Debug, Serialize, Deserialize)]
-pub struct BundleAndSplitMetadata {
+pub struct SplitMetadataAndFooterOffsets {
     /// A split metadata carries all meta data about a split.
     pub split_metadata: SplitMetadata,
     /// Contains hotcache and footer offset used for single reads of hotcache and footer.
@@ -140,7 +140,7 @@ pub struct MetadataSet {
     /// Metadata specific to the index.
     pub index: IndexMetadata,
     /// List of splits belonging to the index.
-    pub splits: HashMap<String, BundleAndSplitMetadata>,
+    pub splits: HashMap<String, SplitMetadataAndFooterOffsets>,
 }
 
 /// Metastore meant to manage Quickwit's indexes and their splits.
@@ -195,7 +195,7 @@ pub trait Metastore: Send + Sync + 'static {
     async fn stage_split(
         &self,
         index_id: &str,
-        split_metadata: BundleAndSplitMetadata,
+        split_metadata: SplitMetadataAndFooterOffsets,
     ) -> MetastoreResult<()>;
 
     /// Publishes a list splits.
@@ -220,12 +220,12 @@ pub trait Metastore: Send + Sync + 'static {
         split_state: SplitState,
         time_range: Option<Range<i64>>,
         tags: &[String],
-    ) -> MetastoreResult<Vec<BundleAndSplitMetadata>>;
+    ) -> MetastoreResult<Vec<SplitMetadataAndFooterOffsets>>;
 
     /// Lists the splits without filtering.
     /// Returns a list of all splits currently known to the metastore regardless of their state.
     async fn list_all_splits(&self, index_id: &str)
-        -> MetastoreResult<Vec<BundleAndSplitMetadata>>;
+        -> MetastoreResult<Vec<SplitMetadataAndFooterOffsets>>;
 
     /// Marks a list of splits as deleted.
     /// This API will change the state to `ScheduledForDeletion` so that it is not referenced by the client.

--- a/quickwit-metastore/src/metastore/single_file_metastore.rs
+++ b/quickwit-metastore/src/metastore/single_file_metastore.rs
@@ -33,7 +33,7 @@ use quickwit_storage::{PutPayload, Storage, StorageErrorKind};
 
 use crate::checkpoint::CheckpointDelta;
 use crate::{
-    BundleAndSplitMetadata, IndexMetadata, MetadataSet, Metastore, MetastoreError, MetastoreResult,
+    SplitMetadataAndFooterOffsets, IndexMetadata, MetadataSet, Metastore, MetastoreError, MetastoreResult,
     SplitMetadata, SplitState,
 };
 
@@ -233,7 +233,7 @@ impl Metastore for SingleFileMetastore {
     async fn stage_split(
         &self,
         index_id: &str,
-        mut metadata: BundleAndSplitMetadata,
+        mut metadata: SplitMetadataAndFooterOffsets,
     ) -> MetastoreResult<()> {
         let mut metadata_set = self.get_index(index_id).await?;
 
@@ -311,7 +311,7 @@ impl Metastore for SingleFileMetastore {
         state: SplitState,
         time_range_opt: Option<Range<i64>>,
         tags: &[String],
-    ) -> MetastoreResult<Vec<BundleAndSplitMetadata>> {
+    ) -> MetastoreResult<Vec<SplitMetadataAndFooterOffsets>> {
         let time_range_filter = |split_metadata: &SplitMetadata| match (
             time_range_opt.as_ref(),
             split_metadata.time_range.as_ref(),
@@ -350,7 +350,7 @@ impl Metastore for SingleFileMetastore {
     async fn list_all_splits(
         &self,
         index_id: &str,
-    ) -> MetastoreResult<Vec<BundleAndSplitMetadata>> {
+    ) -> MetastoreResult<Vec<SplitMetadataAndFooterOffsets>> {
         let metadata_set = self.get_index(index_id).await?;
         let splits = metadata_set.splits.into_values().collect();
         Ok(splits)

--- a/quickwit-metastore/src/metastore/single_file_metastore.rs
+++ b/quickwit-metastore/src/metastore/single_file_metastore.rs
@@ -33,8 +33,8 @@ use quickwit_storage::{PutPayload, Storage, StorageErrorKind};
 
 use crate::checkpoint::CheckpointDelta;
 use crate::{
-    SplitMetadataAndFooterOffsets, IndexMetadata, MetadataSet, Metastore, MetastoreError, MetastoreResult,
-    SplitMetadata, SplitState,
+    IndexMetadata, MetadataSet, Metastore, MetastoreError, MetastoreResult, SplitMetadata,
+    SplitMetadataAndFooterOffsets, SplitState,
 };
 
 /// Metadata file managed by [`SingleFileMetastore`].

--- a/quickwit-metastore/src/tests.rs
+++ b/quickwit-metastore/src/tests.rs
@@ -31,7 +31,8 @@ use quickwit_index_config::AllFlattenIndexConfig;
 
 use crate::checkpoint::{Checkpoint, CheckpointDelta};
 use crate::{
-    SplitMetadataAndFooterOffsets, IndexMetadata, Metastore, MetastoreError, SplitMetadata, SplitState,
+    IndexMetadata, Metastore, MetastoreError, SplitMetadata, SplitMetadataAndFooterOffsets,
+    SplitState,
 };
 
 pub async fn test_metastore_create_index(metastore: &dyn Metastore) {
@@ -56,7 +57,6 @@ pub async fn test_metastore_create_index(metastore: &dyn Metastore) {
         .await
         .unwrap_err();
     assert!(matches!(result, MetastoreError::IndexAlreadyExists { .. }));
-    ;
     // Delete an index
     let result = metastore.delete_index(index_id).await.unwrap();
     assert!(matches!(result, ()));
@@ -142,7 +142,7 @@ pub async fn test_metastore_stage_split(metastore: &dyn Metastore) {
             update_timestamp: current_timestamp,
             ..Default::default()
         },
-        footer_offsets: (1000..2000)
+        footer_offsets: 1000..2000,
     };
 
     // Stage a split on a non-existent index
@@ -187,7 +187,7 @@ pub async fn test_metastore_publish_splits(metastore: &dyn Metastore) {
 
     let split_id_1 = "one";
     let split_metadata_1 = SplitMetadataAndFooterOffsets {
-        footer_offsets: (1000..2000),
+        footer_offsets: 1000..2000,
         split_metadata: SplitMetadata {
             split_id: split_id_1.to_string(),
             split_state: SplitState::Staged,
@@ -202,7 +202,7 @@ pub async fn test_metastore_publish_splits(metastore: &dyn Metastore) {
 
     let split_id_2 = "two";
     let split_metadata_2 = SplitMetadataAndFooterOffsets {
-        footer_offsets: (1000..2000),
+        footer_offsets: 1000..2000,
         split_metadata: SplitMetadata {
             split_id: split_id_2.to_string(),
             split_state: SplitState::Staged,
@@ -580,7 +580,7 @@ pub async fn test_metastore_mark_splits_as_deleted(metastore: &dyn Metastore) {
 
     let split_id_1 = "one";
     let split_metadata_1 = SplitMetadataAndFooterOffsets {
-        footer_offsets: (1000..2000),
+        footer_offsets: 1000..2000,
         split_metadata: SplitMetadata {
             split_id: split_id_1.to_string(),
             split_state: SplitState::Staged,
@@ -658,7 +658,7 @@ pub async fn test_metastore_delete_splits(metastore: &dyn Metastore) {
 
     let split_id_1 = "one";
     let split_metadata_1 = SplitMetadataAndFooterOffsets {
-        footer_offsets: (1000..2000),
+        footer_offsets: 1000..2000,
         split_metadata: SplitMetadata {
             split_id: split_id_1.to_string(),
             split_state: SplitState::Staged,
@@ -796,7 +796,7 @@ pub async fn test_metastore_list_all_splits(metastore: &dyn Metastore) {
 
     let split_id_1 = "one";
     let split_metadata_1 = SplitMetadataAndFooterOffsets {
-        footer_offsets: (1000..2000),
+        footer_offsets: 1000..2000,
         split_metadata: SplitMetadata {
             split_id: split_id_1.to_string(),
             split_state: SplitState::Staged,
@@ -810,7 +810,7 @@ pub async fn test_metastore_list_all_splits(metastore: &dyn Metastore) {
     };
 
     let split_metadata_2 = SplitMetadataAndFooterOffsets {
-        footer_offsets: (1000..2000),
+        footer_offsets: 1000..2000,
         split_metadata: SplitMetadata {
             split_id: "two".to_string(),
             split_state: SplitState::Staged,
@@ -824,7 +824,7 @@ pub async fn test_metastore_list_all_splits(metastore: &dyn Metastore) {
     };
 
     let split_metadata_3 = SplitMetadataAndFooterOffsets {
-        footer_offsets: (1000..2000),
+        footer_offsets: 1000..2000,
         split_metadata: SplitMetadata {
             split_id: "three".to_string(),
             split_state: SplitState::Staged,
@@ -838,7 +838,7 @@ pub async fn test_metastore_list_all_splits(metastore: &dyn Metastore) {
     };
 
     let split_metadata_4 = SplitMetadataAndFooterOffsets {
-        footer_offsets: (1000..2000),
+        footer_offsets: 1000..2000,
         split_metadata: SplitMetadata {
             split_id: "four".to_string(),
             split_state: SplitState::Staged,
@@ -852,7 +852,7 @@ pub async fn test_metastore_list_all_splits(metastore: &dyn Metastore) {
     };
 
     let split_metadata_5 = SplitMetadataAndFooterOffsets {
-        footer_offsets: (1000..2000),
+        footer_offsets: 1000..2000,
         split_metadata: SplitMetadata {
             split_id: "five".to_string(),
             split_state: SplitState::Staged,
@@ -941,7 +941,7 @@ pub async fn test_metastore_list_splits(metastore: &dyn Metastore) {
 
     let split_id_1 = "one";
     let split_metadata_1 = SplitMetadataAndFooterOffsets {
-        footer_offsets: (1000..2000),
+        footer_offsets: 1000..2000,
         split_metadata: SplitMetadata {
             split_id: split_id_1.to_string(),
             split_state: SplitState::Staged,
@@ -951,12 +951,11 @@ pub async fn test_metastore_list_splits(metastore: &dyn Metastore) {
             generation: 3,
             update_timestamp: current_timestamp,
             tags: vec!["foo".to_string(), "bar".to_string()],
-            ..Default::default()
         },
     };
 
     let split_metadata_2 = SplitMetadataAndFooterOffsets {
-        footer_offsets: (1000..2000),
+        footer_offsets: 1000..2000,
         split_metadata: SplitMetadata {
             split_id: "two".to_string(),
             split_state: SplitState::Staged,
@@ -966,12 +965,11 @@ pub async fn test_metastore_list_splits(metastore: &dyn Metastore) {
             generation: 3,
             update_timestamp: current_timestamp,
             tags: vec!["bar".to_string()],
-            ..Default::default()
         },
     };
 
     let split_metadata_3 = SplitMetadataAndFooterOffsets {
-        footer_offsets: (1000..2000),
+        footer_offsets: 1000..2000,
         split_metadata: SplitMetadata {
             split_id: "three".to_string(),
             split_state: SplitState::Staged,
@@ -981,12 +979,11 @@ pub async fn test_metastore_list_splits(metastore: &dyn Metastore) {
             generation: 3,
             update_timestamp: current_timestamp,
             tags: vec!["foo".to_string(), "baz".to_string()],
-            ..Default::default()
         },
     };
 
     let split_metadata_4 = SplitMetadataAndFooterOffsets {
-        footer_offsets: (1000..2000),
+        footer_offsets: 1000..2000,
         split_metadata: SplitMetadata {
             split_id: "four".to_string(),
             split_state: SplitState::Staged,
@@ -996,12 +993,11 @@ pub async fn test_metastore_list_splits(metastore: &dyn Metastore) {
             generation: 3,
             update_timestamp: current_timestamp,
             tags: vec!["foo".to_string()],
-            ..Default::default()
         },
     };
 
     let split_metadata_5 = SplitMetadataAndFooterOffsets {
-        footer_offsets: (1000..2000),
+        footer_offsets: 1000..2000,
         split_metadata: SplitMetadata {
             split_id: "five".to_string(),
             split_state: SplitState::Staged,
@@ -1011,7 +1007,6 @@ pub async fn test_metastore_list_splits(metastore: &dyn Metastore) {
             generation: 3,
             update_timestamp: current_timestamp,
             tags: vec!["baz".to_string(), "biz".to_string()],
-            ..Default::default()
         },
     };
 
@@ -1483,7 +1478,7 @@ pub async fn test_metastore_split_update_timestamp(metastore: &dyn Metastore) {
 
     let split_id = "one";
     let split_metadata = SplitMetadataAndFooterOffsets {
-        footer_offsets: (1000..2000),
+        footer_offsets: 1000..2000,
         split_metadata: SplitMetadata {
             split_id: split_id.to_string(),
             split_state: SplitState::Staged,
@@ -1551,7 +1546,7 @@ pub async fn test_metastore_storage_failing(metastore: &dyn Metastore) {
 
     let split_id = "one";
     let split_metadata = SplitMetadataAndFooterOffsets {
-        footer_offsets: (1000..2000),
+        footer_offsets: 1000..2000,
         split_metadata: SplitMetadata {
             split_id: split_id.to_string(),
             split_state: SplitState::Staged,

--- a/quickwit-metastore/src/tests.rs
+++ b/quickwit-metastore/src/tests.rs
@@ -56,7 +56,7 @@ pub async fn test_metastore_create_index(metastore: &dyn Metastore) {
         .await
         .unwrap_err();
     assert!(matches!(result, MetastoreError::IndexAlreadyExists { .. }));
-
+    ;
     // Delete an index
     let result = metastore.delete_index(index_id).await.unwrap();
     assert!(matches!(result, ()));
@@ -132,7 +132,6 @@ pub async fn test_metastore_stage_split(metastore: &dyn Metastore) {
 
     let split_id = "one";
     let split_metadata = SplitMetadataAndFooterOffsets {
-        bundle_offsets: Default::default(),
         split_metadata: SplitMetadata {
             split_id: split_id.to_string(),
             split_state: SplitState::Staged,
@@ -143,6 +142,7 @@ pub async fn test_metastore_stage_split(metastore: &dyn Metastore) {
             update_timestamp: current_timestamp,
             ..Default::default()
         },
+        footer_offsets: (1000..2000)
     };
 
     // Stage a split on a non-existent index
@@ -187,7 +187,7 @@ pub async fn test_metastore_publish_splits(metastore: &dyn Metastore) {
 
     let split_id_1 = "one";
     let split_metadata_1 = SplitMetadataAndFooterOffsets {
-        bundle_offsets: Default::default(),
+        footer_offsets: (1000..2000),
         split_metadata: SplitMetadata {
             split_id: split_id_1.to_string(),
             split_state: SplitState::Staged,
@@ -202,7 +202,7 @@ pub async fn test_metastore_publish_splits(metastore: &dyn Metastore) {
 
     let split_id_2 = "two";
     let split_metadata_2 = SplitMetadataAndFooterOffsets {
-        bundle_offsets: Default::default(),
+        footer_offsets: (1000..2000),
         split_metadata: SplitMetadata {
             split_id: split_id_2.to_string(),
             split_state: SplitState::Staged,
@@ -580,7 +580,7 @@ pub async fn test_metastore_mark_splits_as_deleted(metastore: &dyn Metastore) {
 
     let split_id_1 = "one";
     let split_metadata_1 = SplitMetadataAndFooterOffsets {
-        bundle_offsets: Default::default(),
+        footer_offsets: (1000..2000),
         split_metadata: SplitMetadata {
             split_id: split_id_1.to_string(),
             split_state: SplitState::Staged,
@@ -658,7 +658,7 @@ pub async fn test_metastore_delete_splits(metastore: &dyn Metastore) {
 
     let split_id_1 = "one";
     let split_metadata_1 = SplitMetadataAndFooterOffsets {
-        bundle_offsets: Default::default(),
+        footer_offsets: (1000..2000),
         split_metadata: SplitMetadata {
             split_id: split_id_1.to_string(),
             split_state: SplitState::Staged,
@@ -796,7 +796,7 @@ pub async fn test_metastore_list_all_splits(metastore: &dyn Metastore) {
 
     let split_id_1 = "one";
     let split_metadata_1 = SplitMetadataAndFooterOffsets {
-        bundle_offsets: Default::default(),
+        footer_offsets: (1000..2000),
         split_metadata: SplitMetadata {
             split_id: split_id_1.to_string(),
             split_state: SplitState::Staged,
@@ -810,7 +810,7 @@ pub async fn test_metastore_list_all_splits(metastore: &dyn Metastore) {
     };
 
     let split_metadata_2 = SplitMetadataAndFooterOffsets {
-        bundle_offsets: Default::default(),
+        footer_offsets: (1000..2000),
         split_metadata: SplitMetadata {
             split_id: "two".to_string(),
             split_state: SplitState::Staged,
@@ -824,7 +824,7 @@ pub async fn test_metastore_list_all_splits(metastore: &dyn Metastore) {
     };
 
     let split_metadata_3 = SplitMetadataAndFooterOffsets {
-        bundle_offsets: Default::default(),
+        footer_offsets: (1000..2000),
         split_metadata: SplitMetadata {
             split_id: "three".to_string(),
             split_state: SplitState::Staged,
@@ -838,7 +838,7 @@ pub async fn test_metastore_list_all_splits(metastore: &dyn Metastore) {
     };
 
     let split_metadata_4 = SplitMetadataAndFooterOffsets {
-        bundle_offsets: Default::default(),
+        footer_offsets: (1000..2000),
         split_metadata: SplitMetadata {
             split_id: "four".to_string(),
             split_state: SplitState::Staged,
@@ -852,7 +852,7 @@ pub async fn test_metastore_list_all_splits(metastore: &dyn Metastore) {
     };
 
     let split_metadata_5 = SplitMetadataAndFooterOffsets {
-        bundle_offsets: Default::default(),
+        footer_offsets: (1000..2000),
         split_metadata: SplitMetadata {
             split_id: "five".to_string(),
             split_state: SplitState::Staged,
@@ -941,7 +941,7 @@ pub async fn test_metastore_list_splits(metastore: &dyn Metastore) {
 
     let split_id_1 = "one";
     let split_metadata_1 = SplitMetadataAndFooterOffsets {
-        bundle_offsets: Default::default(),
+        footer_offsets: (1000..2000),
         split_metadata: SplitMetadata {
             split_id: split_id_1.to_string(),
             split_state: SplitState::Staged,
@@ -956,7 +956,7 @@ pub async fn test_metastore_list_splits(metastore: &dyn Metastore) {
     };
 
     let split_metadata_2 = SplitMetadataAndFooterOffsets {
-        bundle_offsets: Default::default(),
+        footer_offsets: (1000..2000),
         split_metadata: SplitMetadata {
             split_id: "two".to_string(),
             split_state: SplitState::Staged,
@@ -971,7 +971,7 @@ pub async fn test_metastore_list_splits(metastore: &dyn Metastore) {
     };
 
     let split_metadata_3 = SplitMetadataAndFooterOffsets {
-        bundle_offsets: Default::default(),
+        footer_offsets: (1000..2000),
         split_metadata: SplitMetadata {
             split_id: "three".to_string(),
             split_state: SplitState::Staged,
@@ -986,7 +986,7 @@ pub async fn test_metastore_list_splits(metastore: &dyn Metastore) {
     };
 
     let split_metadata_4 = SplitMetadataAndFooterOffsets {
-        bundle_offsets: Default::default(),
+        footer_offsets: (1000..2000),
         split_metadata: SplitMetadata {
             split_id: "four".to_string(),
             split_state: SplitState::Staged,
@@ -1001,7 +1001,7 @@ pub async fn test_metastore_list_splits(metastore: &dyn Metastore) {
     };
 
     let split_metadata_5 = SplitMetadataAndFooterOffsets {
-        bundle_offsets: Default::default(),
+        footer_offsets: (1000..2000),
         split_metadata: SplitMetadata {
             split_id: "five".to_string(),
             split_state: SplitState::Staged,
@@ -1483,7 +1483,7 @@ pub async fn test_metastore_split_update_timestamp(metastore: &dyn Metastore) {
 
     let split_id = "one";
     let split_metadata = SplitMetadataAndFooterOffsets {
-        bundle_offsets: Default::default(),
+        footer_offsets: (1000..2000),
         split_metadata: SplitMetadata {
             split_id: split_id.to_string(),
             split_state: SplitState::Staged,
@@ -1551,7 +1551,7 @@ pub async fn test_metastore_storage_failing(metastore: &dyn Metastore) {
 
     let split_id = "one";
     let split_metadata = SplitMetadataAndFooterOffsets {
-        bundle_offsets: Default::default(),
+        footer_offsets: (1000..2000),
         split_metadata: SplitMetadata {
             split_id: split_id.to_string(),
             split_state: SplitState::Staged,

--- a/quickwit-metastore/src/tests.rs
+++ b/quickwit-metastore/src/tests.rs
@@ -31,7 +31,7 @@ use quickwit_index_config::AllFlattenIndexConfig;
 
 use crate::checkpoint::{Checkpoint, CheckpointDelta};
 use crate::{
-    BundleAndSplitMetadata, IndexMetadata, Metastore, MetastoreError, SplitMetadata, SplitState,
+    SplitMetadataAndFooterOffsets, IndexMetadata, Metastore, MetastoreError, SplitMetadata, SplitState,
 };
 
 pub async fn test_metastore_create_index(metastore: &dyn Metastore) {
@@ -131,7 +131,7 @@ pub async fn test_metastore_stage_split(metastore: &dyn Metastore) {
     };
 
     let split_id = "one";
-    let split_metadata = BundleAndSplitMetadata {
+    let split_metadata = SplitMetadataAndFooterOffsets {
         bundle_offsets: Default::default(),
         split_metadata: SplitMetadata {
             split_id: split_id.to_string(),
@@ -186,7 +186,7 @@ pub async fn test_metastore_publish_splits(metastore: &dyn Metastore) {
     };
 
     let split_id_1 = "one";
-    let split_metadata_1 = BundleAndSplitMetadata {
+    let split_metadata_1 = SplitMetadataAndFooterOffsets {
         bundle_offsets: Default::default(),
         split_metadata: SplitMetadata {
             split_id: split_id_1.to_string(),
@@ -201,7 +201,7 @@ pub async fn test_metastore_publish_splits(metastore: &dyn Metastore) {
     };
 
     let split_id_2 = "two";
-    let split_metadata_2 = BundleAndSplitMetadata {
+    let split_metadata_2 = SplitMetadataAndFooterOffsets {
         bundle_offsets: Default::default(),
         split_metadata: SplitMetadata {
             split_id: split_id_2.to_string(),
@@ -579,7 +579,7 @@ pub async fn test_metastore_mark_splits_as_deleted(metastore: &dyn Metastore) {
     };
 
     let split_id_1 = "one";
-    let split_metadata_1 = BundleAndSplitMetadata {
+    let split_metadata_1 = SplitMetadataAndFooterOffsets {
         bundle_offsets: Default::default(),
         split_metadata: SplitMetadata {
             split_id: split_id_1.to_string(),
@@ -657,7 +657,7 @@ pub async fn test_metastore_delete_splits(metastore: &dyn Metastore) {
     };
 
     let split_id_1 = "one";
-    let split_metadata_1 = BundleAndSplitMetadata {
+    let split_metadata_1 = SplitMetadataAndFooterOffsets {
         bundle_offsets: Default::default(),
         split_metadata: SplitMetadata {
             split_id: split_id_1.to_string(),
@@ -795,7 +795,7 @@ pub async fn test_metastore_list_all_splits(metastore: &dyn Metastore) {
     };
 
     let split_id_1 = "one";
-    let split_metadata_1 = BundleAndSplitMetadata {
+    let split_metadata_1 = SplitMetadataAndFooterOffsets {
         bundle_offsets: Default::default(),
         split_metadata: SplitMetadata {
             split_id: split_id_1.to_string(),
@@ -809,7 +809,7 @@ pub async fn test_metastore_list_all_splits(metastore: &dyn Metastore) {
         },
     };
 
-    let split_metadata_2 = BundleAndSplitMetadata {
+    let split_metadata_2 = SplitMetadataAndFooterOffsets {
         bundle_offsets: Default::default(),
         split_metadata: SplitMetadata {
             split_id: "two".to_string(),
@@ -823,7 +823,7 @@ pub async fn test_metastore_list_all_splits(metastore: &dyn Metastore) {
         },
     };
 
-    let split_metadata_3 = BundleAndSplitMetadata {
+    let split_metadata_3 = SplitMetadataAndFooterOffsets {
         bundle_offsets: Default::default(),
         split_metadata: SplitMetadata {
             split_id: "three".to_string(),
@@ -837,7 +837,7 @@ pub async fn test_metastore_list_all_splits(metastore: &dyn Metastore) {
         },
     };
 
-    let split_metadata_4 = BundleAndSplitMetadata {
+    let split_metadata_4 = SplitMetadataAndFooterOffsets {
         bundle_offsets: Default::default(),
         split_metadata: SplitMetadata {
             split_id: "four".to_string(),
@@ -851,7 +851,7 @@ pub async fn test_metastore_list_all_splits(metastore: &dyn Metastore) {
         },
     };
 
-    let split_metadata_5 = BundleAndSplitMetadata {
+    let split_metadata_5 = SplitMetadataAndFooterOffsets {
         bundle_offsets: Default::default(),
         split_metadata: SplitMetadata {
             split_id: "five".to_string(),
@@ -940,7 +940,7 @@ pub async fn test_metastore_list_splits(metastore: &dyn Metastore) {
     };
 
     let split_id_1 = "one";
-    let split_metadata_1 = BundleAndSplitMetadata {
+    let split_metadata_1 = SplitMetadataAndFooterOffsets {
         bundle_offsets: Default::default(),
         split_metadata: SplitMetadata {
             split_id: split_id_1.to_string(),
@@ -955,7 +955,7 @@ pub async fn test_metastore_list_splits(metastore: &dyn Metastore) {
         },
     };
 
-    let split_metadata_2 = BundleAndSplitMetadata {
+    let split_metadata_2 = SplitMetadataAndFooterOffsets {
         bundle_offsets: Default::default(),
         split_metadata: SplitMetadata {
             split_id: "two".to_string(),
@@ -970,7 +970,7 @@ pub async fn test_metastore_list_splits(metastore: &dyn Metastore) {
         },
     };
 
-    let split_metadata_3 = BundleAndSplitMetadata {
+    let split_metadata_3 = SplitMetadataAndFooterOffsets {
         bundle_offsets: Default::default(),
         split_metadata: SplitMetadata {
             split_id: "three".to_string(),
@@ -985,7 +985,7 @@ pub async fn test_metastore_list_splits(metastore: &dyn Metastore) {
         },
     };
 
-    let split_metadata_4 = BundleAndSplitMetadata {
+    let split_metadata_4 = SplitMetadataAndFooterOffsets {
         bundle_offsets: Default::default(),
         split_metadata: SplitMetadata {
             split_id: "four".to_string(),
@@ -1000,7 +1000,7 @@ pub async fn test_metastore_list_splits(metastore: &dyn Metastore) {
         },
     };
 
-    let split_metadata_5 = BundleAndSplitMetadata {
+    let split_metadata_5 = SplitMetadataAndFooterOffsets {
         bundle_offsets: Default::default(),
         split_metadata: SplitMetadata {
             split_id: "five".to_string(),
@@ -1482,7 +1482,7 @@ pub async fn test_metastore_split_update_timestamp(metastore: &dyn Metastore) {
     };
 
     let split_id = "one";
-    let split_metadata = BundleAndSplitMetadata {
+    let split_metadata = SplitMetadataAndFooterOffsets {
         bundle_offsets: Default::default(),
         split_metadata: SplitMetadata {
             split_id: split_id.to_string(),
@@ -1550,7 +1550,7 @@ pub async fn test_metastore_storage_failing(metastore: &dyn Metastore) {
     };
 
     let split_id = "one";
-    let split_metadata = BundleAndSplitMetadata {
+    let split_metadata = SplitMetadataAndFooterOffsets {
         bundle_offsets: Default::default(),
         split_metadata: SplitMetadata {
             split_id: split_id.to_string(),

--- a/quickwit-search/src/lib.rs
+++ b/quickwit-search/src/lib.rs
@@ -48,7 +48,7 @@ use anyhow::Context;
 use tantivy::DocAddress;
 
 use quickwit_metastore::SplitState;
-use quickwit_metastore::{BundleAndSplitMetadata, Metastore, MetastoreResult};
+use quickwit_metastore::{SplitMetadataAndFooterOffsets, Metastore, MetastoreResult};
 use quickwit_proto::SearchRequest;
 use quickwit_proto::{PartialHit, SearchResult};
 use quickwit_storage::StorageUriResolver;
@@ -130,7 +130,7 @@ fn extract_time_range(search_request: &SearchRequest) -> Option<Range<i64>> {
 async fn list_relevant_splits(
     search_request: &SearchRequest,
     metastore: &dyn Metastore,
-) -> MetastoreResult<Vec<BundleAndSplitMetadata>> {
+) -> MetastoreResult<Vec<SplitMetadataAndFooterOffsets>> {
     let time_range_opt = extract_time_range(search_request);
     let split_metas = metastore
         .list_splits(

--- a/quickwit-search/src/lib.rs
+++ b/quickwit-search/src/lib.rs
@@ -48,7 +48,7 @@ use anyhow::Context;
 use tantivy::DocAddress;
 
 use quickwit_metastore::SplitState;
-use quickwit_metastore::{SplitMetadataAndFooterOffsets, Metastore, MetastoreResult};
+use quickwit_metastore::{Metastore, MetastoreResult, SplitMetadataAndFooterOffsets};
 use quickwit_proto::SearchRequest;
 use quickwit_proto::{PartialHit, SearchResult};
 use quickwit_storage::StorageUriResolver;

--- a/quickwit-search/src/root.rs
+++ b/quickwit-search/src/root.rs
@@ -437,13 +437,13 @@ mod tests {
 
     use crate::{MockSearchService, SearchResultJson};
     use quickwit_index_config::WikipediaIndexConfig;
-    use quickwit_metastore::BundleAndSplitMetadata;
+    use quickwit_metastore::SplitMetadataAndFooterOffsets;
     use quickwit_metastore::{checkpoint::Checkpoint, IndexMetadata, MockMetastore, SplitState};
     use quickwit_proto::SplitSearchError;
     use quickwit_storage::BundleStorageOffsets;
 
-    fn mock_split_meta(split_id: &str) -> BundleAndSplitMetadata {
-        BundleAndSplitMetadata {
+    fn mock_split_meta(split_id: &str) -> SplitMetadataAndFooterOffsets {
+        SplitMetadataAndFooterOffsets {
             bundle_offsets: Default::default(),
             split_metadata: SplitMetadata {
                 split_id: split_id.to_string(),

--- a/quickwit-search/src/root.rs
+++ b/quickwit-search/src/root.rs
@@ -440,11 +440,10 @@ mod tests {
     use quickwit_metastore::SplitMetadataAndFooterOffsets;
     use quickwit_metastore::{checkpoint::Checkpoint, IndexMetadata, MockMetastore, SplitState};
     use quickwit_proto::SplitSearchError;
-    use quickwit_storage::BundleStorageOffsets;
 
     fn mock_split_meta(split_id: &str) -> SplitMetadataAndFooterOffsets {
         SplitMetadataAndFooterOffsets {
-            bundle_offsets: Default::default(),
+            footer_offsets: Default::default(),
             split_metadata: SplitMetadata {
                 split_id: split_id.to_string(),
                 split_state: SplitState::Published,

--- a/quickwit-search/src/root.rs
+++ b/quickwit-search/src/root.rs
@@ -454,11 +454,6 @@ mod tests {
                 generation: 1,
                 update_timestamp: 0,
                 tags: vec!["foo".to_string()],
-                bundle_offsets: BundleStorageOffsets {
-                    footer_offsets: 700..800,
-                    hotcache_offset_start: 1234,
-                    bundle_file_size: 9001,
-                },
             },
         }
     }

--- a/quickwit-search/src/search_stream/root.rs
+++ b/quickwit-search/src/search_stream/root.rs
@@ -135,7 +135,7 @@ mod tests {
 
     fn mock_split_meta(split_id: &str) -> SplitMetadataAndFooterOffsets {
         SplitMetadataAndFooterOffsets {
-            bundle_offsets: Default::default(),
+            footer_offsets: Default::default(),
             split_metadata: SplitMetadata {
                 split_id: split_id.to_string(),
                 split_state: SplitState::Published,

--- a/quickwit-search/src/search_stream/root.rs
+++ b/quickwit-search/src/search_stream/root.rs
@@ -127,15 +127,15 @@ mod tests {
     use crate::MockSearchService;
     use quickwit_index_config::WikipediaIndexConfig;
     use quickwit_metastore::{
-        checkpoint::Checkpoint, SplitMetadataAndFooterOffsets, IndexMetadata, MockMetastore, SplitState,
+        checkpoint::Checkpoint, IndexMetadata, MockMetastore, SplitMetadataAndFooterOffsets,
+        SplitState,
     };
     use quickwit_proto::OutputFormat;
-    use quickwit_storage::BundleStorageOffsets;
     use tokio_stream::wrappers::UnboundedReceiverStream;
 
     fn mock_split_meta(split_id: &str) -> SplitMetadataAndFooterOffsets {
         SplitMetadataAndFooterOffsets {
-            footer_offsets: Default::default(),
+            footer_offsets: 700..800,
             split_metadata: SplitMetadata {
                 split_id: split_id.to_string(),
                 split_state: SplitState::Published,
@@ -145,11 +145,6 @@ mod tests {
                 generation: 1,
                 update_timestamp: 0,
                 tags: vec![],
-                bundle_offsets: BundleStorageOffsets {
-                    footer_offsets: 700..800,
-                    hotcache_offset_start: 1234,
-                    bundle_file_size: 9001,
-                },
             },
         }
     }

--- a/quickwit-search/src/search_stream/root.rs
+++ b/quickwit-search/src/search_stream/root.rs
@@ -127,14 +127,14 @@ mod tests {
     use crate::MockSearchService;
     use quickwit_index_config::WikipediaIndexConfig;
     use quickwit_metastore::{
-        checkpoint::Checkpoint, BundleAndSplitMetadata, IndexMetadata, MockMetastore, SplitState,
+        checkpoint::Checkpoint, SplitMetadataAndFooterOffsets, IndexMetadata, MockMetastore, SplitState,
     };
     use quickwit_proto::OutputFormat;
     use quickwit_storage::BundleStorageOffsets;
     use tokio_stream::wrappers::UnboundedReceiverStream;
 
-    fn mock_split_meta(split_id: &str) -> BundleAndSplitMetadata {
-        BundleAndSplitMetadata {
+    fn mock_split_meta(split_id: &str) -> SplitMetadataAndFooterOffsets {
+        SplitMetadataAndFooterOffsets {
             bundle_offsets: Default::default(),
             split_metadata: SplitMetadata {
                 split_id: split_id.to_string(),

--- a/quickwit-storage/src/lib.rs
+++ b/quickwit-storage/src/lib.rs
@@ -45,9 +45,7 @@ mod ram_storage;
 mod retry;
 mod storage_resolver;
 
-pub use self::bundle_storage::{
-    BundleStorage, BundleStorageBuilder, BundleStorageOffsets, BUNDLE_FILENAME,
-};
+pub use self::bundle_storage::{BundleStorage, BundleStorageBuilder, BUNDLE_FILENAME};
 pub use self::local_file_storage::{LocalFileStorage, LocalFileStorageFactory};
 pub use self::object_storage::{
     MultiPartPolicy, S3CompatibleObjectStorage, S3CompatibleObjectStorageFactory,
@@ -58,11 +56,11 @@ pub use self::storage_resolver::{localstack_region, StorageFactory, StorageUriRe
 pub use crate::cache::{Cache, SliceCache, StorageWithCacheFactory};
 pub use crate::error::{StorageError, StorageErrorKind, StorageResolverError, StorageResult};
 
-#[cfg(feature = "testsuite")]
+#[cfg(any(test, feature = "testsuite"))]
 pub use self::cache::MockCache;
-#[cfg(feature = "testsuite")]
+#[cfg(any(test, feature = "testsuite"))]
 pub use self::storage::MockStorage;
-#[cfg(feature = "testsuite")]
+#[cfg(any(test, feature = "testsuite"))]
 pub use self::storage_resolver::MockStorageFactory;
 
 #[cfg(feature = "testsuite")]

--- a/quickwit-storage/src/lib.rs
+++ b/quickwit-storage/src/lib.rs
@@ -46,7 +46,7 @@ mod retry;
 mod storage_resolver;
 
 pub use self::bundle_storage::{
-    BundleStorage, BundleStorageBuilder, BundleStorageOffsets, FileStatistics, BUNDLE_FILENAME,
+    BundleStorage, BundleStorageBuilder, BundleStorageOffsets, BUNDLE_FILENAME,
 };
 pub use self::local_file_storage::{LocalFileStorage, LocalFileStorageFactory};
 pub use self::object_storage::{


### PR DESCRIPTION
### Context / purpose

This PR refactors the organisation of the split file.
The split file is now the concatenation

- concatenated files (does not contain hotcache anymore)
- FOOTER - bundle meta data (file offsets)
- FOOTER - bundle meta data len
- FOOTER - hotcache
- FOOTER - hotcache len

The element marked footer are what we need to download in order to open a split in one fetch.