### PR TITLE
Add tracing with jaeger

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,3 +30,10 @@ The process is simple and fast. Upon your first pull request, you will be prompt
 3. Install awslocal https://github.com/localstack/awscli-local
 4. Prepare s3 bucket used in tests, execute `./quickwit-cli/tests/prepare_tests.sh`
 5. `QUICKWIT_ENV=LOCAL cargo test --all-features`
+
+## Tracing with jaeger
+1. Start a jaeger instance
+```bash
+make jaeger-start
+```
+2. Open your brower [localhost:16686](http://localhost:16686/)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,4 +36,4 @@ The process is simple and fast. Upon your first pull request, you will be prompt
 ```bash
 make jaeger-start
 ```
-2. Open your brower [localhost:16686](http://localhost:16686/)
+2. Open your browser [localhost:16686](http://localhost:16686/)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,6 +257,12 @@ checksum = "5927edd8345aef08578bcbb4aea7314f340d80c7f4931f99fbeb40b99d8f5060"
 
 [[package]]
 name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
@@ -398,7 +404,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -407,7 +413,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae5588f6b3c3cb05239e90bd110f257254aecd01e4635400391aeae07497845"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-epoch",
@@ -421,7 +427,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-utils",
 ]
 
@@ -431,7 +437,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
@@ -442,7 +448,7 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-utils",
  "lazy_static",
  "memoffset",
@@ -455,7 +461,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b10ddc024425c88c2ad148c1b0fd53f4c6d38db9697c9f1588381212fa657c9"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-utils",
 ]
 
@@ -465,7 +471,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "lazy_static",
 ]
 
@@ -479,7 +485,7 @@ dependencies = [
  "crossterm_winapi",
  "libc",
  "mio",
- "parking_lot",
+ "parking_lot 0.11.2",
  "signal-hook",
  "signal-hook-mio",
  "winapi 0.3.9",
@@ -567,7 +573,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "dirs-sys-next",
 ]
 
@@ -634,7 +640,7 @@ version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80df024fbc5ac80f87dfef0d9f5209a252f2a497f7f42944cff24d8253cac065"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -872,7 +878,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
 ]
@@ -883,7 +889,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "js-sys",
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
@@ -1140,8 +1146,14 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bee0328b1209d157ef001c94dd85b4f8f64139adb0eac2659f4b08382b2f474d"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
+
+[[package]]
+name = "integer-encoding"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48dc51180a9b377fd75814d0cc02199c20f8e99433d6762f650d39cdbbd3b56f"
 
 [[package]]
 name = "inventory"
@@ -1239,6 +1251,15 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
+name = "lock_api"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
@@ -1252,7 +1273,7 @@ version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -1378,7 +1399,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18d614ad23f9bb59119b8b5670a85c7ba92c5e9adf4385c81ea00c51c8be33d5"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "downcast",
  "fragile",
  "lazy_static",
@@ -1393,7 +1414,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ab571328afa78ae322493cacca3efac6a0f2e0a67305b4df31fd439ef129ac0"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "downcast",
  "fragile",
  "lazy_static",
