### PR TITLE
Fix #483, #484 and above all handle errors happening in search stream leaves.

### DIFF
--- a/quickwit-cli/tests/cli.rs
+++ b/quickwit-cli/tests/cli.rs
@@ -606,11 +606,11 @@ async fn test_all_local_index() -> Result<()> {
     .assert()
     .success();
 
-    let metadata_file_exist = test_env
+    let metadata_file_exists = test_env
         .storage
         .exists(&Path::new(index_id).join("quickwit.json"))
         .await?;
-    assert_eq!(metadata_file_exist, true);
+    assert_eq!(metadata_file_exists, true);
 
     index_data(
         index_id,
@@ -669,11 +669,11 @@ async fn test_all_local_index() -> Result<()> {
     )
     .assert()
     .success();
-    let metadata_file_exist = test_env
+    let metadata_file_exists = test_env
         .storage
         .exists(&Path::new(index_id).join("quickwit.json"))
         .await?;
-    assert_eq!(metadata_file_exist, false);
+    assert_eq!(metadata_file_exists, false);
 
     Ok(())
 }

--- a/quickwit-cli/tests/cli.rs
+++ b/quickwit-cli/tests/cli.rs
@@ -606,7 +606,10 @@ async fn test_all_local_index() -> Result<()> {
     .assert()
     .success();
 
-    let metadata_file_exist = test_env.storage.exists(&Path::new(index_id).join("quickwit.json")).await?;
+    let metadata_file_exist = test_env
+        .storage
+        .exists(&Path::new(index_id).join("quickwit.json"))
+        .await?;
     assert_eq!(metadata_file_exist, true);
 
     index_data(
@@ -654,7 +657,7 @@ async fn test_all_local_index() -> Result<()> {
     .text()
     .await?;
     assert_eq!(search_stream_response, "2\n13\n");
-    
+
     server_process.kill().unwrap();
 
     make_command(
@@ -666,7 +669,10 @@ async fn test_all_local_index() -> Result<()> {
     )
     .assert()
     .success();
-    let metadata_file_exist = test_env.storage.exists(&Path::new(index_id).join("quickwit.json")).await?;
+    let metadata_file_exist = test_env
+        .storage
+        .exists(&Path::new(index_id).join("quickwit.json"))
+        .await?;
     assert_eq!(metadata_file_exist, false);
 
     Ok(())

--- a/quickwit-search/src/client.rs
+++ b/quickwit-search/src/client.rs
@@ -126,7 +126,7 @@ impl SearchServiceClient {
     pub async fn leaf_search_stream(
         &mut self,
         request: quickwit_proto::LeafSearchStreamRequest,
-    ) -> crate::Result<UnboundedReceiverStream<Result<LeafSearchStreamResult, tonic::Status>>> {
+    ) -> crate::Result<UnboundedReceiverStream<crate::Result<LeafSearchStreamResult>>> {
         match &mut self.client_impl {
             SearchServiceClientImpl::Grpc(grpc_client) => {
                 let mut grpc_client_clone = grpc_client.clone();
@@ -138,25 +138,35 @@ impl SearchServiceClient {
                         .await
                         .map_err(|tonic_error| parse_grpc_error(&tonic_error))?
                         .into_inner();
+                    loop {
+                        let grpc_result = results_stream.message().await;
+                        if grpc_result.is_err() {
+                            result_sender
+                                .send(Err(parse_grpc_error(&grpc_result.unwrap_err())))
+                                .map_err(|_| {
+                                    SearchError::InternalError(
+                                        "Sender closed, could not send leaf result.".into(),
+                                    )
+                                })?;
+                            // Stop the loop as soon as we receive a leaf error.
+                            break;
+                        }
 
-                    // TODO: returning stream instead of a channel may be better.
-                    // But this seems to be difficult. Try it at your own expense.
-                    while let Some(result) = results_stream
-                        .message()
-                        .await
-                        .map_err(|status| parse_grpc_error(&status))?
-                    {
-                        // We want to stop doing unnecessary work on the leaves as soon as
-                        // there is an issue sending the result.
-                        // Terminating the task will drop the `result_stream` consequently
-                        // canceling the gRPC request.
-                        result_sender.send(Ok(result)).map_err(|_| {
-                            SearchError::InternalError("Could not send leaf result".into())
-                        })?;
+                        if let Some(result) = grpc_result.unwrap() {
+                            result_sender.send(Ok(result)).map_err(|_| {
+                                SearchError::InternalError(
+                                    "Sender closed, could not send leaf result.".into(),
+                                )
+                            })?;
+                        } else {
+                            // Stop the loop as soon as we get an empty message as this means that
+                            // there is no more result to receive.
+                            break;
+                        }
                     }
+
                     Result::<_, SearchError>::Ok(())
                 });
-
                 Ok(UnboundedReceiverStream::new(result_receiver))
             }
             SearchServiceClientImpl::Local(service) => service.leaf_search_stream(request).await,

--- a/quickwit-search/src/error.rs
+++ b/quickwit-search/src/error.rs
@@ -29,7 +29,7 @@ use quickwit_storage::StorageResolverError;
 
 /// Possible SearchError
 #[allow(missing_docs)]
-#[derive(Error, Debug, Serialize, Deserialize)]
+#[derive(Error, Debug, Serialize, Deserialize, Clone)]
 pub enum SearchError {
     #[error("Index `{index_id}` does not exist.")]
     IndexDoesNotExist { index_id: String },

--- a/quickwit-search/src/leaf.rs
+++ b/quickwit-search/src/leaf.rs
@@ -27,7 +27,7 @@ use quickwit_directories::{CachingDirectory, HotDirectory, StorageDirectory};
 use quickwit_index_config::IndexConfig;
 use quickwit_proto::{LeafSearchResult, SearchRequest, SplitIdAndFooterOffsets, SplitSearchError};
 use quickwit_storage::{BundleStorage, Storage};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::convert::TryInto;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -81,7 +81,7 @@ pub(crate) async fn open_index(
 pub(crate) async fn warmup(
     searcher: &Searcher,
     query: &dyn Query,
-    fast_field_names: Vec<String>,
+    fast_field_names: &HashSet<String>,
 ) -> anyhow::Result<()> {
     warm_up_terms(searcher, query).await?;
     warm_up_fastfields(searcher, fast_field_names).await?;
@@ -90,7 +90,7 @@ pub(crate) async fn warmup(
 
 async fn warm_up_fastfields(
     searcher: &Searcher,
-    fast_field_names: Vec<String>,
+    fast_field_names: &HashSet<String>,
 ) -> anyhow::Result<()> {
     let mut fast_fields = Vec::new();
     for fast_field_name in fast_field_names.iter() {
@@ -168,7 +168,7 @@ async fn leaf_search_single_split(
         .reload_policy(ReloadPolicy::Manual)
         .try_into()?;
     let searcher = reader.searcher();
-    warmup(&*searcher, &query, quickwit_collector.fast_field_names()).await?;
+    warmup(&*searcher, &query, &quickwit_collector.fast_field_names()).await?;
     let leaf_search_result = searcher.search(&query, &quickwit_collector)?;
     Ok(leaf_search_result)
 }

--- a/quickwit-search/src/search_stream/collector.rs
+++ b/quickwit-search/src/search_stream/collector.rs
@@ -18,6 +18,7 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+use std::collections::HashSet;
 use std::marker::PhantomData;
 
 use crate::filters::TimestampFilter;
@@ -167,12 +168,11 @@ impl FastFieldCollectorBuilder {
         self.fast_field_value_type
     }
 
-    pub fn fast_field_to_warm(&self) -> Vec<String> {
-        let mut fields = vec![self.fast_field_name.clone()];
+    pub fn fast_field_to_warm(&self) -> HashSet<String> {
+        let mut fields = HashSet::new();
+        fields.insert(self.fast_field_name.clone());
         if let Some(timestamp_field_name) = &self.timestamp_field_name {
-            if *timestamp_field_name != self.fast_field_name {
-                fields.push(timestamp_field_name.clone());
-            }
+            fields.insert(timestamp_field_name.clone());
         }
         fields
     }
@@ -200,6 +200,8 @@ impl FastFieldCollectorBuilder {
 
 #[cfg(test)]
 mod tests {
+    use std::iter::FromIterator;
+
     use super::*;
 
     #[test]
@@ -212,7 +214,7 @@ mod tests {
             None,
             None,
         )?;
-        assert_eq!(builder.fast_field_to_warm(), vec!["field_name"]);
+        assert_eq!(builder.fast_field_to_warm(), HashSet::from_iter(["field_name".to_string()]));
         let builder = FastFieldCollectorBuilder::new(
             Type::U64,
             "field_name".to_string(),
@@ -223,7 +225,7 @@ mod tests {
         )?;
         assert_eq!(
             builder.fast_field_to_warm(),
-            vec!["field_name", "timestamp_field_name"]
+            HashSet::from_iter(["field_name".to_string(), "timestamp_field_name".to_string()])
         );
         Ok(())
     }

--- a/quickwit-search/src/search_stream/collector.rs
+++ b/quickwit-search/src/search_stream/collector.rs
@@ -214,7 +214,10 @@ mod tests {
             None,
             None,
         )?;
-        assert_eq!(builder.fast_field_to_warm(), HashSet::from_iter(["field_name".to_string()]));
+        assert_eq!(
+            builder.fast_field_to_warm(),
+            HashSet::from_iter(["field_name".to_string()])
+        );
         let builder = FastFieldCollectorBuilder::new(
             Type::U64,
             "field_name".to_string(),

--- a/quickwit-search/src/search_stream/collector.rs
+++ b/quickwit-search/src/search_stream/collector.rs
@@ -168,11 +168,13 @@ impl FastFieldCollectorBuilder {
     }
 
     pub fn fast_field_to_warm(&self) -> Vec<String> {
+        let mut fields = vec![self.fast_field_name.clone()];
         if let Some(timestamp_field_name) = &self.timestamp_field_name {
-            vec![timestamp_field_name.clone(), self.fast_field_name.clone()]
-        } else {
-            vec![self.fast_field_name.clone()]
+            if *timestamp_field_name != self.fast_field_name {
+                fields.push(timestamp_field_name.clone());
+            }
         }
+        fields
     }
 
     pub fn typed_build<TFastValue: FastValue>(&self) -> FastFieldCollector<TFastValue> {
@@ -193,5 +195,36 @@ impl FastFieldCollectorBuilder {
     pub fn build_u64(&self) -> FastFieldCollector<u64> {
         // TODO: check type
         self.typed_build::<u64>()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_fast_field_collector_builder() -> anyhow::Result<()> {
+        let builder = FastFieldCollectorBuilder::new(
+            Type::U64,
+            "field_name".to_string(),
+            Some("field_name".to_string()),
+            None,
+            None,
+            None,
+        )?;
+        assert_eq!(builder.fast_field_to_warm(), vec!["field_name"]);
+        let builder = FastFieldCollectorBuilder::new(
+            Type::U64,
+            "field_name".to_string(),
+            Some("timestamp_field_name".to_string()),
+            None,
+            None,
+            None,
+        )?;
+        assert_eq!(
+            builder.fast_field_to_warm(),
+            vec!["field_name", "timestamp_field_name"]
+        );
+        Ok(())
     }
 }

--- a/quickwit-search/src/search_stream/leaf.rs
+++ b/quickwit-search/src/search_stream/leaf.rs
@@ -22,6 +22,7 @@ use super::FastFieldCollectorBuilder;
 use crate::leaf::open_index;
 use crate::leaf::warmup;
 use crate::SearchError;
+use futures::{FutureExt, StreamExt};
 use quickwit_index_config::IndexConfig;
 use quickwit_proto::LeafSearchStreamResult;
 use quickwit_proto::OutputFormat;
@@ -30,9 +31,17 @@ use quickwit_proto::SearchStreamRequest;
 use quickwit_proto::SplitIdAndFooterOffsets;
 use quickwit_storage::Storage;
 use std::sync::Arc;
+use tantivy::query::Query;
 use tantivy::schema::Type;
+use tantivy::LeasedItem;
 use tantivy::ReloadPolicy;
+use tantivy::Searcher;
+use tokio::task::spawn_blocking;
 use tokio_stream::wrappers::UnboundedReceiverStream;
+use tracing::error;
+
+// TODO: buffer of 5 seems to be sufficient to do the job locally, needs to be tested on a cluster.
+const CONCURRENT_SPLIT_SEARCH_STREAM: usize = 5;
 
 /// `leaf` step of search stream.
 // Note: we return a stream of a result with a tonic::Status error
@@ -46,39 +55,59 @@ pub async fn leaf_search_stream(
     storage: Arc<dyn Storage>,
     splits: Vec<SplitIdAndFooterOffsets>,
     index_config: Arc<dyn IndexConfig>,
-) -> UnboundedReceiverStream<Result<LeafSearchStreamResult, tonic::Status>> {
+) -> UnboundedReceiverStream<crate::Result<LeafSearchStreamResult>> {
     let (result_sender, result_receiver) = tokio::sync::mpsc::unbounded_channel();
-    for split in splits {
-        let index_config_clone = index_config.clone();
-        let result_sender_clone = result_sender.clone();
-        let request_clone = request.clone();
-        let storage_clone = storage.clone();
-        tokio::spawn(async move {
-            let leaf_split_result = leaf_search_stream_single_split(
-                split.clone(),
-                index_config_clone,
-                &request_clone,
-                storage_clone,
-            )
-            .await
-            .map_err(SearchError::convert_to_tonic_status);
-            result_sender_clone.send(leaf_split_result).map_err(|_| {
-                SearchError::InternalError(format!(
-                    "Unable to send leaf export result for split `{}`",
-                    &split.split_id
-                ))
-            })?;
-            Result::<(), SearchError>::Ok(())
-        });
-    }
+    let request_clone = request.clone();
+    tokio::spawn(async move {
+        let mut stream =
+            leaf_search_results_stream(request_clone, storage, splits, index_config).await;
+        while let Some(item) = stream.next().await {
+            if let Err(error) = result_sender.send(item) {
+                error!(
+                    "Failed to send leaf search stream result. Stop sending. Cause: {}",
+                    error
+                );
+                break;
+            }
+        }
+    });
     UnboundedReceiverStream::new(result_receiver)
+}
+
+async fn leaf_search_results_stream(
+    request: SearchStreamRequest,
+    storage: Arc<dyn Storage>,
+    splits: Vec<SplitIdAndFooterOffsets>,
+    index_config: Arc<dyn IndexConfig>,
+) -> impl futures::Stream<Item = crate::Result<LeafSearchStreamResult>> + Sync + Send + 'static {
+    futures::stream::iter(splits)
+        .map(move |split| {
+            (
+                split,
+                index_config.clone(),
+                request.clone(),
+                storage.clone(),
+            )
+        })
+        .map(
+            |(split, index_config_clone, request_clone, split_storage)| {
+                leaf_search_stream_single_split(
+                    split,
+                    index_config_clone,
+                    request_clone,
+                    split_storage,
+                )
+                .shared()
+            },
+        )
+        .buffer_unordered(CONCURRENT_SPLIT_SEARCH_STREAM)
 }
 
 /// Apply a leaf search on a single split.
 async fn leaf_search_stream_single_split(
     split: SplitIdAndFooterOffsets,
     index_config: Arc<dyn IndexConfig>,
-    stream_request: &SearchStreamRequest,
+    stream_request: SearchStreamRequest,
     storage: Arc<dyn Storage>,
 ) -> crate::Result<LeafSearchStreamResult> {
     let index = open_index(storage, &split).await?;
@@ -88,8 +117,8 @@ async fn leaf_search_stream_single_split(
         .get_field(&fast_field_to_extract)
         .ok_or_else(|| {
             SearchError::InvalidQuery(format!(
-                "Fast field `{}` does not exist.",
-                fast_field_to_extract
+                "Fast field `{}` does not exist for split {}.",
+                fast_field_to_extract, split.split_id,
             ))
         })?;
     let fast_field_type = split_schema.get_field_entry(fast_field).field_type();
@@ -103,7 +132,10 @@ async fn leaf_search_stream_single_split(
     )?;
 
     let output_format = OutputFormat::from_i32(stream_request.output_format).ok_or_else(|| {
-        SearchError::InternalError("Invalid output format specified.".to_string())
+        SearchError::InternalError(format!(
+            "Invalid output format specified for split {}.",
+            split.split_id
+        ))
     })?;
     let search_request = SearchRequest::from(stream_request.clone());
     let query = index_config.query(split_schema, &search_request)?;
@@ -120,6 +152,27 @@ async fn leaf_search_stream_single_split(
         fast_field_collector_builder.fast_field_to_warm(),
     )
     .await?;
+    let collect_handle = spawn_blocking(move || {
+        collect_fast_field_values(
+            &fast_field_collector_builder,
+            &searcher,
+            query,
+            output_format,
+        )
+    });
+    let buffer = collect_handle.await.map_err(|error| {
+        error!(split_id = %split.split_id, fast_field=%fast_field_to_extract, error_message=%error, "Failed to collect fast field");
+        SearchError::InternalError(format!("Error when collecting fast field values for split {}: {:?}", split.split_id, error))
+    })??;
+    Ok(LeafSearchStreamResult { data: buffer })
+}
+
+fn collect_fast_field_values(
+    fast_field_collector_builder: &FastFieldCollectorBuilder,
+    searcher: &LeasedItem<Searcher>,
+    query: Box<dyn Query>,
+    output_format: OutputFormat,
+) -> crate::Result<Vec<u8>> {
     let mut buffer = Vec::new();
     match fast_field_collector_builder.value_type() {
         Type::I64 => {
@@ -151,5 +204,5 @@ async fn leaf_search_stream_single_split(
             )));
         }
     }
-    Ok(LeafSearchStreamResult { data: buffer })
+    Ok(buffer)
 }

--- a/quickwit-search/src/search_stream/root.rs
+++ b/quickwit-search/src/search_stream/root.rs
@@ -201,7 +201,7 @@ mod tests {
                 Ok(UnboundedReceiverStream::new(result_receiver))
             },
         );
-        // The test will hang on indefinitely if we don't drop the receiver.
+        // The test will hang on indefinitely if we don't drop the sender.
         drop(result_sender);
         let client_pool =
             Arc::new(SearchClientPool::from_mocks(vec![Arc::new(mock_search_service)]).await?);
@@ -252,7 +252,7 @@ mod tests {
                 Ok(UnboundedReceiverStream::new(result_receiver))
             },
         );
-        // The test will hang on indefinitely if we don't drop the receiver.
+        // The test will hang on indefinitely if we don't drop the sender.
         drop(result_sender);
         let client_pool =
             Arc::new(SearchClientPool::from_mocks(vec![Arc::new(mock_search_service)]).await?);

--- a/quickwit-search/src/search_stream/root.rs
+++ b/quickwit-search/src/search_stream/root.rs
@@ -36,7 +36,6 @@ use quickwit_metastore::Metastore;
 use quickwit_proto::SearchRequest;
 
 use crate::client_pool::Job;
-use crate::error::parse_grpc_error;
 use crate::list_relevant_splits;
 use crate::root::job_for_splits;
 use crate::root::NodeSearchError;
@@ -96,8 +95,8 @@ pub async fn root_search_stream(
 
             let mut leaf_bytes: Vec<Bytes> = Vec::new();
             while let Some(leaf_result) = receiver.next().await {
-                let leaf_data = leaf_result.map_err(|status| NodeSearchError {
-                    search_error: parse_grpc_error(&status),
+                let leaf_data = leaf_result.map_err(|search_error| NodeSearchError {
+                    search_error,
                     split_ids: split_metadata_list
                         .iter()
                         .map(|split| split.split_id.clone())

--- a/quickwit-search/src/service.rs
+++ b/quickwit-search/src/service.rs
@@ -188,7 +188,7 @@ impl SearchService for SearchServiceImpl {
         let storage = self.storage_resolver.resolve(&index_metadata.index_uri)?;
         let index_config = index_metadata.index_config;
         let leaf_receiver = leaf_search_stream(
-            &stream_request,
+            stream_request,
             storage.clone(),
             leaf_stream_request.split_metadata,
             index_config,

--- a/quickwit-search/src/service.rs
+++ b/quickwit-search/src/service.rs
@@ -89,7 +89,7 @@ pub trait SearchService: 'static + Send + Sync {
     async fn leaf_search_stream(
         &self,
         _request: LeafSearchStreamRequest,
-    ) -> crate::Result<UnboundedReceiverStream<Result<LeafSearchStreamResult, tonic::Status>>>;
+    ) -> crate::Result<UnboundedReceiverStream<crate::Result<LeafSearchStreamResult>>>;
 }
 
 impl SearchServiceImpl {
@@ -176,7 +176,7 @@ impl SearchService for SearchServiceImpl {
     async fn leaf_search_stream(
         &self,
         leaf_stream_request: LeafSearchStreamRequest,
-    ) -> crate::Result<UnboundedReceiverStream<Result<LeafSearchStreamResult, tonic::Status>>> {
+    ) -> crate::Result<UnboundedReceiverStream<crate::Result<LeafSearchStreamResult>>> {
         let stream_request = leaf_stream_request
             .request
             .ok_or_else(|| SearchError::InternalError("No search request.".to_string()))?;

--- a/quickwit-serve/src/grpc_adapter/search_adapter.rs
+++ b/quickwit-serve/src/grpc_adapter/search_adapter.rs
@@ -22,7 +22,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use tokio_stream::wrappers::UnboundedReceiverStream;
+use futures::TryStreamExt;
 
 use quickwit_proto::{
     search_service_server as grpc, LeafSearchStreamRequest, LeafSearchStreamResult,
@@ -79,8 +79,11 @@ impl grpc::SearchService for GrpcSearchAdapter {
         Ok(tonic::Response::new(fetch_docs_result))
     }
 
-    type LeafSearchStreamStream =
-        UnboundedReceiverStream<Result<LeafSearchStreamResult, tonic::Status>>;
+    type LeafSearchStreamStream = std::pin::Pin<
+        Box<
+            dyn futures::Stream<Item = Result<LeafSearchStreamResult, tonic::Status>> + Send + Sync,
+        >,
+    >;
     async fn leaf_search_stream(
         &self,
         request: tonic::Request<LeafSearchStreamRequest>,
@@ -90,7 +93,8 @@ impl grpc::SearchService for GrpcSearchAdapter {
             .0
             .leaf_search_stream(leaf_search_request)
             .await
-            .map_err(SearchError::convert_to_tonic_status)?;
-        Ok(tonic::Response::new(leaf_search_result))
+            .map_err(SearchError::convert_to_tonic_status)?
+            .map_err(SearchError::convert_to_tonic_status);
+        Ok(tonic::Response::new(Box::pin(leaf_search_result)))
     }
 }

--- a/quickwit-storage/src/error.rs
+++ b/quickwit-storage/src/error.rs
@@ -42,7 +42,7 @@ pub enum StorageErrorKind {
 
 /// Generic Storage Resolver Error.
 #[allow(missing_docs)]
-#[derive(Error, Debug, Serialize, Deserialize)]
+#[derive(Error, Debug, Serialize, Deserialize, Clone)]
 pub enum StorageResolverError {
     /// The input is not a valid URI.
     /// A protocol is required for the URI.


### PR DESCRIPTION
Fixes #483 #484 

Bonus: 
- the leaf stream return a search error and not a tonic status
- add tests at the root and leaf levels
- add test on the cli (csv output)

Not included:
- tests on collector: some important changes are coming soon and I would prefer to implement tests at this moment
- tests on performance would be nice