### PR TITLE
Use futures::stream in leaf functions

### DIFF
--- a/quickwit-search/src/client.rs
+++ b/quickwit-search/src/client.rs
@@ -19,6 +19,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+use futures::StreamExt;
 use http::Uri;
 use quickwit_proto::LeafSearchStreamResult;
 use std::fmt;
@@ -126,21 +127,20 @@ impl SearchServiceClient {
     pub async fn leaf_search_stream(
         &mut self,
         request: quickwit_proto::LeafSearchStreamRequest,
-    ) -> crate::Result<UnboundedReceiverStream<Result<LeafSearchStreamResult, tonic::Status>>> {
+    ) -> crate::Result<UnboundedReceiverStream<crate::Result<LeafSearchStreamResult>>> {
+        // It could be possible to return a stream... but the stream should be Sync + Send and tonic returns
+        // a stream which is only Send.
+        let (result_sender, result_receiver) = tokio::sync::mpsc::unbounded_channel();
         match &mut self.client_impl {
             SearchServiceClientImpl::Grpc(grpc_client) => {
                 let mut grpc_client_clone = grpc_client.clone();
-                let (result_sender, result_receiver) = tokio::sync::mpsc::unbounded_channel();
+                let tonic_request = Request::new(request);
+                let mut results_stream = grpc_client_clone
+                    .leaf_search_stream(tonic_request)
+                    .await
+                    .map_err(|tonic_error| parse_grpc_error(&tonic_error))?
+                    .into_inner();
                 tokio::spawn(async move {
-                    let tonic_request = Request::new(request);
-                    let mut results_stream = grpc_client_clone
-                        .leaf_search_stream(tonic_request)
-                        .await
-                        .map_err(|tonic_error| parse_grpc_error(&tonic_error))?
-                        .into_inner();
-
-                    // TODO: returning stream instead of a channel may be better.
-                    // But this seems to be difficult. Try it at your own expense.
                     while let Some(result) = results_stream
                         .message()
                         .await
@@ -156,11 +156,25 @@ impl SearchServiceClient {
                     }
                     Result::<_, SearchError>::Ok(())
                 });
-
-                Ok(UnboundedReceiverStream::new(result_receiver))
             }
-            SearchServiceClientImpl::Local(service) => service.leaf_search_stream(request).await,
+            SearchServiceClientImpl::Local(service) => {
+                let mut results_stream = service.leaf_search_stream(request).await?;
+                tokio::spawn(async move {
+                    while let Some(result) = results_stream.next().await {
+                        // We want to stop doing unnecessary work on the leaves as soon as
+                        // there is an issue sending the result.
+                        // Terminating the task will drop the `result_stream` consequently
+                        // canceling the gRPC request.
+                        result_sender.send(result).map_err(|_| {
+                            SearchError::InternalError("Could not send leaf result".into())
+                        })?;
+                    }
+                    Result::<_, SearchError>::Ok(())
+                });
+            }
         }
+
+        Ok(UnboundedReceiverStream::new(result_receiver))
     }
 
     /// Perform fetch docs.

--- a/quickwit-search/src/error.rs
+++ b/quickwit-search/src/error.rs
@@ -29,7 +29,7 @@ use quickwit_storage::StorageResolverError;
 
 /// Possible SearchError
 #[allow(missing_docs)]
-#[derive(Error, Debug, Serialize, Deserialize)]
+#[derive(Error, Debug, Serialize, Deserialize, Clone)]
 pub enum SearchError {
     #[error("Index `{index_id}` does not exist.")]
     IndexDoesNotExist { index_id: String },

--- a/quickwit-serve/src/grpc_adapter/search_adapter.rs
+++ b/quickwit-serve/src/grpc_adapter/search_adapter.rs
@@ -19,10 +19,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-use std::sync::Arc;
+use std::{pin::Pin, sync::Arc};
 
 use async_trait::async_trait;
-use tokio_stream::wrappers::UnboundedReceiverStream;
+use futures::TryStreamExt;
 
 use quickwit_proto::{
     search_service_server as grpc, LeafSearchStreamRequest, LeafSearchStreamResult,
@@ -79,8 +79,14 @@ impl grpc::SearchService for GrpcSearchAdapter {
         Ok(tonic::Response::new(fetch_docs_result))
     }
 
-    type LeafSearchStreamStream =
-        UnboundedReceiverStream<Result<LeafSearchStreamResult, tonic::Status>>;
+    type LeafSearchStreamStream = Pin<
+        Box<
+            dyn futures::Stream<Item = Result<LeafSearchStreamResult, tonic::Status>>
+                + Sync
+                + Send
+                + 'static,
+        >,
+    >;
     async fn leaf_search_stream(
         &self,
         request: tonic::Request<LeafSearchStreamRequest>,
@@ -90,7 +96,8 @@ impl grpc::SearchService for GrpcSearchAdapter {
             .0
             .leaf_search_stream(leaf_search_request)
             .await
-            .map_err(SearchError::convert_to_tonic_status)?;
-        Ok(tonic::Response::new(leaf_search_result))
+            .map_err(SearchError::convert_to_tonic_status)?
+            .map_err(SearchError::convert_to_tonic_status);
+        Ok(tonic::Response::new(Box::pin(leaf_search_result)))
     }
 }

--- a/quickwit-storage/src/error.rs
+++ b/quickwit-storage/src/error.rs
@@ -42,7 +42,7 @@ pub enum StorageErrorKind {
 
 /// Generic Storage Resolver Error.
 #[allow(missing_docs)]
-#[derive(Error, Debug, Serialize, Deserialize)]
+#[derive(Error, Debug, Serialize, Deserialize, Clone)]
 pub enum StorageResolverError {
     /// The input is not a valid URI.
     /// A protocol is required for the URI.


### PR DESCRIPTION
### Context / purpose
It could be useful to return `futures::stream` in `leaf` functions to:
- easily limit the number of `leaf_search_stream_single_split` or `leaf_search_single_split` executed concurrently
- easily convert a stream item error `SearchError` to tonic `Status` and vice versa, currently `leaf_search_stream` returns an UnboundedReceiver with a result containing tonic `status`. We don't want to have this status at the `leaf_search_stream` level.


### Description
This PR shows how to use streams in `leaf_search_stream` function and the subsequent changes we must apply to make the grpc layer compatible.


### Caveats
I did not manage to make the `SearchClient` returns a stream because of trait bounds error: the stream has to be Send + Sync but I only have a Send stream from tonic response. So I keep the unbounded receiver.