@@ -1408,7 +1429,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd4234635bca06fc96c7368d038061e0aae1b00a764dc817e900dc974e3deea"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -1420,7 +1441,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7e25b214433f669161f414959594216d8e6ba83b6679d3db96899c0b4639033"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -1553,14 +1574,90 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
+name = "opentelemetry"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf9b1c4e9a6c4de793c632496fa490bdc0e1eea73f0c91394f7b6990935d22"
+dependencies = [
+ "async-trait",
+ "crossbeam-channel",
+ "futures",
+ "js-sys",
+ "lazy_static",
+ "percent-encoding",
+ "pin-project",
+ "rand 0.8.4",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
+name = "opentelemetry-jaeger"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db22f492873ea037bc267b35a0e8e4fb846340058cb7c864efe3d0bf23684593"
+dependencies = [
+ "async-trait",
+ "lazy_static",
+ "opentelemetry",
+ "opentelemetry-semantic-conventions",
+ "thiserror",
+ "thrift",
+ "tokio",
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffeac823339e8b0f27b961f4385057bf9f97f2863bc745bd015fd6091f2270e9"
+dependencies = [
+ "opentelemetry",
+]
+
+[[package]]
+name = "ordered-float"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3305af35278dd29f46fcdd139e0b1fbfae2153f0e5928b39b035542dd31e37b7"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e"
+dependencies = [
+ "lock_api 0.3.4",
+ "parking_lot_core 0.7.2",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
- "lock_api",
- "parking_lot_core",
+ "lock_api 0.4.5",
+ "parking_lot_core 0.8.5",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d58c7c768d4ba344e3e8d72518ac13e259d7c7ade24167003b8488e10b6740a3"
+dependencies = [
+ "cfg-if 0.1.10",
+ "cloudabi",
+ "libc",
+ "redox_syscall 0.1.57",
+ "smallvec",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1569,10 +1666,10 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "instant",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.10",
  "smallvec",
  "winapi 0.3.9",
 ]
@@ -1840,6 +1937,8 @@ dependencies = [
  "crossterm",
  "json_comments",
  "once_cell",
+ "opentelemetry",
+ "opentelemetry-jaeger",
  "predicates 2.0.2",
  "quickwit-actors",
  "quickwit-common",
@@ -1859,6 +1958,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "tracing-opentelemetry",
  "tracing-subscriber",
 ]
 
@@ -2046,6 +2146,7 @@ dependencies = [
  "lru",
  "mockall 0.9.1",
  "once_cell",
+ "opentelemetry",
  "quickwit-cluster",
  "quickwit-common",
  "quickwit-directories",
@@ -2064,6 +2165,8 @@ dependencies = [
  "tokio-util",
  "tonic",
  "tracing",
+ "tracing-futures",
+ "tracing-opentelemetry",
 ]
 
 [[package]]
@@ -2078,6 +2181,7 @@ dependencies = [
  "futures-util",
  "hyper",
  "mockall 0.10.2",
+ "opentelemetry",
  "quickwit-cluster",
  "quickwit-common",
  "quickwit-core",
@@ -2098,6 +2202,7 @@ dependencies = [
  "tokio-stream",
  "tonic",
  "tracing",
+ "tracing-opentelemetry",
  "warp",
 ]
 
@@ -2436,6 +2541,12 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
+
+[[package]]
+name = "redox_syscall"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
@@ -2450,7 +2561,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
 dependencies = [
  "getrandom 0.2.3",
- "redox_syscall",
+ "redox_syscall 0.2.10",
 ]
 
 [[package]]
@@ -2838,7 +2949,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0bccbcf40c8938196944a3da0e133e031a33f4d6b72db3bda3cc556e361905d"
 dependencies = [
  "lazy_static",
- "parking_lot",
+ "parking_lot 0.10.2",
  "serial_test_derive",
 ]
 
@@ -2860,7 +2971,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
 dependencies = [
  "block-buffer",
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "digest",
  "opaque-debug",
@@ -2879,7 +2990,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9204c41a1597a8c5af23c82d1c921cb01ec0a4c59e07a9c7306062829a3903f3"
 dependencies = [
  "block-buffer",
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "digest",
  "opaque-debug",
@@ -2964,7 +3075,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "511254be0c5bcf062b019a6c89c01a664aa359ded62f78aa72c6fc137c0590e5"
 dependencies = [
- "lock_api",
+ "lock_api 0.4.5",
 ]
 
 [[package]]
@@ -3141,10 +3252,10 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "rand 0.8.4",
- "redox_syscall",
+ "redox_syscall 0.2.10",
  "remove_dir_all",
  "winapi 0.3.9",
 ]
@@ -3194,6 +3305,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
+]
+
+[[package]]
+name = "thrift"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6d965454947cc7266d22716ebfd07b18d84ebaf35eec558586bbb2a8cb6b5b"
+dependencies = [
+ "byteorder",
+ "integer-encoding",
+ "log",
+ "ordered-float",
+ "threadpool",
 ]
 
 [[package]]
@@ -3273,7 +3406,7 @@ dependencies = [
  "mio",
  "num_cpus",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.11.2",
  "pin-project-lite",
  "signal-hook-registry",
  "tokio-macros",
@@ -3443,7 +3576,7 @@ version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09adeb8c97449311ccd28a427f96fb563e7fd31aabf994189879d9da2394b89d"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "log",
  "pin-project-lite",
  "tracing-attributes",
@@ -3489,6 +3622,19 @@ dependencies = [
  "lazy_static",
  "log",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "599f388ecb26b28d9c1b2e4437ae019a7b336018b45ed911458cd9ebf91129f6"
+dependencies = [
+ "opentelemetry",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -3569,7 +3715,7 @@ version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f559b464de2e2bdabcac6a210d12e9b5a5973c251e102c44c585c71d51bd78e"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "static_assertions",
 ]
 
@@ -3815,7 +3961,7 @@ version = "0.2.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e68338db6becec24d3c7977b5bf8a48be992c934b5d07177e3931f5dc9b076c"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "serde",
  "serde_json",
  "wasm-bindgen-macro",
@@ -3842,7 +3988,7 @@ version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a87d738d4abc4cf22f6eb142f5b9a81301331ee3c767f2fef2fda4e325492060"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "js-sys",
  "wasm-bindgen",
  "web-sys",

--- a/Makefile
+++ b/Makefile
@@ -9,3 +9,6 @@ license-fix:
 
 fmt:
 	rustup toolchain list | grep nightly -q && cargo +nightly fmt || echo "Toolchain 'nightly' is not installed. Please install using 'rustup toolchain install nightly'."
+
+jaeger-start:
+	docker run -d -p6831:6831/udp -p6832:6832/udp -p16686:16686 jaegertracing/all-in-one:latest

--- a/quickwit-cli/Cargo.toml
+++ b/quickwit-cli/Cargo.toml
@@ -30,6 +30,9 @@ quickwit-telemetry = { version = "0.1", path = "../quickwit-telemetry" }
 quickwit-proto = { version = "0.1", path = "../quickwit-proto" }
 tracing = '0.1'
 tracing-subscriber = "0.2"
+tracing-opentelemetry = "0.15"
+opentelemetry = { version = "0.16", features = ["rt-tokio"] }
+opentelemetry-jaeger = { version = "0.15", features = ["rt-tokio"] }
 tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.6", features = ["full"] }
 crossterm = "0.20"

--- a/quickwit-cli/src/main.rs
+++ b/quickwit-cli/src/main.rs
@@ -25,12 +25,15 @@ use std::time::Duration;
 use anyhow::{bail, Context};
 use byte_unit::Byte;
 use clap::{load_yaml, value_t, App, AppSettings, ArgMatches};
+use opentelemetry::global;
+use opentelemetry::sdk::propagation::TraceContextPropagator;
 use quickwit_cli::*;
 use quickwit_common::to_socket_addr;
 use quickwit_serve::{serve_cli, ServeArgs};
 use quickwit_telemetry::payload::TelemetryEvent;
 use tracing::Level;
-use tracing_subscriber::fmt::Subscriber;
+use tracing_subscriber::prelude::*;
+use tracing_subscriber::EnvFilter;
 
 #[derive(Debug, PartialEq)]
 enum CliCommand {
@@ -243,20 +246,32 @@ impl CliCommand {
     }
 }
 
-fn setup_logger(default_level: Level) {
-    if env::var("RUST_LOG").is_ok() {
-        tracing_subscriber::fmt::init();
-        return;
-    }
-    Subscriber::builder()
-        .with_env_filter(format!("quickwit={}", default_level))
+fn setup_logging_and_tracing(default_level: Level) {
+    let env_filter = {
+        if env::var("RUST_LOG").is_ok() {
+            EnvFilter::from_default_env()
+        } else {
+            EnvFilter::try_new(format!("quickwit={}", default_level))
+                .expect("Failed to set up tracing env filter.")
+        }
+    };
+    global::set_text_map_propagator(TraceContextPropagator::new());
+    // TODO: use install_batch once this issue is fixed: https://github.com/open-telemetry/opentelemetry-rust/issues/545
+    let tracer = opentelemetry_jaeger::new_pipeline()
+        .with_service_name("quickwit")
+        //.install_batch(opentelemetry::runtime::Tokio)
+        .install_simple()
+        .expect("Failed to initialize Jaeger exporter.");
+    tracing_subscriber::registry()
+        .with(env_filter)
+        .with(tracing_opentelemetry::layer().with_tracer(tracer))
+        .with(tracing_subscriber::fmt::layer())
         .try_init()
-        .expect("Failed to set up logger.")
+        .expect("Failed to setup tracing.");
 }
 
-#[tracing::instrument]
 #[tokio::main]
-async fn main() {
+async fn main() -> anyhow::Result<()> {
     let telemetry_handle = quickwit_telemetry::start_telemetry_loop();
     let about_text = about_text();
 
@@ -275,7 +290,7 @@ async fn main() {
         }
     };
 
-    setup_logger(command.default_log_level());
+    setup_logging_and_tracing(command.default_log_level());
 
     let command_res = match command {
         CliCommand::New(args) => create_index_cli(args).await,
@@ -296,6 +311,7 @@ async fn main() {
     quickwit_telemetry::send_telemetry_event(TelemetryEvent::EndCommand { return_code }).await;
 
     telemetry_handle.terminate_telemetry().await;
+    global::shutdown_tracer_provider();
 
     std::process::exit(return_code);
 }

--- a/quickwit-directories/src/storage_directory.rs
+++ b/quickwit-directories/src/storage_directory.rs
@@ -29,7 +29,7 @@ use quickwit_storage::Storage;
 use tantivy::directory::error::{DeleteError, OpenReadError, OpenWriteError};
 use tantivy::directory::{FileHandle, OwnedBytes, WatchCallback, WatchHandle, WritePtr};
 use tantivy::{AsyncIoResult, Directory, HasLen};
-use tracing::error;
+use tracing::{error, instrument};
 
 use crate::caching_directory::BytesWrapper;
 
@@ -60,6 +60,7 @@ impl FileHandle for StorageDirectoryFileHandle {
         Err(unsupported_operation(&self.path))
     }
 
+    #[instrument(level = "debug", fields(path = %self.path.to_string_lossy()), skip(self, byte_range))]
     async fn read_bytes_async(&self, byte_range: Range<usize>) -> AsyncIoResult<OwnedBytes> {
         if byte_range.is_empty() {
             return Ok(OwnedBytes::empty());

--- a/quickwit-directories/src/storage_directory.rs
+++ b/quickwit-directories/src/storage_directory.rs
@@ -60,7 +60,7 @@ impl FileHandle for StorageDirectoryFileHandle {
         Err(unsupported_operation(&self.path))
     }
 
-    #[instrument(level = "debug", fields(path = %self.path.to_string_lossy()), skip(self, byte_range))]
+    #[instrument(level = "debug", fields(path = %self.path.to_string_lossy()), skip(self))]
     async fn read_bytes_async(&self, byte_range: Range<usize>) -> AsyncIoResult<OwnedBytes> {
         if byte_range.is_empty() {
             return Ok(OwnedBytes::empty());

--- a/quickwit-search/Cargo.toml
+++ b/quickwit-search/Cargo.toml
@@ -22,6 +22,7 @@ thiserror = "1"
 tonic = '0.5.2'
 tokio-stream = '0.1.6'
 tracing = "0.1"
+tracing-futures = "0.2.5"
 serde_json = "1"
 serde = { version = "1.0", features = ["derive"] }
 hyper = { version = "0.14", features = ["stream", "server", "http1", "http2", "tcp", "client"] }
@@ -29,6 +30,8 @@ bytes = "1"
 quickwit-common = {path="../quickwit-common"}
 lru = "0.6.6"
 once_cell = "1"
+opentelemetry = "0.16"
+tracing-opentelemetry = "0.15"
 
 [dependencies.tantivy]
 git = 'https://github.com/quickwit-inc/tantivy'

--- a/quickwit-search/src/client.rs
+++ b/quickwit-search/src/client.rs
@@ -17,17 +17,14 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use futures::StreamExt;
-use futures::TryStreamExt;
-use http::Uri;
-use opentelemetry::{global, propagation::Injector};
-use quickwit_proto::LeafSearchStreamResult;
 use std::fmt;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
 use futures::{StreamExt, TryStreamExt};
 use http::Uri;
+use opentelemetry::global;
+use opentelemetry::propagation::Injector;
 use quickwit_proto::LeafSearchStreamResult;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tonic::transport::{Channel, Endpoint};
@@ -41,7 +38,8 @@ use crate::{SearchError, SearchService};
 struct MetadataMap<'a>(&'a mut tonic::metadata::MetadataMap);
 
 impl<'a> Injector for MetadataMap<'a> {
-    /// Sets a key and value in the MetadataMap.  Does nothing if the key or value are not valid inputs
+    /// Sets a key and value in the MetadataMap.  Does nothing if the key or value are not valid
+    /// inputs
     fn set(&mut self, key: &str, value: String) {
         if let Ok(metadata_key) = tonic::metadata::MetadataKey::from_bytes(key.as_bytes()) {
             if let Ok(metadata_value) = tonic::metadata::MetadataValue::from_str(&value) {

--- a/quickwit-search/src/fetch_docs.rs
+++ b/quickwit-search/src/fetch_docs.rs
@@ -128,6 +128,7 @@ async fn get_searcher_for_split(
 }
 
 /// Fetching docs from a specific split.
+#[tracing::instrument(skip(global_doc_addrs, index_storage, split))]
 #[allow(clippy::needless_lifetimes)]
 async fn fetch_docs_in_split<'a>(
     global_doc_addrs: Vec<GlobalDocAddress<'a>>,

--- a/quickwit-search/src/leaf.rs
+++ b/quickwit-search/src/leaf.rs
@@ -112,17 +112,17 @@ pub(crate) async fn open_index(
 ///
 /// The downloaded data depends on the query (which term's posting list is required,
 /// are position required too), and the collector.
-#[instrument(skip(searcher, query, fast_field_names))]
+#[instrument(level = "debug", skip(searcher, query, fast_field_names))]
 pub(crate) async fn warmup(
     searcher: &Searcher,
     query: &dyn Query,
     fast_field_names: &HashSet<String>,
 ) -> anyhow::Result<()> {
     warm_up_terms(searcher, query)
-        .instrument(info_span!("warm_up_terms"))
+        .instrument(debug_span!("warm_up_terms"))
         .await?;
     warm_up_fastfields(searcher, fast_field_names)
-        .instrument(info_span!("warm_up_fastfields"))
+        .instrument(debug_span!("warm_up_fastfields"))
         .await?;
     Ok(())
 }

--- a/quickwit-search/src/leaf.rs
+++ b/quickwit-search/src/leaf.rs
@@ -35,6 +35,7 @@ use tantivy::collector::Collector;
 use tantivy::query::Query;
 use tantivy::{Index, ReloadPolicy, Searcher, Term};
 use tokio::task::spawn_blocking;
+use tracing::*;
 
 use crate::collector::{make_collector_for_split, make_merge_collector, GenericQuickwitCollector};
 use crate::SearchError;
@@ -111,13 +112,18 @@ pub(crate) async fn open_index(
 ///
 /// The downloaded data depends on the query (which term's posting list is required,
 /// are position required too), and the collector.
+#[tracing::instrument(skip(searcher, query, fast_field_names))]
 pub(crate) async fn warmup(
     searcher: &Searcher,
     query: &dyn Query,
     fast_field_names: &HashSet<String>,
 ) -> anyhow::Result<()> {
-    warm_up_terms(searcher, query).await?;
-    warm_up_fastfields(searcher, fast_field_names).await?;
+    warm_up_terms(searcher, query)
+        .instrument(info_span!("warm_up_terms"))
+        .await?;
+    warm_up_fastfields(searcher, fast_field_names)
+        .instrument(info_span!("warm_up_fastfields"))
+        .await?;
     Ok(())
 }
 
@@ -178,6 +184,7 @@ async fn warm_up_terms(searcher: &Searcher, query: &dyn Query) -> anyhow::Result
 }
 
 /// Apply a leaf search on a single split.
+#[tracing::instrument(skip(search_request, storage, split, index_config))]
 async fn leaf_search_single_split(
     search_request: &SearchRequest,
     storage: Arc<dyn Storage>,
@@ -247,6 +254,7 @@ pub async fn leaf_search(
     let merge_collector = make_merge_collector(request);
     let mut merged_search_results =
         spawn_blocking(move || merge_collector.merge_fruits(search_results))
+            .instrument(info_span!("merge_search_results"))
             .await
             .with_context(|| "Merging search on split results failed")??;
 

--- a/quickwit-search/src/leaf.rs
+++ b/quickwit-search/src/leaf.rs
@@ -112,7 +112,7 @@ pub(crate) async fn open_index(
 ///
 /// The downloaded data depends on the query (which term's posting list is required,
 /// are position required too), and the collector.
-#[tracing::instrument(skip(searcher, query, fast_field_names))]
+#[instrument(skip(searcher, query, fast_field_names))]
 pub(crate) async fn warmup(
     searcher: &Searcher,
     query: &dyn Query,
@@ -184,7 +184,7 @@ async fn warm_up_terms(searcher: &Searcher, query: &dyn Query) -> anyhow::Result
 }
 
 /// Apply a leaf search on a single split.
-#[tracing::instrument(skip(search_request, storage, split, index_config))]
+#[instrument(skip(search_request, storage, split, index_config))]
 async fn leaf_search_single_split(
     search_request: &SearchRequest,
     storage: Arc<dyn Storage>,

--- a/quickwit-search/src/leaf.rs
+++ b/quickwit-search/src/leaf.rs
@@ -112,7 +112,7 @@ pub(crate) async fn open_index(
 ///
 /// The downloaded data depends on the query (which term's posting list is required,
 /// are position required too), and the collector.
-#[instrument(level = "debug", skip(searcher, query, fast_field_names))]
+#[instrument(skip(searcher, query, fast_field_names))]
 pub(crate) async fn warmup(
     searcher: &Searcher,
     query: &dyn Query,
@@ -209,6 +209,11 @@ async fn leaf_search_single_split(
         .try_into()?;
     let searcher = reader.searcher();
     warmup(&*searcher, &query, &quickwit_collector.fast_field_names()).await?;
+    let span = info_span!(
+        "search",
+        split_id = %split.split_id,
+    );
+    let _ = span.enter();
     let leaf_search_result = searcher.search(&query, &quickwit_collector)?;
     Ok(leaf_search_result)
 }

--- a/quickwit-search/src/root.rs
+++ b/quickwit-search/src/root.rs
@@ -79,8 +79,8 @@ async fn execute_search(
         debug!(leaf_search_request=?leaf_search_request, grpc_addr=?search_client.grpc_addr(), "Leaf node search.");
         let mut search_client_clone: SearchServiceClient = search_client.clone();
         let span = info_span!(
-            "execute_leaf_search",
-            idx = result_per_node_addr_futures.len()
+            "leaf_node_search",
+            grpc_addr=?search_client.grpc_addr()
         );
         let handle = tokio::spawn(
             async move {

--- a/quickwit-search/src/root.rs
+++ b/quickwit-search/src/root.rs
@@ -79,7 +79,7 @@ async fn execute_search(
         debug!(leaf_search_request=?leaf_search_request, grpc_addr=?search_client.grpc_addr(), "Leaf node search.");
         let mut search_client_clone: SearchServiceClient = search_client.clone();
         let span = info_span!(
-            "leaf_node_search",
+            "execute_search",
             grpc_addr=?search_client.grpc_addr()
         );
         let handle = tokio::spawn(
@@ -420,9 +420,11 @@ pub async fn root_search(
                     index_uri: index_metadata.index_uri.to_string(),
                 };
                 let mut search_client_clone = search_client.clone();
-                let handle = tokio::spawn(async move {
-                    search_client_clone.fetch_docs(fetch_docs_request).await
-                });
+                let span = info_span!("execute_fetch_docs",);
+                let handle = tokio::spawn(
+                    async move { search_client_clone.fetch_docs(fetch_docs_request).await }
+                        .instrument(span),
+                );
                 fetch_docs_handles.push(handle);
             }
         }

--- a/quickwit-search/src/search_stream/leaf.rs
+++ b/quickwit-search/src/search_stream/leaf.rs
@@ -94,6 +94,7 @@ async fn leaf_search_results_stream(
 }
 
 /// Apply a leaf search on a single split.
+#[instrument(level = "debug", fields(split_id = %split.split_id), skip(split, index_config, stream_request, storage))]
 async fn leaf_search_stream_single_split(
     split: SplitIdAndFooterOffsets,
     index_config: Arc<dyn IndexConfig>,

--- a/quickwit-search/src/search_stream/leaf.rs
+++ b/quickwit-search/src/search_stream/leaf.rs
@@ -94,7 +94,7 @@ async fn leaf_search_results_stream(
 }
 
 /// Apply a leaf search on a single split.
-#[instrument(level = "debug", fields(split_id = %split.split_id), skip(split, index_config, stream_request, storage))]
+#[instrument(fields(split_id = %split.split_id), skip(split, index_config, stream_request, storage))]
 async fn leaf_search_stream_single_split(
     split: SplitIdAndFooterOffsets,
     index_config: Arc<dyn IndexConfig>,
@@ -151,7 +151,7 @@ async fn leaf_search_stream_single_split(
             output_format,
         )
     });
-    let span = debug_span!(
+    let span = info_span!(
         "collect_fast_field",
         split_id = %split.split_id,
         fast_field=%fast_field_to_extract,

--- a/quickwit-search/src/search_stream/leaf.rs
+++ b/quickwit-search/src/search_stream/leaf.rs
@@ -31,7 +31,7 @@ use tantivy::schema::Type;
 use tantivy::{LeasedItem, ReloadPolicy, Searcher};
 use tokio::task::spawn_blocking;
 use tokio_stream::wrappers::UnboundedReceiverStream;
-use tracing::error;
+use tracing::*;
 
 use super::FastFieldCollectorBuilder;
 use crate::leaf::{open_index, warmup};

--- a/quickwit-search/src/search_stream/leaf.rs
+++ b/quickwit-search/src/search_stream/leaf.rs
@@ -54,18 +54,23 @@ pub async fn leaf_search_stream(
     index_config: Arc<dyn IndexConfig>,
 ) -> UnboundedReceiverStream<crate::Result<LeafSearchStreamResult>> {
     let (result_sender, result_receiver) = tokio::sync::mpsc::unbounded_channel();
-    tokio::spawn(async move {
-        let mut stream = leaf_search_results_stream(request, storage, splits, index_config).await;
-        while let Some(item) = stream.next().await {
-            if let Err(error) = result_sender.send(item) {
-                error!(
-                    "Failed to send leaf search stream result. Stop sending. Cause: {}",
-                    error
-                );
-                break;
+    let span = info_span!("leaf_search_stream",);
+    tokio::spawn(
+        async move {
+            let mut stream =
+                leaf_search_results_stream(request, storage, splits, index_config).await;
+            while let Some(item) = stream.next().await {
+                if let Err(error) = result_sender.send(item) {
+                    error!(
+                        "Failed to send leaf search stream result. Stop sending. Cause: {}",
+                        error
+                    );
+                    break;
+                }
             }
         }
-    });
+        .instrument(span),
+    );
     UnboundedReceiverStream::new(result_receiver)
 }
 
@@ -145,6 +150,12 @@ async fn leaf_search_stream_single_split(
             output_format,
         )
     });
+    let span = debug_span!(
+        "collect_fast_field",
+        split_id = %split.split_id,
+        fast_field=%fast_field_to_extract,
+    );
+    let _ = span.enter();
     let buffer = collect_handle.await.map_err(|error| {
         error!(split_id = %split.split_id, fast_field=%fast_field_to_extract, error_message=%error, "Failed to collect fast field");
         SearchError::InternalError(format!("Error when collecting fast field values for split {}: {:?}", split.split_id, error))

--- a/quickwit-search/src/search_stream/root.rs
+++ b/quickwit-search/src/search_stream/root.rs
@@ -34,6 +34,7 @@ use crate::root::{job_for_splits, NodeSearchError};
 use crate::{list_relevant_splits, ClientPool, SearchClientPool, SearchError};
 
 /// Perform a distributed search stream.
+#[instrument(skip(search_stream_request, metastore, client_pool))]
 pub async fn root_search_stream(
     search_stream_request: &SearchStreamRequest,
     metastore: &dyn Metastore,
@@ -80,6 +81,10 @@ pub async fn root_search_stream(
             index_uri: index_metadata.index_uri.to_string(),
         };
         debug!(leaf_request=?leaf_request, grpc_addr=?search_client.grpc_addr(), "Leaf node search stream.");
+        let span = info_span!(
+            "leaf_node_search_stream",
+            grpc_addr=?search_client.grpc_addr()
+        );
         let handle = tokio::spawn(async move {
             let mut receiver = search_client
                 .leaf_search_stream(leaf_request)
@@ -104,10 +109,9 @@ pub async fn root_search_stream(
                 leaf_bytes.push(Bytes::from(leaf_data.data));
             }
             Result::<Vec<Bytes>, NodeSearchError>::Ok(leaf_bytes)
-        });
+        }.instrument(span));
         handles.push(handle);
     }
-
     let nodes_results = futures::future::try_join_all(handles).await?;
     let (nodes_bytes, errors): (Vec<Vec<Bytes>>, Vec<_>) =
         nodes_results

--- a/quickwit-search/src/search_stream/root.rs
+++ b/quickwit-search/src/search_stream/root.rs
@@ -34,7 +34,7 @@ use crate::root::{job_for_splits, NodeSearchError};
 use crate::{list_relevant_splits, ClientPool, SearchClientPool, SearchError};
 
 /// Perform a distributed search stream.
-#[instrument(skip(search_stream_request, metastore, client_pool))]
+#[instrument(skip(metastore, client_pool))]
 pub async fn root_search_stream(
     search_stream_request: &SearchStreamRequest,
     metastore: &dyn Metastore,
@@ -74,6 +74,10 @@ pub async fn root_search_stream(
                 split_footer_end: job.metadata.footer_offsets.end,
             })
             .collect();
+        let split_ids: Vec<_> = split_metadata_list
+            .iter()
+            .map(|split| split.split_id.clone())
+            .collect();
         let leaf_request = LeafSearchStreamRequest {
             request: Some(search_stream_request.clone()),
             split_metadata: split_metadata_list.clone(),
@@ -83,33 +87,31 @@ pub async fn root_search_stream(
         debug!(leaf_request=?leaf_request, grpc_addr=?search_client.grpc_addr(), "Leaf node search stream.");
         let span = info_span!(
             "leaf_node_search_stream",
-            grpc_addr=?search_client.grpc_addr()
+            grpc_addr=?search_client.grpc_addr(),
+            split_ids=?split_ids,
         );
-        let handle = tokio::spawn(async move {
-            let mut receiver = search_client
-                .leaf_search_stream(leaf_request)
-                .await
-                .map_err(|search_error| NodeSearchError {
-                    search_error,
-                    split_ids: split_metadata_list
-                        .iter()
-                        .map(|split| split.split_id.clone())
-                        .collect(),
-                })?;
+        let handle = tokio::spawn(
+            async move {
+                let mut receiver = search_client
+                    .leaf_search_stream(leaf_request)
+                    .await
+                    .map_err(|search_error| NodeSearchError {
+                        search_error,
+                        split_ids: split_ids.clone(),
+                    })?;
 
-            let mut leaf_bytes: Vec<Bytes> = Vec::new();
-            while let Some(leaf_result) = receiver.next().await {
-                let leaf_data = leaf_result.map_err(|search_error| NodeSearchError {
-                    search_error,
-                    split_ids: split_metadata_list
-                        .iter()
-                        .map(|split| split.split_id.clone())
-                        .collect(),
-                })?;
-                leaf_bytes.push(Bytes::from(leaf_data.data));
+                let mut leaf_bytes: Vec<Bytes> = Vec::new();
+                while let Some(leaf_result) = receiver.next().await {
+                    let leaf_data = leaf_result.map_err(|search_error| NodeSearchError {
+                        search_error,
+                        split_ids: split_ids.clone(),
+                    })?;
+                    leaf_bytes.push(Bytes::from(leaf_data.data));
+                }
+                Result::<Vec<Bytes>, NodeSearchError>::Ok(leaf_bytes)
             }
-            Result::<Vec<Bytes>, NodeSearchError>::Ok(leaf_bytes)
-        }.instrument(span));
+            .instrument(span),
+        );
         handles.push(handle);
     }
     let nodes_results = futures::future::try_join_all(handles).await?;

--- a/quickwit-serve/Cargo.toml
+++ b/quickwit-serve/Cargo.toml
@@ -30,6 +30,8 @@ termcolor = "1"
 bytes = "1"
 tokio = { version = "1.7", features = [ "full" ] }
 tokio-stream = "0.1.6"
+opentelemetry = "0.16"
+tracing-opentelemetry = "0.15"
 
 [dev-dependencies]
 mockall = "0.10"

--- a/quickwit-serve/src/grpc_adapter/search_adapter.rs
+++ b/quickwit-serve/src/grpc_adapter/search_adapter.rs
@@ -21,19 +21,20 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use futures::TryStreamExt;
-use opentelemetry::{global, propagation::Extractor};
-use tracing::*;
-use tracing_opentelemetry::OpenTelemetrySpanExt;
-
+use opentelemetry::global;
+use opentelemetry::propagation::Extractor;
 use quickwit_proto::{
     search_service_server as grpc, LeafSearchStreamRequest, LeafSearchStreamResult,
 };
 use quickwit_search::{SearchError, SearchService, SearchServiceImpl};
+use tracing::*;
+use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 struct MetadataMap<'a>(&'a tonic::metadata::MetadataMap);
 
 impl<'a> Extractor for MetadataMap<'a> {
-    /// Gets a value for a key from the MetadataMap.  If the value can't be converted to &str, returns None
+    /// Gets a value for a key from the MetadataMap.  If the value can't be converted to &str,
+    /// returns None
     fn get(&self, key: &str) -> Option<&str> {
         self.0.get(key).and_then(|metadata| metadata.to_str().ok())
     }

--- a/quickwit-serve/src/grpc_adapter/search_adapter.rs
+++ b/quickwit-serve/src/grpc_adapter/search_adapter.rs
@@ -21,10 +21,34 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use futures::TryStreamExt;
+use opentelemetry::{global, propagation::Extractor};
+use tracing::{instrument, Span};
+use tracing_opentelemetry::OpenTelemetrySpanExt;
+
 use quickwit_proto::{
     search_service_server as grpc, LeafSearchStreamRequest, LeafSearchStreamResult,
 };
 use quickwit_search::{SearchError, SearchService, SearchServiceImpl};
+
+struct MetadataMap<'a>(&'a tonic::metadata::MetadataMap);
+
+impl<'a> Extractor for MetadataMap<'a> {
+    /// Get a value for a key from the MetadataMap.  If the value can't be converted to &str, returns None
+    fn get(&self, key: &str) -> Option<&str> {
+        self.0.get(key).and_then(|metadata| metadata.to_str().ok())
+    }
+
+    /// Collect all the keys from the MetadataMap.
+    fn keys(&self) -> Vec<&str> {
+        self.0
+            .keys()
+            .map(|key| match key {
+                tonic::metadata::KeyRef::Ascii(v) => v.as_str(),
+                tonic::metadata::KeyRef::Binary(v) => v.as_str(),
+            })
+            .collect::<Vec<_>>()
+    }
+}
 
 #[derive(Clone)]
 pub struct GrpcSearchAdapter(Arc<dyn SearchService>);
@@ -44,10 +68,14 @@ impl From<Arc<SearchServiceImpl>> for GrpcSearchAdapter {
 
 #[async_trait]
 impl grpc::SearchService for GrpcSearchAdapter {
+    #[instrument(skip(self, request))]
     async fn root_search(
         &self,
         request: tonic::Request<quickwit_proto::SearchRequest>,
     ) -> Result<tonic::Response<quickwit_proto::SearchResult>, tonic::Status> {
+        let parent_cx =
+            global::get_text_map_propagator(|prop| prop.extract(&MetadataMap(request.metadata())));
+        Span::current().set_parent(parent_cx);
         let search_request = request.into_inner();
         let search_result = self
             .0
@@ -57,10 +85,14 @@ impl grpc::SearchService for GrpcSearchAdapter {
         Ok(tonic::Response::new(search_result))
     }
 
+    #[instrument(skip(self, request))]
     async fn leaf_search(
         &self,
         request: tonic::Request<quickwit_proto::LeafSearchRequest>,
     ) -> Result<tonic::Response<quickwit_proto::LeafSearchResult>, tonic::Status> {
+        let parent_cx =
+            global::get_text_map_propagator(|prop| prop.extract(&MetadataMap(request.metadata())));
+        Span::current().set_parent(parent_cx);
         let leaf_search_request = request.into_inner();
         let leaf_search_result = self
             .0
@@ -70,10 +102,14 @@ impl grpc::SearchService for GrpcSearchAdapter {
         Ok(tonic::Response::new(leaf_search_result))
     }
 
+    #[instrument(skip(self, request))]
     async fn fetch_docs(
         &self,
         request: tonic::Request<quickwit_proto::FetchDocsRequest>,
     ) -> Result<tonic::Response<quickwit_proto::FetchDocsResult>, tonic::Status> {
+        let parent_cx =
+            global::get_text_map_propagator(|prop| prop.extract(&MetadataMap(request.metadata())));
+        Span::current().set_parent(parent_cx);
         let fetch_docs_request = request.into_inner();
         let fetch_docs_result = self
             .0

--- a/quickwit-serve/src/grpc_adapter/search_adapter.rs
+++ b/quickwit-serve/src/grpc_adapter/search_adapter.rs
@@ -22,8 +22,8 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use futures::TryStreamExt;
 use opentelemetry::{global, propagation::Extractor};
-use tracing_opentelemetry::OpenTelemetrySpanExt;
 use tracing::*;
+use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 use quickwit_proto::{
     search_service_server as grpc, LeafSearchStreamRequest, LeafSearchStreamResult,
@@ -33,7 +33,7 @@ use quickwit_search::{SearchError, SearchService, SearchServiceImpl};
 struct MetadataMap<'a>(&'a tonic::metadata::MetadataMap);
 
 impl<'a> Extractor for MetadataMap<'a> {
-    /// Get a value for a key from the MetadataMap.  If the value can't be converted to &str, returns None
+    /// Gets a value for a key from the MetadataMap.  If the value can't be converted to &str, returns None
     fn get(&self, key: &str) -> Option<&str> {
         self.0.get(key).and_then(|metadata| metadata.to_str().ok())
     }
@@ -124,7 +124,7 @@ impl grpc::SearchService for GrpcSearchAdapter {
             dyn futures::Stream<Item = Result<LeafSearchStreamResult, tonic::Status>> + Send + Sync,
         >,
     >;
-    #[instrument(skip(self, request))]
+    #[instrument(name = "search_adapter:leaf_search_stream", skip(self, request))]
     async fn leaf_search_stream(
         &self,
         request: tonic::Request<LeafSearchStreamRequest>,

--- a/quickwit-serve/src/rest.rs
+++ b/quickwit-serve/src/rest.rs
@@ -144,7 +144,6 @@ pub struct SearchRequestQueryString {
     pub tags: Option<Vec<String>>,
 }
 
-#[instrument(skip(index_id, search_request, search_service))]
 async fn search_endpoint<TSearchService: SearchService>(
     index_id: String,
     search_request: SearchRequestQueryString,

--- a/quickwit-serve/src/rest.rs
+++ b/quickwit-serve/src/rest.rs
@@ -144,6 +144,7 @@ pub struct SearchRequestQueryString {
     pub tags: Option<Vec<String>>,
 }
 
+#[instrument(skip(index_id, search_request, search_service))]
 async fn search_endpoint<TSearchService: SearchService>(
     index_id: String,
     search_request: SearchRequestQueryString,

--- a/quickwit-swim/src/cluster.rs
+++ b/quickwit-swim/src/cluster.rs
@@ -12,13 +12,13 @@ use crate::state::{ArtilleryClusterEvent, ArtilleryClusterRequest};
 
 #[derive(Debug)]
 pub struct Cluster {
-    comm: flume::Sender<ArtilleryClusterRequest>
+    comm: flume::Sender<ArtilleryClusterRequest>,
 }
 
 impl Cluster {
     pub fn create_and_start(
         host_key: Uuid,
-        config: ClusterConfig
+        config: ClusterConfig,
     ) -> Result<(Cluster, flume::Receiver<ArtilleryClusterEvent>)> {
         let (event_tx, event_rx) = flume::unbounded::<ArtilleryClusterEvent>();
         let (internal_tx, mut internal_rx) = flume::unbounded::<ArtilleryClusterRequest>();
@@ -44,7 +44,7 @@ impl Cluster {
         self.comm
             .send(ArtilleryClusterRequest::Payload(
                 id,
-                msg.as_ref().to_string()
+                msg.as_ref().to_string(),
             ))
             .unwrap();
     }

--- a/quickwit-swim/src/cluster_config.rs
+++ b/quickwit-swim/src/cluster_config.rs
@@ -17,7 +17,7 @@ pub struct ClusterConfig {
     pub network_mtu: usize,
     pub ping_request_host_count: usize,
     pub ping_timeout: Duration,
-    pub listen_addr: SocketAddr
+    pub listen_addr: SocketAddr,
 }
 
 impl Default for ClusterConfig {
@@ -30,7 +30,7 @@ impl Default for ClusterConfig {
             network_mtu: CONST_PACKET_SIZE,
             ping_request_host_count: 3,
             ping_timeout: Duration::from_secs(3),
-            listen_addr: directed.to_socket_addrs().unwrap().next().unwrap()
+            listen_addr: directed.to_socket_addrs().unwrap().next().unwrap(),
         }
     }
 }

--- a/quickwit-swim/src/errors.rs
+++ b/quickwit-swim/src/errors.rs
@@ -21,7 +21,7 @@ pub enum ArtilleryError {
     #[error("Artillery :: Decoding Error: {}", _0)]
     Decoding(String),
     #[error("Artillery :: Numeric Cast Error: {}", _0)]
-    NumericCast(String)
+    NumericCast(String),
 }
 
 impl From<serde_json::error::Error> for ArtilleryError {

--- a/quickwit-swim/src/member.rs
+++ b/quickwit-swim/src/member.rs
@@ -20,7 +20,7 @@ pub enum ArtilleryMemberState {
     Down,
     /// Left the cluster
     #[serde(rename = "l")]
-    Left
+    Left,
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq)]
@@ -34,12 +34,12 @@ pub struct ArtilleryMember {
     #[serde(rename = "m")]
     member_state: ArtilleryMemberState,
     #[serde(rename = "t", skip, default = "Instant::now")]
-    last_state_change: Instant
+    last_state_change: Instant,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialOrd, Ord, PartialEq, Eq)]
 pub struct ArtilleryStateChange {
-    member: ArtilleryMember
+    member: ArtilleryMember,
 }
 
 impl ArtilleryMember {
@@ -47,14 +47,14 @@ impl ArtilleryMember {
         host_key: Uuid,
         remote_host: SocketAddr,
         incarnation_number: u64,
-        known_state: ArtilleryMemberState
+        known_state: ArtilleryMemberState,
     ) -> Self {
         ArtilleryMember {
             host_key,
             remote_host: Some(remote_host),
             incarnation_number,
             member_state: known_state,
-            last_state_change: Instant::now()
+            last_state_change: Instant::now(),
         }
     }
 
@@ -64,7 +64,7 @@ impl ArtilleryMember {
             remote_host: None,
             incarnation_number: 0,
             member_state: ArtilleryMemberState::Alive,
-            last_state_change: Instant::now()
+            last_state_change: Instant::now(),
         }
     }
 
@@ -131,14 +131,14 @@ impl PartialOrd for ArtilleryMember {
             self.host_key.as_bytes(),
             format!("{:?}", self.remote_host),
             self.incarnation_number,
-            self.member_state
+            self.member_state,
         );
 
         let t2 = (
             rhs.host_key.as_bytes(),
             format!("{:?}", rhs.remote_host),
             rhs.incarnation_number,
-            rhs.member_state
+            rhs.member_state,
         );
 
         t1.partial_cmp(&t2)
@@ -159,14 +159,14 @@ impl Debug for ArtilleryMember {
             .field("state", &self.member_state)
             .field(
                 "drift_time_ms",
-                &self.last_state_change.elapsed().as_millis()
+                &self.last_state_change.elapsed().as_millis(),
             )
             .field(
                 "remote_host",
                 &self
                     .remote_host
                     .map_or(String::from("(current)"), |r| format!("{}", r))
-                    .as_str()
+                    .as_str(),
             )
             .finish()
     }
@@ -174,7 +174,7 @@ impl Debug for ArtilleryMember {
 
 pub fn most_uptodate_member_data<'a>(
     lhs: &'a ArtilleryMember,
-    rhs: &'a ArtilleryMember
+    rhs: &'a ArtilleryMember,
 ) -> &'a ArtilleryMember {
     // Don't apply clippy here.
     // It's important bit otherwise we won't understand.
@@ -184,7 +184,7 @@ pub fn most_uptodate_member_data<'a>(
         lhs.member_state,
         lhs.incarnation_number,
         rhs.member_state,
-        rhs.incarnation_number
+        rhs.incarnation_number,
     ) {
         (ArtilleryMemberState::Alive, i, ArtilleryMemberState::Suspect, j) => i > j,
         (ArtilleryMemberState::Alive, i, ArtilleryMemberState::Alive, j) => i > j,
@@ -193,7 +193,7 @@ pub fn most_uptodate_member_data<'a>(
         (ArtilleryMemberState::Down, _, ArtilleryMemberState::Alive, _) => true,
         (ArtilleryMemberState::Down, _, ArtilleryMemberState::Suspect, _) => true,
         (ArtilleryMemberState::Left, _, _, _) => true,
-        _ => false
+        _ => false,
     };
 
     if lhs_overrides {
@@ -219,7 +219,7 @@ mod test {
             remote_host: Some(FromStr::from_str("127.0.0.1:1337").unwrap()),
             incarnation_number: 123,
             member_state: ArtilleryMemberState::Alive,
-            last_state_change: Instant::now() - Duration::from_secs(3600)
+            last_state_change: Instant::now() - Duration::from_secs(3600),
         };
 
         let encoded = bincode::serialize(&member).unwrap();

--- a/quickwit-swim/src/membership.rs
+++ b/quickwit-swim/src/membership.rs
@@ -10,14 +10,14 @@ use crate::member::{self, ArtilleryMember, ArtilleryMemberState, ArtilleryStateC
 
 pub struct ArtilleryMemberList {
     members: Vec<ArtilleryMember>,
-    periodic_index: usize
+    periodic_index: usize,
 }
 
 impl ArtilleryMemberList {
     pub fn new(current: ArtilleryMember) -> Self {
         ArtilleryMemberList {
             members: vec![current],
-            periodic_index: 0
+            periodic_index: 0,
         }
     }
 
@@ -79,7 +79,7 @@ impl ArtilleryMemberList {
 
     pub fn time_out_nodes(
         &mut self,
-        expired_hosts: &HashSet<SocketAddr>
+        expired_hosts: &HashSet<SocketAddr>,
     ) -> (Vec<ArtilleryMember>, Vec<ArtilleryMember>) {
         let mut suspect_members = Vec::new();
         let mut down_members = Vec::new();
@@ -129,7 +129,7 @@ impl ArtilleryMemberList {
     pub fn apply_state_changes(
         &mut self,
         state_changes: Vec<ArtilleryStateChange>,
-        from: &SocketAddr
+        from: &SocketAddr,
     ) -> (Vec<ArtilleryMember>, Vec<ArtilleryMember>) {
         let mut current_members = self.to_map();
 
@@ -183,7 +183,7 @@ impl ArtilleryMemberList {
     pub fn hosts_for_indirect_ping(
         &self,
         host_count: usize,
-        target: &SocketAddr
+        target: &SocketAddr,
     ) -> Vec<SocketAddr> {
         let mut possible_members: Vec<_> = self
             .members

--- a/quickwit-swim/src/state.rs
+++ b/quickwit-swim/src/state.rs
@@ -27,7 +27,7 @@ pub enum ArtilleryMemberEvent {
     SuspectedDown(ArtilleryMember),
     WentDown(ArtilleryMember),
     Left(ArtilleryMember),
-    Payload(ArtilleryMember, String)
+    Payload(ArtilleryMember, String),
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -35,7 +35,7 @@ pub struct ArtilleryMessage {
     sender: Uuid,
     cluster_key: Vec<u8>,
     request: Request,
-    state_changes: Vec<ArtilleryStateChange>
+    state_changes: Vec<ArtilleryStateChange>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
@@ -47,13 +47,13 @@ enum Request {
     Ack,
     Ping(EncSocketAddr),
     AckHost(ArtilleryMember),
-    Payload(Uuid, String)
+    Payload(Uuid, String),
 }
 
 #[derive(Debug, Clone)]
 pub struct TargetedRequest {
     request: Request,
-    target: SocketAddr
+    target: SocketAddr,
 }
 
 #[derive(Clone)]
@@ -63,7 +63,7 @@ pub enum ArtilleryClusterRequest {
     React(TargetedRequest),
     LeaveCluster,
     Exit,
-    Payload(Uuid, String)
+    Payload(Uuid, String),
 }
 
 const UDP_SERVER: Token = Token(0);
@@ -79,7 +79,7 @@ pub struct ArtilleryEpidemic {
     server_socket: UdpSocket,
     request_tx: flume::Sender<ArtilleryClusterRequest>,
     event_tx: flume::Sender<ArtilleryClusterEvent>,
-    running: AtomicBool
+    running: AtomicBool,
 }
 
 pub type ClusterReactor = (Poll, ArtilleryEpidemic);
@@ -89,7 +89,7 @@ impl ArtilleryEpidemic {
         host_key: Uuid,
         config: ClusterConfig,
         event_tx: flume::Sender<ArtilleryClusterEvent>,
-        internal_tx: flume::Sender<ArtilleryClusterRequest>
+        internal_tx: flume::Sender<ArtilleryClusterRequest>,
     ) -> Result<ClusterReactor> {
         let poll: Poll = Poll::new()?;
 
@@ -111,7 +111,7 @@ impl ArtilleryEpidemic {
             server_socket,
             request_tx: internal_tx,
             event_tx,
-            running: AtomicBool::new(true)
+            running: AtomicBool::new(true),
         };
 
         Ok((poll, state))
@@ -120,7 +120,7 @@ impl ArtilleryEpidemic {
     pub(crate) fn event_loop(
         receiver: &mut flume::Receiver<ArtilleryClusterRequest>,
         mut poll: Poll,
-        mut state: ArtilleryEpidemic
+        mut state: ArtilleryEpidemic,
     ) -> Result<()> {
         let mut events = Events::with_capacity(1);
         let mut buf = [0_u8; CONST_PACKET_SIZE];
@@ -164,7 +164,7 @@ impl ArtilleryEpidemic {
                                 let message = serde_json::from_slice(&buf[..packet_size])?;
                                 state.request_tx.send(ArtilleryClusterRequest::Respond(
                                     source_address,
-                                    message
+                                    message,
                                 ))?;
                             }
                             Err(e) if e.kind() == io::ErrorKind::WouldBlock => {
@@ -204,7 +204,7 @@ impl ArtilleryEpidemic {
             &self.config.cluster_key,
             &request.request,
             &self.state_changes,
-            self.config.network_mtu
+            self.config.network_mtu,
         );
 
         if should_add_pending {
@@ -225,7 +225,7 @@ impl ArtilleryEpidemic {
             self.request_tx
                 .send(ArtilleryClusterRequest::React(TargetedRequest {
                     request: Request::Heartbeat,
-                    target: *seed_node
+                    target: *seed_node,
                 }))
                 .unwrap();
         }
@@ -236,7 +236,7 @@ impl ArtilleryEpidemic {
             self.request_tx
                 .send(ArtilleryClusterRequest::React(TargetedRequest {
                     request: Request::Heartbeat,
-                    target: member.remote_host().unwrap()
+                    target: member.remote_host().unwrap(),
                 }))
                 .unwrap();
         }
@@ -279,7 +279,7 @@ impl ArtilleryEpidemic {
                 self.request_tx
                     .send(ArtilleryClusterRequest::React(TargetedRequest {
                         request: Request::Ping(EncSocketAddr::from_addr(&target_host)),
-                        target: relay
+                        target: relay,
                     }))
                     .unwrap();
             }
@@ -311,7 +311,7 @@ impl ArtilleryEpidemic {
                         request: Request::Payload(id, msg),
                         target: target_peer
                             .remote_host()
-                            .expect("Expected target peer addr")
+                            .expect("Expected target peer addr"),
                     });
                     return;
                 }
@@ -338,7 +338,7 @@ impl ArtilleryEpidemic {
             let response = match message.request {
                 Heartbeat => Some(TargetedRequest {
                     request: Ack,
-                    target: src_addr
+                    target: src_addr,
                 }),
                 Ack => {
                     self.ack_response(src_addr);
@@ -350,7 +350,7 @@ impl ArtilleryEpidemic {
                     add_to_wait_list(&mut self.wait_list, &dest_addr, &src_addr);
                     Some(TargetedRequest {
                         request: Heartbeat,
-                        target: dest_addr
+                        target: dest_addr,
                     })
                 }
                 AckHost(member) => {
@@ -419,7 +419,7 @@ impl ArtilleryEpidemic {
             WentUp(ref m) => assert_eq!(m.state(), ArtilleryMemberState::Alive),
             WentDown(ref m) => assert_eq!(m.state(), ArtilleryMemberState::Down),
             SuspectedDown(ref m) => assert_eq!(m.state(), ArtilleryMemberState::Suspect),
-            Left(ref m) => assert_eq!(m.state(), ArtilleryMemberState::Left)
+            Left(ref m) => assert_eq!(m.state(), ArtilleryMemberState::Left),
         };
 
         // If an error is returned, no one is listening to events anymore. This is normal.
@@ -448,7 +448,7 @@ impl ArtilleryEpidemic {
                     self.request_tx
                         .send(ArtilleryClusterRequest::React(TargetedRequest {
                             request: Request::AckHost(member.clone()),
-                            target: *remote
+                            target: *remote,
                         }))
                         .unwrap();
                 }
@@ -467,13 +467,13 @@ fn build_message(
     cluster_key: &[u8],
     request: &Request,
     state_changes: &[ArtilleryStateChange],
-    network_mtu: usize
+    network_mtu: usize,
 ) -> ArtilleryMessage {
     let mut message = ArtilleryMessage {
         sender: *sender,
         cluster_key: cluster_key.into(),
         request: request.clone(),
-        state_changes: Vec::new()
+        state_changes: Vec::new(),
     };
 
     for i in 0..=state_changes.len() {
@@ -481,7 +481,7 @@ fn build_message(
             sender: *sender,
             cluster_key: cluster_key.into(),
             request: request.clone(),
-            state_changes: (&state_changes[..i]).to_vec()
+            state_changes: (&state_changes[..i]).to_vec(),
         };
 
         let encoded = serde_json::to_string(&message).unwrap();
@@ -513,13 +513,13 @@ fn determine_member_event(member: ArtilleryMember) -> ArtilleryMemberEvent {
         ArtilleryMemberState::Alive => ArtilleryMemberEvent::WentUp(member),
         ArtilleryMemberState::Suspect => ArtilleryMemberEvent::SuspectedDown(member),
         ArtilleryMemberState::Down => ArtilleryMemberEvent::WentDown(member),
-        ArtilleryMemberState::Left => ArtilleryMemberEvent::Left(member)
+        ArtilleryMemberState::Left => ArtilleryMemberEvent::Left(member),
     }
 }
 
 fn enqueue_state_change(
     state_changes: &mut Vec<ArtilleryStateChange>,
-    members: &[ArtilleryMember]
+    members: &[ArtilleryMember],
 ) {
     for member in members {
         for state_change in state_changes.iter_mut() {


### PR DESCRIPTION
This PR works with a jaeger instance that you can start with the following command:
`docker run -d -p6831:6831/udp -p6832:6832/udp -p16686:16686 jaegertracing/all-in-one:latest`

## Search tracing

<img width="1435" alt="Capture d’écran 2021-08-24 à 09 56 14" src="https://user-images.githubusercontent.com/653704/130579115-1d00fd8b-563c-4bcf-9e8a-11da48cae41c.png">


### Comments 

## Search stream tracing

<img width="1435" alt="Capture d’écran 2021-08-23 à 21 18 41" src="https://user-images.githubusercontent.com/653704/130505165-d457fc27-03b3-47d4-a173-6a54b147d312.png">

### Comments
TODO