### PR TITLE
Add and apply rustfmt config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
             target/
           key: ${{ runner.os }}-cargolint-${{ hashFiles('Cargo.lock') }}
       - name: rustfmt
-        run: cargo fmt --all -- --check
+        run: cargo +nightly fmt --all -- --check
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.license_header.txt
+++ b/.license_header.txt
@@ -1,0 +1,19 @@
+// Copyright (C) {\d+} Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+

--- a/Makefile
+++ b/Makefile
@@ -7,3 +7,5 @@ license-check:
 license-fix:
 	docker run -it --rm -v $(shell pwd):/github/workspace apache/skywalking-eyes header fix
 
+fmt:
+	rustup toolchain list | grep nightly -q && cargo +nightly fmt || echo "Toolchain 'nightly' is not installed. Please install using 'rustup toolchain install nightly'."

--- a/quickwit-actors/src/actor.rs
+++ b/quickwit-actors/src/actor.rs
@@ -1,40 +1,39 @@
-//  Quickwit
-//  Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
 //
-//  Quickwit is offered under the AGPL v3.0 and as commercial software.
-//  For commercial licensing, contact us at hello@quickwit.io.
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
 //
-//  AGPL:
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU Affero General Public License as
-//  published by the Free Software Foundation, either version 3 of the
-//  License, or (at your option) any later version.
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
 //
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU Affero General Public License for more details.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
 //
-//  You should have received a copy of the GNU Affero General Public License
-//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+use std::any::type_name;
 use std::fmt;
 use std::ops::Deref;
+use std::sync::Arc;
 use std::time::Duration;
-use std::{any::type_name, sync::Arc};
+
 use thiserror::Error;
 use tokio::sync::watch::Sender;
 use tracing::{debug, error};
 
+use crate::actor_state::{ActorState, AtomicState};
 use crate::channel_with_priority::Priority;
 use crate::mailbox::{Command, CommandOrMessage};
+use crate::progress::{Progress, ProtectedZoneGuard};
 use crate::scheduler::{Callback, SchedulerMessage};
 use crate::spawn_builder::SpawnBuilder;
-use crate::{
-    actor_state::{ActorState, AtomicState},
-    progress::{Progress, ProtectedZoneGuard},
-    KillSwitch, Mailbox, QueueCapacity, SendError,
-};
+use crate::{KillSwitch, Mailbox, QueueCapacity, SendError};
 
 /// The actor exit status represents the outcome of the execution of an actor,
 /// after the end of the execution.
@@ -58,7 +57,8 @@ pub enum ActorExitStatus {
 
     /// The actor was asked to gracefully shutdown.
     ///
-    /// (Semantically equivalent to exit status code 130, triggered by SIGINT aka Ctrl-C, or SIGQUIT)
+    /// (Semantically equivalent to exit status code 130, triggered by SIGINT aka Ctrl-C, or
+    /// SIGQUIT)
     #[error("Quit")]
     Quit,
 

--- a/quickwit-actors/src/actor_handle.rs
+++ b/quickwit-actors/src/actor_handle.rs
@@ -1,36 +1,37 @@
-/*
- * Copyright (C) 2021 Quickwit Inc.
- *
- * Quickwit is offered under the AGPL v3.0 and as commercial software.
- * For commercial licensing, contact us at hello@quickwit.io.
- *
- * AGPL:
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use std::any::Any;
+use std::borrow::Borrow;
+use std::fmt;
+use std::sync::Arc;
+
+use tokio::sync::{oneshot, watch};
+use tokio::task::JoinHandle;
+use tokio::time::timeout;
+use tracing::error;
+
 use crate::actor_state::ActorState;
 use crate::channel_with_priority::Priority;
 use crate::mailbox::Command;
 use crate::observation::ObservationType;
 use crate::{Actor, ActorContext, ActorExitStatus, Observation};
-use std::any::Any;
-use std::borrow::Borrow;
-use std::fmt;
-use std::sync::Arc;
-use tokio::sync::{oneshot, watch};
-use tokio::task::JoinHandle;
-use tokio::time::timeout;
-use tracing::error;
 
 /// An Actor Handle serves as an address to communicate with an actor.
 pub struct ActorHandle<A: Actor> {
@@ -134,8 +135,8 @@ impl<A: Actor> ActorHandle<A> {
                 "Failed to send observe message"
             );
         }
-        // The timeout is required here. If the actor fails, its inbox is properly dropped but the send channel might actually
-        // prevent the onechannel Receiver from being dropped.
+        // The timeout is required here. If the actor fails, its inbox is properly dropped but the
+        // send channel might actually prevent the onechannel Receiver from being dropped.
         self.wait_for_observable_state_callback(rx).await
     }
 
@@ -275,12 +276,10 @@ impl<A: Actor> ActorHandle<A> {
 
 #[cfg(test)]
 mod tests {
-    use crate::AsyncActor;
-    use crate::SyncActor;
-    use crate::Universe;
     use async_trait::async_trait;
 
     use super::*;
+    use crate::{AsyncActor, SyncActor, Universe};
 
     #[derive(Default)]
     struct PanickingActor {

--- a/quickwit-actors/src/actor_state.rs
+++ b/quickwit-actors/src/actor_state.rs
@@ -1,25 +1,23 @@
-// Quickwit
-//  Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
 //
-//  Quickwit is offered under the AGPL v3.0 and as commercial software.
-//  For commercial licensing, contact us at hello@quickwit.io.
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
 //
-//  AGPL:
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU Affero General Public License as
-//  published by the Free Software Foundation, either version 3 of the
-//  License, or (at your option) any later version.
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
 //
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU Affero General Public License for more details.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
 //
-//  You should have received a copy of the GNU Affero General Public License
-//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use std::sync::atomic::AtomicU32;
-use std::sync::atomic::Ordering;
+use std::sync::atomic::{AtomicU32, Ordering};
 
 #[repr(u32)]
 #[derive(Clone, Debug, Copy, Eq, PartialEq)]

--- a/quickwit-actors/src/actor_with_state_tx.rs
+++ b/quickwit-actors/src/actor_with_state_tx.rs
@@ -1,26 +1,25 @@
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
 use tokio::sync::watch::Sender;
 
 use crate::Actor;
-
-// Quickwit
-//  Copyright (C) 2021 Quickwit Inc.
-//
-//  Quickwit is offered under the AGPL v3.0 and as commercial software.
-//  For commercial licensing, contact us at hello@quickwit.io.
-//
-//  AGPL:
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU Affero General Public License as
-//  published by the Free Software Foundation, either version 3 of the
-//  License, or (at your option) any later version.
-//
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU Affero General Public License for more details.
-//
-//  You should have received a copy of the GNU Affero General Public License
-//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 pub struct ActorWithStateTx<A: Actor> {
     pub actor: A,

--- a/quickwit-actors/src/async_actor.rs
+++ b/quickwit-actors/src/async_actor.rs
@@ -1,22 +1,27 @@
-//  Quickwit
-//  Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
 //
-//  Quickwit is offered under the AGPL v3.0 and as commercial software.
-//  For commercial licensing, contact us at hello@quickwit.io.
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
 //
-//  AGPL:
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU Affero General Public License as
-//  published by the Free Software Foundation, either version 3 of the
-//  License, or (at your option) any later version.
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
 //
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU Affero General Public License for more details.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
 //
-//  You should have received a copy of the GNU Affero General Public License
-//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use anyhow::Context;
+use async_trait::async_trait;
+use tokio::sync::watch::{self, Sender};
+use tokio::task::JoinHandle;
+use tracing::{debug, error, info};
 
 use crate::actor::{process_command, ActorExitStatus};
 use crate::actor_handle::ActorHandle;
@@ -24,11 +29,6 @@ use crate::actor_state::ActorState;
 use crate::actor_with_state_tx::ActorWithStateTx;
 use crate::mailbox::{CommandOrMessage, Inbox};
 use crate::{Actor, ActorContext, RecvError};
-use anyhow::Context;
-use async_trait::async_trait;
-use tokio::sync::watch::{self, Sender};
-use tokio::task::JoinHandle;
-use tracing::{debug, error, info};
 
 /// An async actor is executed on a regular tokio task.
 ///

--- a/quickwit-actors/src/channel_with_priority.rs
+++ b/quickwit-actors/src/channel_with_priority.rs
@@ -1,26 +1,25 @@
-/*
- * Copyright (C) 2021 Quickwit Inc.
- *
- * Quickwit is offered under the AGPL v3.0 and as commercial software.
- * For commercial licensing, contact us at hello@quickwit.io.
- *
- * AGPL:
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
-use flume::RecvTimeoutError;
-use flume::TryRecvError;
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
 use std::time::Duration;
+
+use flume::{RecvTimeoutError, TryRecvError};
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -257,8 +256,7 @@ impl<T> Receiver<T> {
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
-    use std::time::Instant;
+    use std::time::{Duration, Instant};
 
     use super::*;
 

--- a/quickwit-actors/src/kill_switch.rs
+++ b/quickwit-actors/src/kill_switch.rs
@@ -1,25 +1,23 @@
-//  Quickwit
-//  Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
 //
-//  Quickwit is offered under the AGPL v3.0 and as commercial software.
-//  For commercial licensing, contact us at hello@quickwit.io.
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
 //
-//  AGPL:
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU Affero General Public License as
-//  published by the Free Software Foundation, either version 3 of the
-//  License, or (at your option) any later version.
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
 //
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU Affero General Public License for more details.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
 //
-//  You should have received a copy of the GNU Affero General Public License
-//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use std::sync::atomic::AtomicBool;
-use std::sync::atomic::Ordering;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 #[derive(Clone)]

--- a/quickwit-actors/src/lib.rs
+++ b/quickwit-actors/src/lib.rs
@@ -1,33 +1,29 @@
-//  Quickwit
-//  Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
 //
-//  Quickwit is offered under the AGPL v3.0 and as commercial software.
-//  For commercial licensing, contact us at hello@quickwit.io.
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
 //
-//  AGPL:
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU Affero General Public License as
-//  published by the Free Software Foundation, either version 3 of the
-//  License, or (at your option) any later version.
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
 //
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU Affero General Public License for more details.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
 //
-//  You should have received a copy of the GNU Affero General Public License
-//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-/*!
-quickwit-actors is a simplified actor framework for quickwit.
-
-It solves the following problem:
-- have sync and async tasks communicate together.
-- make these task observable
-- make these task modular and testable
-- detect when some task is stuck and does not progress anymore
-
-*/
+//! quickwit-actors is a simplified actor framework for quickwit.
+//!
+//! It solves the following problem:
+//! - have sync and async tasks communicate together.
+//! - make these task observable
+//! - make these task modular and testable
+//! - detect when some task is stuck and does not progress anymore
 
 use tokio::time::Duration;
 mod actor;
@@ -47,10 +43,6 @@ mod sync_actor;
 mod tests;
 mod universe;
 
-pub use self::actor::ActorContext;
-pub use self::actor_state::ActorState;
-pub use self::channel_with_priority::{QueueCapacity, RecvError, SendError};
-pub use self::mailbox::{create_mailbox, create_test_mailbox, Mailbox};
 pub use actor::{Actor, ActorExitStatus};
 pub use actor_handle::{ActorHandle, Health, Supervisable};
 pub use async_actor::AsyncActor;
@@ -59,6 +51,11 @@ pub use observation::{Observation, ObservationType};
 pub(crate) use scheduler::Scheduler;
 pub use sync_actor::SyncActor;
 pub use universe::Universe;
+
+pub use self::actor::ActorContext;
+pub use self::actor_state::ActorState;
+pub use self::channel_with_priority::{QueueCapacity, RecvError, SendError};
+pub use self::mailbox::{create_mailbox, create_test_mailbox, Mailbox};
 
 /// Heartbeat used to verify that actors are progressing.
 ///

--- a/quickwit-actors/src/mailbox.rs
+++ b/quickwit-actors/src/mailbox.rs
@@ -1,36 +1,31 @@
-//  Quickwit
-//  Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
 //
-//  Quickwit is offered under the AGPL v3.0 and as commercial software.
-//  For commercial licensing, contact us at hello@quickwit.io.
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
 //
-//  AGPL:
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU Affero General Public License as
-//  published by the Free Software Foundation, either version 3 of the
-//  License, or (at your option) any later version.
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
 //
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU Affero General Public License for more details.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
 //
-//  You should have received a copy of the GNU Affero General Public License
-//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::any::Any;
 use std::fmt;
+use std::hash::Hash;
 use std::sync::Arc;
 
-use std::hash::Hash;
 use tokio::sync::oneshot;
 
-use crate::channel_with_priority::Priority;
-use crate::channel_with_priority::Receiver;
-use crate::channel_with_priority::Sender;
-use crate::QueueCapacity;
-use crate::RecvError;
-use crate::SendError;
+use crate::channel_with_priority::{Priority, Receiver, Sender};
+use crate::{QueueCapacity, RecvError, SendError};
 
 /// A mailbox is the object that makes it possible to send a message
 /// to an actor.

--- a/quickwit-actors/src/observation.rs
+++ b/quickwit-actors/src/observation.rs
@@ -1,22 +1,21 @@
-//  Quickwit
-//  Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
 //
-//  Quickwit is offered under the AGPL v3.0 and as commercial software.
-//  For commercial licensing, contact us at hello@quickwit.io.
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
 //
-//  AGPL:
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU Affero General Public License as
-//  published by the Free Software Foundation, either version 3 of the
-//  License, or (at your option) any later version.
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
 //
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU Affero General Public License for more details.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
 //
-//  You should have received a copy of the GNU Affero General Public License
-//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::fmt;
 use std::ops::Deref;

--- a/quickwit-actors/src/progress.rs
+++ b/quickwit-actors/src/progress.rs
@@ -1,25 +1,23 @@
-// Quickwit
-//  Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
 //
-//  Quickwit is offered under the AGPL v3.0 and as commercial software.
-//  For commercial licensing, contact us at hello@quickwit.io.
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
 //
-//  AGPL:
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU Affero General Public License as
-//  published by the Free Software Foundation, either version 3 of the
-//  License, or (at your option) any later version.
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
 //
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU Affero General Public License for more details.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
 //
-//  You should have received a copy of the GNU Affero General Public License
-//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use std::sync::atomic::AtomicU32;
-use std::sync::atomic::Ordering;
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 
 /// Progress makes it possible to register some progress.

--- a/quickwit-actors/src/scheduler.rs
+++ b/quickwit-actors/src/scheduler.rs
@@ -1,44 +1,40 @@
-// Quickwit
-//  Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
 //
-//  Quickwit is offered under the AGPL v3.0 and as commercial software.
-//  For commercial licensing, contact us at hello@quickwit.io.
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
 //
-//  AGPL:
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU Affero General Public License as
-//  published by the Free Software Foundation, either version 3 of the
-//  License, or (at your option) any later version.
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
 //
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU Affero General Public License for more details.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
 //
-//  You should have received a copy of the GNU Affero General Public License
-//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use async_trait::async_trait;
 use core::fmt;
-use futures::Future;
-use std::cmp::Ordering;
-use std::cmp::Reverse;
+use std::cmp::{Ordering, Reverse};
 use std::collections::BinaryHeap;
 use std::pin::Pin;
-use std::time::Duration;
-use std::time::Instant;
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+use futures::Future;
 use tokio::sync::oneshot::Sender;
 use tokio::task::JoinHandle;
 use tracing::info;
 
-use crate::Actor;
-use crate::ActorContext;
-use crate::AsyncActor;
+use crate::{Actor, ActorContext, AsyncActor};
 
 pub(crate) struct Callback(pub Pin<Box<dyn Future<Output = ()> + Sync + Send + 'static>>);
 
-// A bug in the rustc requires wrapping Box<...> in order to use it as an argument in an async method.
-// pub(crate) struct Callback(pub BoxFuture<'static, ()>);
+// A bug in the rustc requires wrapping Box<...> in order to use it as an argument in an async
+// method. pub(crate) struct Callback(pub BoxFuture<'static, ()>);
 
 struct TimeoutEvent {
     deadline: Instant,
@@ -198,8 +194,8 @@ impl Scheduler {
         {
             self.advance_by_duration(next_evt_before_deadline - now, ctx)
                 .await;
-            // We leave 100ms for actors to process their messages. A callback on process would not work here,
-            // as callbacks might create extra messages in turn.
+            // We leave 100ms for actors to process their messages. A callback on process would not
+            // work here, as callbacks might create extra messages in turn.
             // A good way could be to wait for the overall actors in the universe to be idle.
             tokio::time::sleep(Duration::from_millis(100)).await;
             let _ = ctx
@@ -281,13 +277,15 @@ impl Scheduler {
 
 #[cfg(test)]
 mod tests {
-    use super::{Callback, Scheduler, SchedulerMessage};
-    use crate::scheduler::{SchedulerCounters, TimeShift};
-    use crate::Universe;
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::Arc;
     use std::time::Duration;
+
     use tokio::sync::oneshot;
+
+    use super::{Callback, Scheduler, SchedulerMessage};
+    use crate::scheduler::{SchedulerCounters, TimeShift};
+    use crate::Universe;
 
     fn create_test_callback() -> (Arc<AtomicBool>, Callback) {
         let cb_called = Arc::new(AtomicBool::default());

--- a/quickwit-actors/src/spawn_builder.rs
+++ b/quickwit-actors/src/spawn_builder.rs
@@ -1,22 +1,21 @@
-//  Quickwit
-//  Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
 //
-//  Quickwit is offered under the AGPL v3.0 and as commercial software.
-//  For commercial licensing, contact us at hello@quickwit.io.
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
 //
-//  AGPL:
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU Affero General Public License as
-//  published by the Free Software Foundation, either version 3 of the
-//  License, or (at your option) any later version.
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
 //
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU Affero General Public License for more details.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
 //
-//  You should have received a copy of the GNU Affero General Public License
-//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use crate::async_actor::spawn_async_actor;
 use crate::mailbox::Inbox;

--- a/quickwit-actors/src/sync_actor.rs
+++ b/quickwit-actors/src/sync_actor.rs
@@ -1,22 +1,21 @@
-//  Quickwit
-//  Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
 //
-//  Quickwit is offered under the AGPL v3.0 and as commercial software.
-//  For commercial licensing, contact us at hello@quickwit.io.
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
 //
-//  AGPL:
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU Affero General Public License as
-//  published by the Free Software Foundation, either version 3 of the
-//  License, or (at your option) any later version.
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
 //
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU Affero General Public License for more details.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
 //
-//  You should have received a copy of the GNU Affero General Public License
-//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use tokio::sync::watch::{self, Sender};
 use tokio::task::{spawn_blocking, JoinHandle};
@@ -89,7 +88,8 @@ pub(crate) fn spawn_sync_actor<A: SyncActor>(
 
 /// Process a given message.
 ///
-/// If some `ActorExitStatus` is returned, the actor will exit and no more message will be processed.
+/// If some `ActorExitStatus` is returned, the actor will exit and no more message will be
+/// processed.
 fn process_msg<A: Actor + SyncActor>(
     actor: &mut A,
     inbox: &mut Inbox<A::Message>,

--- a/quickwit-actors/src/tests.rs
+++ b/quickwit-actors/src/tests.rs
@@ -1,33 +1,32 @@
-/*
- * Copyright (C) 2021 Quickwit Inc.
- *
- * Quickwit is offered under the AGPL v3.0 and as commercial software.
- * For commercial licensing, contact us at hello@quickwit.io.
- *
- * AGPL:
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use std::collections::HashSet;
+
+use async_trait::async_trait;
+
 use crate::mailbox::Command;
 use crate::observation::ObservationType;
-use crate::Actor;
-use crate::ActorHandle;
-use crate::Health;
-use crate::Supervisable;
-use crate::Universe;
-use crate::{ActorContext, ActorExitStatus, AsyncActor, Mailbox, Observation, SyncActor};
-use async_trait::async_trait;
-use std::collections::HashSet;
+use crate::{
+    Actor, ActorContext, ActorExitStatus, ActorHandle, AsyncActor, Health, Mailbox, Observation,
+    Supervisable, SyncActor, Universe,
+};
 
 // An actor that receives ping messages.
 #[derive(Default)]
@@ -217,7 +216,7 @@ async fn test_ping_actor() {
         ping_recv_handle.process_pending_and_observe().await,
         Observation {
             obs_type: ObservationType::PostMortem,
-            state: 2,
+            state: 2
         }
     );
     assert_eq!(

--- a/quickwit-actors/src/universe.rs
+++ b/quickwit-actors/src/universe.rs
@@ -1,42 +1,37 @@
-// Quickwit
-//  Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
 //
-//  Quickwit is offered under the AGPL v3.0 and as commercial software.
-//  For commercial licensing, contact us at hello@quickwit.io.
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
 //
-//  AGPL:
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU Affero General Public License as
-//  published by the Free Software Foundation, either version 3 of the
-//  License, or (at your option) any later version.
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
 //
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU Affero General Public License for more details.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
 //
-//  You should have received a copy of the GNU Affero General Public License
-//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::time::Duration;
 
-use crate::scheduler::SchedulerMessage;
-use crate::scheduler::TimeShift;
+use crate::scheduler::{SchedulerMessage, TimeShift};
 use crate::spawn_builder::SpawnBuilder;
-use crate::Actor;
-use crate::KillSwitch;
-use crate::Mailbox;
-use crate::QueueCapacity;
-use crate::Scheduler;
+use crate::{Actor, KillSwitch, Mailbox, QueueCapacity, Scheduler};
 
 /// Universe serves as the top-level context in which Actor can be spawned.
-/// It is *not* a singleton. A typical application will usually have only one universe hosting all of the actors
-/// but it is not a requirement.
+/// It is *not* a singleton. A typical application will usually have only one universe hosting all
+/// of the actors but it is not a requirement.
 ///
 /// In particular, unit test all have their own universe and hence can be executed in parallel.
 pub struct Universe {
     scheduler_mailbox: Mailbox<<Scheduler as Actor>::Message>,
-    // This killswitch is used for the scheduler, and will be used by default for all spawned actors.
+    // This killswitch is used for the scheduler, and will be used by default for all spawned
+    // actors.
     kill_switch: KillSwitch,
 }
 
@@ -109,11 +104,7 @@ mod tests {
 
     use async_trait::async_trait;
 
-    use crate::Actor;
-    use crate::ActorContext;
-    use crate::ActorExitStatus;
-    use crate::AsyncActor;
-    use crate::Universe;
+    use crate::{Actor, ActorContext, ActorExitStatus, AsyncActor, Universe};
 
     #[derive(Default)]
     pub struct ActorWithSchedule {

--- a/quickwit-cli/build.rs
+++ b/quickwit-cli/build.rs
@@ -1,23 +1,22 @@
-/*
- * Copyright (C) 2021 Quickwit Inc.
- *
- * Quickwit is offered under the AGPL v3.0 and as commercial software.
- * For commercial licensing, contact us at hello@quickwit.io.
- *
- * AGPL:
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
 fn main() {
     let git_commit_hash = std::env::var_os("GITHUB_SHA")
         .map_or("Unknown".to_string(), |value_os_str| {

--- a/quickwit-cli/src/lib.rs
+++ b/quickwit-cli/src/lib.rs
@@ -1,68 +1,50 @@
-/*
-    Quickwit
-    Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-    Quickwit is offered under the AGPL v3.0 and as commercial software.
-    For commercial licensing, contact us at hello@quickwit.io.
-
-    AGPL:
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation, either version 3 of the
-    License, or (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
-
-use anyhow::bail;
-use anyhow::Context;
-use byte_unit::Byte;
-use crossterm::style::Print;
-use crossterm::style::PrintStyledContent;
-use crossterm::style::Stylize;
-use crossterm::QueueableCommand;
-use json_comments::StripComments;
-use quickwit_actors::ActorExitStatus;
-use quickwit_actors::ActorHandle;
-use quickwit_actors::ObservationType;
-use quickwit_actors::Universe;
-use quickwit_common::extract_index_id_from_index_uri;
-use quickwit_core::reset_index;
-use quickwit_index_config::DefaultIndexConfigBuilder;
-use quickwit_index_config::IndexConfig;
-use quickwit_indexing::actors::IndexerParams;
-use quickwit_indexing::actors::{IndexingPipelineParams, IndexingPipelineSupervisor};
-use quickwit_indexing::models::CommitPolicy;
-use quickwit_indexing::models::IndexingStatistics;
-use quickwit_indexing::models::ScratchDirectory;
-use quickwit_indexing::source::FileSourceParams;
-use quickwit_indexing::source::SourceConfig;
-use quickwit_metastore::checkpoint::Checkpoint;
-use quickwit_metastore::IndexMetadata;
-use quickwit_metastore::MetastoreUriResolver;
-use quickwit_proto::SearchRequest;
-use quickwit_proto::SearchResult;
-use quickwit_search::single_node_search;
-use quickwit_search::SearchResultJson;
-use quickwit_storage::quickwit_storage_uri_resolver;
-use quickwit_telemetry::payload::TelemetryEvent;
 use std::collections::VecDeque;
-use std::env;
-use std::io::Stdout;
-use std::io::{stdout, Write};
+use std::io::{stdout, Stdout, Write};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use std::usize;
-use tracing::debug;
+use std::{env, usize};
 
-use quickwit_core::{create_index, delete_index, garbage_collect_index};
+use anyhow::{bail, Context};
+use byte_unit::Byte;
+use crossterm::style::{Print, PrintStyledContent, Stylize};
+use crossterm::QueueableCommand;
+use json_comments::StripComments;
+use quickwit_actors::{ActorExitStatus, ActorHandle, ObservationType, Universe};
+use quickwit_common::extract_index_id_from_index_uri;
+use quickwit_core::{create_index, delete_index, garbage_collect_index, reset_index};
+use quickwit_index_config::{DefaultIndexConfigBuilder, IndexConfig};
+use quickwit_indexing::actors::{
+    IndexerParams, IndexingPipelineParams, IndexingPipelineSupervisor,
+};
+use quickwit_indexing::models::{CommitPolicy, IndexingStatistics, ScratchDirectory};
+use quickwit_indexing::source::{FileSourceParams, SourceConfig};
+use quickwit_metastore::checkpoint::Checkpoint;
+use quickwit_metastore::{IndexMetadata, MetastoreUriResolver};
+use quickwit_proto::{SearchRequest, SearchResult};
+use quickwit_search::{single_node_search, SearchResultJson};
+use quickwit_storage::quickwit_storage_uri_resolver;
+use quickwit_telemetry::payload::TelemetryEvent;
+use tracing::debug;
 
 /// Throughput calculation window size.
 const THROUGHPUT_WINDOW_SIZE: usize = 5;
@@ -217,14 +199,22 @@ pub async fn index_data_cli(args: IndexDataArgs) -> anyhow::Result<()> {
             "windows" => "CTRL+Z",
             _ => "CTRL+D",
         };
-        println!("Please enter your new line delimited json documents one line at a time.\nEnd your input using {}.", eof_shortcut);
+        println!(
+            "Please enter your new line delimited json documents one line at a time.\nEnd your \
+             input using {}.",
+            eof_shortcut
+        );
     }
 
     let statistics =
         start_statistics_reporting_loop(supervisor_handler, args.input_path.clone()).await?;
 
     if statistics.num_published_splits > 0 {
-        println!("You can now query your index with `quickwit search --index-id {} --metastore-uri {} --query \"barack obama\"`" , args.index_id, args.metastore_uri);
+        println!(
+            "You can now query your index with `quickwit search --index-id {} --metastore-uri {} \
+             --query \"barack obama\"`",
+            args.index_id, args.metastore_uri
+        );
     }
     Ok(())
 }
@@ -344,8 +334,9 @@ pub async fn start_statistics_reporting_loop(
     let mut report_interval = tokio::time::interval(Duration::from_secs(1));
 
     loop {
-        // TODO fixme. The way we wait today is a bit lame: if the indexing pipeline exits, we will stil
-        // wait up to an entire heartbeat...  Ideally we should  select between two futures.
+        // TODO fixme. The way we wait today is a bit lame: if the indexing pipeline exits, we will
+        // stil wait up to an entire heartbeat...  Ideally we should  select between two
+        // futures.
         report_interval.tick().await;
         // Try to receive with a timeout of 1 second.
         // 1 second is also the frequency at which we update statistic in the console
@@ -395,7 +386,7 @@ pub async fn start_statistics_reporting_loop(
             is_tty,
         )?;
     }
-    //display end of task report
+    // display end of task report
     println!();
     let elapsed_secs = start_time.elapsed().as_secs();
     if elapsed_secs >= 60 {
@@ -448,7 +439,8 @@ fn display_statistics(
         stdout_handle.queue(Print(format!("{}\n", elapsed_time)))?;
     } else {
         let report_line = format!(
-            "Num docs: {:>7} Parse errs: {:>5} Staged splits: {:>3} Input size: {:>5}MB Thrghput: {:>5.2}MB/s Time: {}\n",
+            "Num docs: {:>7} Parse errs: {:>5} Staged splits: {:>3} Input size: {:>5}MB Thrghput: \
+             {:>5.2}MB/s Time: {}\n",
             statistics.num_docs,
             statistics.num_invalid_docs,
             statistics.num_staged_splits,

--- a/quickwit-cli/src/main.rs
+++ b/quickwit-cli/src/main.rs
@@ -1,38 +1,34 @@
-/*
-    Quickwit
-    Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-    Quickwit is offered under the AGPL v3.0 and as commercial software.
-    For commercial licensing, contact us at hello@quickwit.io.
-
-    AGPL:
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation, either version 3 of the
-    License, or (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
+use std::env;
+use std::net::SocketAddr;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use anyhow::{bail, Context};
 use byte_unit::Byte;
 use clap::{load_yaml, value_t, App, AppSettings, ArgMatches};
 use quickwit_cli::*;
 use quickwit_common::to_socket_addr;
-use quickwit_serve::serve_cli;
-use quickwit_serve::ServeArgs;
+use quickwit_serve::{serve_cli, ServeArgs};
 use quickwit_telemetry::payload::TelemetryEvent;
-use std::env;
-use std::net::SocketAddr;
-use std::path::Path;
-use std::path::PathBuf;
-use std::time::Duration;
 use tracing::Level;
 use tracing_subscriber::fmt::Subscriber;
 
@@ -306,7 +302,11 @@ async fn main() {
 
 /// Return the about text with telemetry info.
 fn about_text() -> String {
-    let mut about_text = format!("Indexing your large dataset on object storage & making it searchable from the command line.\nCommit hash: {}\n", env!("GIT_COMMIT_HASH"));
+    let mut about_text = format!(
+        "Indexing your large dataset on object storage & making it searchable from the command \
+         line.\nCommit hash: {}\n",
+        env!("GIT_COMMIT_HASH")
+    );
     if quickwit_telemetry::is_telemetry_enabled() {
         about_text += "Telemetry Enabled";
     }
@@ -340,17 +340,19 @@ pub fn parse_duration_with_unit(duration: &str) -> anyhow::Result<Duration> {
 
 #[cfg(test)]
 mod tests {
+    use std::io::Write;
+    use std::path::{Path, PathBuf};
+    use std::time::Duration;
+
+    use clap::{load_yaml, App, AppSettings};
+    use quickwit_common::to_socket_addr;
+    use quickwit_serve::ServeArgs;
+    use tempfile::NamedTempFile;
+
     use crate::{
         parse_duration_with_unit, CliCommand, CreateIndexArgs, DeleteIndexArgs,
         GarbageCollectIndexArgs, IndexDataArgs, SearchIndexArgs,
     };
-    use clap::{load_yaml, App, AppSettings};
-    use quickwit_common::to_socket_addr;
-    use quickwit_serve::ServeArgs;
-    use std::io::Write;
-    use std::path::{Path, PathBuf};
-    use std::time::Duration;
-    use tempfile::NamedTempFile;
 
     #[test]
     fn test_parse_new_args() -> anyhow::Result<()> {

--- a/quickwit-cli/tests/cli.rs
+++ b/quickwit-cli/tests/cli.rs
@@ -1,30 +1,29 @@
-/*
-    Quickwit
-    Copyright (C) 2021 Quickwit Inc.
-
-    Quickwit is offered under the AGPL v3.0 and as commercial software.
-    For commercial licensing, contact us at hello@quickwit.io.
-
-    AGPL:
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation, either version 3 of the
-    License, or (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 #![allow(clippy::bool_assert_comparison)]
 
 mod helpers;
 
-use crate::helpers::{create_test_env, make_command, spawn_command};
+use std::io::Read;
+use std::path::Path;
+
 use anyhow::Result;
 use helpers::{TestEnv, TestStorageType};
 use predicates::prelude::*;
@@ -32,8 +31,9 @@ use quickwit_cli::{create_index_cli, CreateIndexArgs};
 use quickwit_metastore::{Metastore, MetastoreUriResolver, SplitState};
 use serde_json::{Number, Value};
 use serial_test::serial;
-use std::{io::Read, path::Path};
 use tokio::time::{sleep, Duration};
+
+use crate::helpers::{create_test_env, make_command, spawn_command};
 
 fn create_logs_index(test_env: &TestEnv, index_id: &str) {
     make_command(
@@ -222,9 +222,9 @@ fn test_cmd_search() -> Result<()> {
     // search with tags
     make_command(
         format!(
-            "search --metastore-uri {} --index-id {} --query level:info --tags city:paris device:rpi",
-            test_env.metastore_uri,
-            index_id,
+            "search --metastore-uri {} --index-id {} --query level:info --tags city:paris \
+             device:rpi",
+            test_env.metastore_uri, index_id,
         )
         .as_str(),
     )

--- a/quickwit-cli/tests/helpers.rs
+++ b/quickwit-cli/tests/helpers.rs
@@ -1,42 +1,34 @@
-/*
-    Quickwit
-    Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-    Quickwit is offered under the AGPL v3.0 and as commercial software.
-    For commercial licensing, contact us at hello@quickwit.io.
-
-    AGPL:
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation, either version 3 of the
-    License, or (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::process::{Child, Stdio};
+use std::sync::Arc;
+use std::{fs, io};
 
 use assert_cmd::cargo::cargo_bin;
 use assert_cmd::Command;
 use predicates::str;
 use quickwit_metastore::SingleFileMetastore;
-use quickwit_storage::LocalFileStorage;
-use quickwit_storage::RegionProvider;
-use quickwit_storage::S3CompatibleObjectStorage;
-use quickwit_storage::Storage;
-use std::collections::HashMap;
-use std::fs;
-use std::io;
-use std::path::PathBuf;
-use std::process::Child;
-use std::process::Stdio;
-use std::sync::Arc;
-use tempfile::tempdir;
-use tempfile::TempDir;
+use quickwit_storage::{LocalFileStorage, RegionProvider, S3CompatibleObjectStorage, Storage};
+use tempfile::{tempdir, TempDir};
 
 const PACKAGE_BIN_NAME: &str = "quickwit";
 

--- a/quickwit-cluster/src/cluster.rs
+++ b/quickwit-cluster/src/cluster.rs
@@ -1,22 +1,21 @@
-//  Quickwit
-//  Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
 //
-//  Quickwit is offered under the AGPL v3.0 and as commercial software.
-//  For commercial licensing, contact us at hello@quickwit.io.
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
 //
-//  AGPL:
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU Affero General Public License as
-//  published by the Free Software Foundation, either version 3 of the
-//  License, or (at your option) any later version.
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
 //
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU Affero General Public License for more details.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
 //
-//  You should have received a copy of the GNU Affero General Public License
-//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::fs;
 use std::net::SocketAddr;
@@ -25,7 +24,6 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
-use crate::error::{ClusterError, ClusterResult};
 use quickwit_swim::prelude::{
     ArtilleryError, ArtilleryMember, ArtilleryMemberEvent, ArtilleryMemberState,
     Cluster as ArtilleryCluster, ClusterConfig as ArtilleryClusterConfig,
@@ -34,6 +32,8 @@ use tokio::sync::watch;
 use tokio_stream::wrappers::WatchStream;
 use tracing::{debug, error, info, warn};
 use uuid::Uuid;
+
+use crate::error::{ClusterError, ClusterResult};
 
 /// The ID that makes the cluster unique.
 const CLUSTER_ID: &str = "quickwit-cluster";
@@ -259,9 +259,8 @@ fn log_artillery_event(artillery_member_event: ArtilleryMemberEvent) {
 #[cfg(test)]
 mod tests {
     use std::net::SocketAddr;
-    use std::thread;
-    use std::time;
     use std::time::Duration;
+    use std::{thread, time};
 
     use quickwit_swim::prelude::{ArtilleryMember, ArtilleryMemberState};
 

--- a/quickwit-cluster/src/error.rs
+++ b/quickwit-cluster/src/error.rs
@@ -1,22 +1,21 @@
-//  Quickwit
-//  Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
 //
-//  Quickwit is offered under the AGPL v3.0 and as commercial software.
-//  For commercial licensing, contact us at hello@quickwit.io.
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
 //
-//  AGPL:
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU Affero General Public License as
-//  published by the Free Software Foundation, either version 3 of the
-//  License, or (at your option) any later version.
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
 //
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU Affero General Public License for more details.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
 //
-//  You should have received a copy of the GNU Affero General Public License
-//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use serde::{Deserialize, Serialize};
 use thiserror::Error;

--- a/quickwit-cluster/src/lib.rs
+++ b/quickwit-cluster/src/lib.rs
@@ -1,22 +1,21 @@
-//  Quickwit
-//  Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
 //
-//  Quickwit is offered under the AGPL v3.0 and as commercial software.
-//  For commercial licensing, contact us at hello@quickwit.io.
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
 //
-//  AGPL:
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU Affero General Public License as
-//  published by the Free Software Foundation, either version 3 of the
-//  License, or (at your option) any later version.
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
 //
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU Affero General Public License for more details.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
 //
-//  You should have received a copy of the GNU Affero General Public License
-//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 pub mod cluster;
 pub mod error;

--- a/quickwit-cluster/src/service.rs
+++ b/quickwit-cluster/src/service.rs
@@ -1,27 +1,25 @@
-//  Quickwit
-//  Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
 //
-//  Quickwit is offered under the AGPL v3.0 and as commercial software.
-//  For commercial licensing, contact us at hello@quickwit.io.
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
 //
-//  AGPL:
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU Affero General Public License as
-//  published by the Free Software Foundation, either version 3 of the
-//  License, or (at your option) any later version.
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
 //
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU Affero General Public License for more details.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
 //
-//  You should have received a copy of the GNU Affero General Public License
-//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::sync::Arc;
 
 use async_trait::async_trait;
-
 use quickwit_proto::{LeaveRequest, LeaveResult, Member as PMember, MembersRequest, MembersResult};
 
 use crate::cluster::{Cluster, Member};
@@ -81,9 +79,8 @@ impl ClusterService for ClusterServiceImpl {
 mod tests {
     use std::net::ToSocketAddrs;
 
-    use uuid::Uuid;
-
     use quickwit_proto::Member as PMember;
+    use uuid::Uuid;
 
     use crate::cluster::Member;
 

--- a/quickwit-cluster/src/test_utils.rs
+++ b/quickwit-cluster/src/test_utils.rs
@@ -1,23 +1,22 @@
-/*
- * Copyright (C) 2021 Quickwit Inc.
- *
- * Quickwit is offered under the AGPL v3.0 and as commercial software.
- * For commercial licensing, contact us at hello@quickwit.io.
- *
- * AGPL:
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
 use std::io;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr, TcpListener};
 use std::path::Path;

--- a/quickwit-common/src/coolid.rs
+++ b/quickwit-common/src/coolid.rs
@@ -1,22 +1,21 @@
-//  Quickwit
-//  Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
 //
-//  Quickwit is offered under the AGPL v3.0 and as commercial software.
-//  For commercial licensing, contact us at hello@quickwit.io.
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
 //
-//  AGPL:
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU Affero General Public License as
-//  published by the Free Software Foundation, either version 3 of the
-//  License, or (at your option) any later version.
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
 //
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU Affero General Public License for more details.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
 //
-//  You should have received a copy of the GNU Affero General Public License
-//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use rand::distributions::Alphanumeric;
 use rand::prelude::*;
@@ -102,8 +101,9 @@ pub fn new_coolid(name: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::new_coolid;
     use std::collections::HashSet;
+
+    use super::new_coolid;
 
     #[test]
     fn test_coolid() {

--- a/quickwit-common/src/lib.rs
+++ b/quickwit-common/src/lib.rs
@@ -1,39 +1,37 @@
-/*
- * Copyright (C) 2021 Quickwit Inc.
- *
- * Quickwit is offered under the AGPL v3.0 and as commercial software.
- * For commercial licensing, contact us at hello@quickwit.io.
- *
- * AGPL:
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 mod coolid;
 
-use once_cell::sync::Lazy;
-use regex::Regex;
 use std::net::{SocketAddr, ToSocketAddrs};
 
 pub use coolid::new_coolid;
+use once_cell::sync::Lazy;
+use regex::Regex;
 
 /// Filenames used for hotcache files.
 pub const HOTCACHE_FILENAME: &str = "hotcache";
 
 /// This function takes such a index_url and breaks it into
 /// s3://my_bucket/some_path_containing_my_indices / my_index
-///                                                  \------/
-///                                                  index_id
+///                                                 \------/
+///                                                 index_id
 pub fn extract_index_id_from_index_uri(mut index_uri: &str) -> anyhow::Result<&str> {
     static INDEX_URI_PATTERN: Lazy<Regex> = Lazy::new(|| Regex::new(r"^.+://.+/.+$").unwrap());
     static INDEX_ID_PATTERN: Lazy<Regex> =
@@ -54,7 +52,11 @@ pub fn extract_index_id_from_index_uri(mut index_uri: &str) -> anyhow::Result<&s
         anyhow::bail!("Failed to parse the uri into a metastore_uri and an index_id.");
     }
     if !INDEX_ID_PATTERN.is_match(parts[0]) {
-        anyhow::bail!("Invalid index_id `{}`. Only alpha-numeric, `-` and `_` characters allowed. Cannot start with `-`, `_` or digit.", parts[0]);
+        anyhow::bail!(
+            "Invalid index_id `{}`. Only alpha-numeric, `-` and `_` characters allowed. Cannot \
+             start with `-`, `_` or digit.",
+            parts[0]
+        );
     }
 
     Ok(parts[0])

--- a/quickwit-core/src/index.rs
+++ b/quickwit-core/src/index.rs
@@ -1,34 +1,34 @@
-/*
-    Quickwit
-    Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-    Quickwit is offered under the AGPL v3.0 and as commercial software.
-    For commercial licensing, contact us at hello@quickwit.io.
-
-    AGPL:
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation, either version 3 of the
-    License, or (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
-
-use crate::FileEntry;
-use futures::StreamExt;
-use quickwit_metastore::{IndexMetadata, Metastore, MetastoreUriResolver};
-use quickwit_metastore::{SplitMetadataAndFooterOffsets, SplitState};
-use quickwit_storage::{quickwit_storage_uri_resolver, StorageUriResolver};
 use std::path::Path;
 use std::time::Duration;
+
+use futures::StreamExt;
+use quickwit_metastore::{
+    IndexMetadata, Metastore, MetastoreUriResolver, SplitMetadataAndFooterOffsets, SplitState,
+};
+use quickwit_storage::{quickwit_storage_uri_resolver, StorageUriResolver};
 use tantivy::chrono::Utc;
 use tracing::warn;
+
+use crate::FileEntry;
 
 pub const MAX_CONCURRENT_SPLIT_TASKS: usize = if cfg!(test) { 2 } else { 10 };
 
@@ -37,7 +37,6 @@ pub const MAX_CONCURRENT_SPLIT_TASKS: usize = if cfg!(test) { 2 } else { 10 };
 ///
 /// * `metastore_uri` - The metastore URI for accessing the metastore.
 /// * `index_metadata` - The metadata used to create the target index.
-///
 pub async fn create_index(
     metastore_uri: &str,
     index_metadata: IndexMetadata,
@@ -99,7 +98,6 @@ pub async fn delete_index(
 /// * `index_id` - The target index Id.
 /// * `grace_period` -  Threshold period after which a staged split can be garbage collected.
 /// * `dry_run` - Should this only return a list of affected files without performing deletion.
-///
 pub async fn garbage_collect_index(
     metastore_uri: &str,
     index_id: &str,
@@ -150,7 +148,6 @@ pub async fn garbage_collect_index(
 /// * `metastore_uri` - The target index metastore uri.
 /// * `index_id` - The target index id.
 /// * `storage_resolver` - The storage resolver object.
-///
 pub async fn delete_garbage_files(
     metastore: &dyn Metastore,
     index_id: &str,
@@ -212,7 +209,6 @@ pub async fn delete_garbage_files(
 /// * `index_id` - The target index Id.
 /// * `storage_resolver` - A storage resolver object to access the storage.
 /// * `metastore` - A metastore object for interacting with the metastore.
-///
 pub async fn reset_index(
     metastore: &dyn Metastore,
     index_id: &str,

--- a/quickwit-core/src/lib.rs
+++ b/quickwit-core/src/lib.rs
@@ -1,33 +1,30 @@
-/*
-    Quickwit
-    Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-    Quickwit is offered under the AGPL v3.0 and as commercial software.
-    For commercial licensing, contact us at hello@quickwit.io.
-
-    AGPL:
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation, either version 3 of the
-    License, or (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
 #![warn(missing_docs)]
 #![allow(clippy::bool_assert_comparison)]
 
-/*! `quickwit-core` provides all the core functions used in quickwit cli:
-- `create_index` for creating a new index
-- `index_data` for indexing new-line delimited json documents
-- `search_index` for searching an index
-- `delete_index` for deleting an index
-*/
+//! `quickwit-core` provides all the core functions used in quickwit cli:
+//! - `create_index` for creating a new index
+//! - `index_data` for indexing new-line delimited json documents
+//! - `search_index` for searching an index
+//! - `delete_index` for deleting an index
 
 mod index;
 

--- a/quickwit-directories/src/bundle_directory.rs
+++ b/quickwit-directories/src/bundle_directory.rs
@@ -1,36 +1,32 @@
-/*
-    Quickwit
-    Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-    Quickwit is offered under the AGPL v3.0 and as commercial software.
-    For commercial licensing, contact us at hello@quickwit.io.
-
-    AGPL:
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation, either version 3 of the
-    License, or (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
-
-use async_trait::async_trait;
-use quickwit_storage::BundleStorageFileOffsets;
 use std::fmt::Debug;
 use std::ops::Range;
 use std::path::{Path, PathBuf};
 use std::{fmt, io};
+
+use async_trait::async_trait;
+use quickwit_storage::BundleStorageFileOffsets;
 use tantivy::directory::error::{DeleteError, OpenReadError, OpenWriteError};
-use tantivy::directory::{FileHandle, WatchCallback, WatchHandle, WritePtr};
-use tantivy::directory::{FileSlice, OwnedBytes};
-use tantivy::HasLen;
-use tantivy::{AsyncIoResult, Directory};
+use tantivy::directory::{FileHandle, FileSlice, OwnedBytes, WatchCallback, WatchHandle, WritePtr};
+use tantivy::{AsyncIoResult, Directory, HasLen};
 use tracing::error;
 
 struct BundleDirectoryFileHandle {
@@ -164,10 +160,8 @@ impl Directory for BundleDirectory {
 
 #[cfg(test)]
 mod tests {
-    use std::{
-        fs::{self, File},
-        io::Write,
-    };
+    use std::fs::{self, File};
+    use std::io::Write;
 
     use quickwit_storage::BundleStorageBuilder;
 

--- a/quickwit-directories/src/caching_directory.rs
+++ b/quickwit-directories/src/caching_directory.rs
@@ -1,35 +1,31 @@
-/*
-    Quickwit
-    Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-    Quickwit is offered under the AGPL v3.0 and as commercial software.
-    For commercial licensing, contact us at hello@quickwit.io.
-
-    AGPL:
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation, either version 3 of the
-    License, or (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
+use std::ops::{Deref, Range};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::{fmt, io};
 
 use async_trait::async_trait;
 use bytes::Bytes;
 use quickwit_storage::SliceCache;
 use stable_deref_trait::StableDeref;
-use std::fmt;
-use std::io;
-use std::ops::Deref;
-use std::ops::Range;
-use std::path::{Path, PathBuf};
-use std::sync::Arc;
 use tantivy::directory::error::{DeleteError, OpenReadError, OpenWriteError};
 use tantivy::directory::{FileHandle, OwnedBytes, WatchHandle, WritePtr};
 use tantivy::{AsyncIoResult, Directory, HasLen};
@@ -198,12 +194,14 @@ impl Directory for CachingDirectory {
 #[cfg(test)]
 mod tests {
 
-    use super::CachingDirectory;
-    use crate::DebugProxyDirectory;
     use std::path::Path;
     use std::sync::Arc;
+
     use tantivy::directory::RamDirectory;
     use tantivy::Directory;
+
+    use super::CachingDirectory;
+    use crate::DebugProxyDirectory;
 
     #[test]
     fn test_caching_directory() -> tantivy::Result<()> {

--- a/quickwit-directories/src/debug_proxy_directory.rs
+++ b/quickwit-directories/src/debug_proxy_directory.rs
@@ -1,40 +1,38 @@
-/*
-    Quickwit
-    Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-    Quickwit is offered under the AGPL v3.0 and as commercial software.
-    For commercial licensing, contact us at hello@quickwit.io.
-
-    AGPL:
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation, either version 3 of the
-    License, or (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
-
-use crate::StorageDirectory;
-use async_trait::async_trait;
-use bytes::Bytes;
 use std::ops::Range;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 use std::{fmt, io, mem};
+
+use async_trait::async_trait;
+use bytes::Bytes;
 use tantivy::chrono::{DateTime, Utc};
 use tantivy::directory::error::{DeleteError, LockError, OpenReadError, OpenWriteError};
 use tantivy::directory::{
     DirectoryLock, FileHandle, OwnedBytes, WatchCallback, WatchHandle, WritePtr,
 };
-use tantivy::Directory;
-use tantivy::HasLen;
+use tantivy::{Directory, HasLen};
+
+use crate::StorageDirectory;
 
 #[derive(Clone, Default)]
 struct OperationBuffer(Arc<Mutex<Vec<ReadOperation>>>);
@@ -270,11 +268,13 @@ impl DebugProxyDirectory<StorageDirectory> {
 
 #[cfg(test)]
 mod tests {
-    use super::DebugProxyDirectory;
     use std::io::Write;
     use std::path::Path;
+
     use tantivy::directory::{RamDirectory, TerminatingWrite};
     use tantivy::Directory;
+
+    use super::DebugProxyDirectory;
 
     const TEST_PATH: &str = "test.file";
     const TEST_PAYLOAD: &[u8] = b"hello happy tax payer";

--- a/quickwit-directories/src/hot_directory.rs
+++ b/quickwit-directories/src/hot_directory.rs
@@ -1,40 +1,37 @@
-/*
-    Quickwit
-    Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-    Quickwit is offered under the AGPL v3.0 and as commercial software.
-    For commercial licensing, contact us at hello@quickwit.io.
-
-    AGPL:
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation, either version 3 of the
-    License, or (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
+use std::collections::{HashMap, HashSet};
+use std::ops::Range;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::{fmt, io};
 
 use async_trait::async_trait;
 use bytes::Bytes;
 use serde::{Deserialize, Serialize};
-use std::collections::{HashMap, HashSet};
-use std::fmt;
-use std::io;
-use std::ops::Range;
-use std::path::{Path, PathBuf};
-use std::sync::Arc;
 use tantivy::directory::error::{LockError, OpenReadError};
-use tantivy::directory::DirectoryLock;
-use tantivy::directory::{FileSlice, OwnedBytes, WatchCallback};
+use tantivy::directory::{
+    DirectoryLock, FileHandle, FileSlice, OwnedBytes, WatchCallback, WatchHandle,
+};
 use tantivy::error::DataCorruption;
-use tantivy::{directory::FileHandle, directory::WatchHandle, HasLen};
-use tantivy::{AsyncIoResult, Directory, Index, IndexReader, ReloadPolicy};
+use tantivy::{AsyncIoResult, Directory, HasLen, Index, IndexReader, ReloadPolicy};
 
 use crate::caching_directory::BytesWrapper;
 use crate::{CachingDirectory, DebugProxyDirectory};
@@ -130,9 +127,7 @@ impl StaticDirectoryCacheBuilder {
 }
 
 fn deserialize_cbor<T>(bytes: &mut OwnedBytes) -> serde_cbor::Result<T>
-where
-    T: serde::de::DeserializeOwned,
-{
+where T: serde::de::DeserializeOwned {
     let len = bytes.read_u64();
     let value = serde_cbor::from_reader(&bytes.as_slice()[..len as usize]);
     bytes.advance(len as usize);

--- a/quickwit-directories/src/lib.rs
+++ b/quickwit-directories/src/lib.rs
@@ -1,33 +1,30 @@
-/*
-    Quickwit
-    Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-    Quickwit is offered under the AGPL v3.0 and as commercial software.
-    For commercial licensing, contact us at hello@quickwit.io.
-
-    AGPL:
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation, either version 3 of the
-    License, or (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
-
-/*!
-This crate contains all of the building pieces that make quickwit's IO possible.
-
-- The `StorageDirectory` justs wraps a `Storage` trait to make it compatible with tantivy's Directory API.
-- The `HotDirectory` wraps another directory with a static cache.
-- The `CachingDirectory` wraps a Directory with a dynamic cache.
-- The `DebugDirectory` acts as a proxy to another directory to instrument it and record all of its IO.
-*/
+//! This crate contains all of the building pieces that make quickwit's IO possible.
+//!
+//! - The `StorageDirectory` justs wraps a `Storage` trait to make it compatible with tantivy's
+//!   Directory API.
+//! - The `HotDirectory` wraps another directory with a static cache.
+//! - The `CachingDirectory` wraps a Directory with a dynamic cache.
+//! - The `DebugDirectory` acts as a proxy to another directory to instrument it and record all of
+//!   its IO.
 #![warn(missing_docs)]
 
 mod bundle_directory;

--- a/quickwit-directories/src/storage_directory.rs
+++ b/quickwit-directories/src/storage_directory.rs
@@ -1,39 +1,34 @@
-/*
-    Quickwit
-    Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-    Quickwit is offered under the AGPL v3.0 and as commercial software.
-    For commercial licensing, contact us at hello@quickwit.io.
-
-    AGPL:
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation, either version 3 of the
-    License, or (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
+use std::fmt::Debug;
+use std::ops::Range;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::{fmt, io};
 
 use async_trait::async_trait;
 use bytes::Bytes;
 use quickwit_storage::Storage;
-use std::fmt;
-use std::fmt::Debug;
-use std::io;
-use std::ops::Range;
-use std::path::{Path, PathBuf};
-use std::sync::Arc;
 use tantivy::directory::error::{DeleteError, OpenReadError, OpenWriteError};
-use tantivy::directory::OwnedBytes;
-use tantivy::directory::{FileHandle, WatchCallback, WatchHandle, WritePtr};
-use tantivy::HasLen;
-use tantivy::{AsyncIoResult, Directory};
+use tantivy::directory::{FileHandle, OwnedBytes, WatchCallback, WatchHandle, WritePtr};
+use tantivy::{AsyncIoResult, Directory, HasLen};
 use tracing::error;
 
 use crate::caching_directory::BytesWrapper;

--- a/quickwit-index-config/src/all_flatten_config.rs
+++ b/quickwit-index-config/src/all_flatten_config.rs
@@ -1,37 +1,31 @@
-/*
-    Quickwit
-    Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-    Quickwit is offered under the AGPL v3.0 and as commercial software.
-    For commercial licensing, contact us at hello@quickwit.io.
-
-    AGPL:
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation, either version 3 of the
-    License, or (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
-
-use crate::{
-    default_index_config::{SOURCE_FIELD_NAME, TAGS_FIELD_NAME},
-    query_builder::build_query,
-    DocParsingError, IndexConfig, QueryParserError,
-};
 use quickwit_proto::SearchRequest;
 use serde::{Deserialize, Serialize};
-use tantivy::{
-    query::Query,
-    schema::{Schema, SchemaBuilder, STORED, STRING},
-    Document,
-};
+use tantivy::query::Query;
+use tantivy::schema::{Schema, SchemaBuilder, STORED, STRING};
+use tantivy::Document;
+
+use crate::default_index_config::{SOURCE_FIELD_NAME, TAGS_FIELD_NAME};
+use crate::query_builder::build_query;
+use crate::{DocParsingError, IndexConfig, QueryParserError};
 
 /// A config that flatten the document to have all fields at top level.
 #[derive(Clone, Serialize, Deserialize)]

--- a/quickwit-index-config/src/config.rs
+++ b/quickwit-index-config/src/config.rs
@@ -1,36 +1,32 @@
-/*
-    Quickwit
-    Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-    Quickwit is offered under the AGPL v3.0 and as commercial software.
-    For commercial licensing, contact us at hello@quickwit.io.
-
-    AGPL:
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation, either version 3 of the
-    License, or (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
-
-use crate::default_index_config::TAGS_FIELD_NAME;
-use crate::DocParsingError;
-use dyn_clone::clone_trait_object;
-use dyn_clone::DynClone;
-use quickwit_proto::SearchRequest;
 use std::fmt::Debug;
+
+use dyn_clone::{clone_trait_object, DynClone};
+use quickwit_proto::SearchRequest;
 use tantivy::query::Query;
 use tantivy::schema::{Field, Schema};
 use tantivy::Document;
 
-use crate::QueryParserError;
+use crate::default_index_config::TAGS_FIELD_NAME;
+use crate::{DocParsingError, QueryParserError};
 
 /// Sorted order (either Ascending or Descending).
 /// To get a regular top-K results search, use `SortOrder::Desc`.
@@ -43,7 +39,8 @@ pub enum SortOrder {
 }
 
 /// Defines the way documents should be sorted.
-/// In case of a tie, the documents are ordered according to descending `(split_id, segment_ord, doc_id)`.
+/// In case of a tie, the documents are ordered according to descending `(split_id, segment_ord,
+/// doc_id)`.
 #[derive(Clone, Debug)]
 pub enum SortBy {
     /// Sort by a specific field.
@@ -65,7 +62,6 @@ pub enum SortBy {
 /// - a way to build a tantivy::Document from a json payload
 /// - a way to build a tantivy::Query from a SearchRequest
 /// - a way to build a tantivy:Schema
-///
 #[typetag::serde(tag = "type")]
 pub trait IndexConfig: Send + Sync + Debug + DynClone + 'static {
     /// Returns the document built from a json string.

--- a/quickwit-index-config/src/default_index_config/field_mapping_type.rs
+++ b/quickwit-index-config/src/default_index_config/field_mapping_type.rs
@@ -1,24 +1,21 @@
-/*
-    Quickwit
-    Copyright (C) 2021 Quickwit Inc.
-
-    Quickwit is offered under the AGPL v3.0 and as commercial software.
-    For commercial licensing, contact us at hello@quickwit.io.
-
-    AGPL:
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation, either version 3 of the
-    License, or (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use tantivy::schema::{BytesOptions, Cardinality, IntOptions, TextOptions};
 

--- a/quickwit-index-config/src/default_index_config/mod.rs
+++ b/quickwit-index-config/src/default_index_config/mod.rs
@@ -1,24 +1,21 @@
-/*
-    Quickwit
-    Copyright (C) 2021 Quickwit Inc.
-
-    Quickwit is offered under the AGPL v3.0 and as commercial software.
-    For commercial licensing, contact us at hello@quickwit.io.
-
-    AGPL:
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation, either version 3 of the
-    License, or (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 mod default_config;
 mod field_mapping_entry;

--- a/quickwit-index-config/src/error.rs
+++ b/quickwit-index-config/src/error.rs
@@ -1,23 +1,22 @@
-/*
- * Copyright (C) 2021 Quickwit Inc.
- *
- * Quickwit is offered under the AGPL v3.0 and as commercial software.
- * For commercial licensing, contact us at hello@quickwit.io.
- *
- * AGPL:
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
 use thiserror::Error;
 
 // TODO improve me and my error messages :)

--- a/quickwit-index-config/src/lib.rs
+++ b/quickwit-index-config/src/lib.rs
@@ -1,24 +1,21 @@
-/*
-    Quickwit
-    Copyright (C) 2021 Quickwit Inc.
-
-    Quickwit is offered under the AGPL v3.0 and as commercial software.
-    For commercial licensing, contact us at hello@quickwit.io.
-
-    AGPL:
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation, either version 3 of the
-    License, or (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 #![warn(missing_docs)]
 #![allow(clippy::bool_assert_comparison)]
@@ -34,11 +31,10 @@ mod error;
 mod query_builder;
 mod wikipedia_config;
 
-pub use error::QueryParserError;
-
 pub use all_flatten_config::AllFlattenIndexConfig;
 pub use config::{IndexConfig, SortBy, SortOrder};
 pub use default_index_config::{DefaultIndexConfig, DefaultIndexConfigBuilder, DocParsingError};
+pub use error::QueryParserError;
 pub use wikipedia_config::WikipediaIndexConfig;
 
 /// Returns a default `DefaultIndexConfig` for unit tests.

--- a/quickwit-index-config/src/query_builder.rs
+++ b/quickwit-index-config/src/query_builder.rs
@@ -1,24 +1,21 @@
-/*
-    Quickwit
-    Copyright (C) 2021 Quickwit Inc.
-
-    Quickwit is offered under the AGPL v3.0 and as commercial software.
-    For commercial licensing, contact us at hello@quickwit.io.
-
-    AGPL:
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation, either version 3 of the
-    License, or (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use quickwit_proto::SearchRequest;
 use tantivy::query::{Query, QueryParser, QueryParserError as TantivyQueryParserError};
@@ -80,10 +77,10 @@ fn resolve_fields(schema: &Schema, field_names: &[String]) -> anyhow::Result<Vec
 
 #[cfg(test)]
 mod test {
-    use super::build_query;
-
     use quickwit_proto::SearchRequest;
     use tantivy::schema::{Schema, TEXT};
+
+    use super::build_query;
 
     enum TestExpectation {
         Err(&'static str),

--- a/quickwit-index-config/src/wikipedia_config.rs
+++ b/quickwit-index-config/src/wikipedia_config.rs
@@ -1,34 +1,32 @@
-/*
-    Quickwit
-    Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-    Quickwit is offered under the AGPL v3.0 and as commercial software.
-    For commercial licensing, contact us at hello@quickwit.io.
-
-    AGPL:
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation, either version 3 of the
-    License, or (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
-
-use crate::default_index_config::TAGS_FIELD_NAME;
-use crate::query_builder::build_query;
-use crate::{DocParsingError, IndexConfig, QueryParserError};
 use quickwit_proto::SearchRequest;
 use serde::{Deserialize, Serialize};
 use tantivy::query::Query;
 use tantivy::schema::{Schema, TextFieldIndexing, TextOptions, STRING};
 use tantivy::tokenizer::TokenizerManager;
 use tantivy::Document;
+
+use crate::default_index_config::TAGS_FIELD_NAME;
+use crate::query_builder::build_query;
+use crate::{DocParsingError, IndexConfig, QueryParserError};
 
 /// A document config tailored for the wikipedia corpus.
 #[derive(Clone, Serialize, Deserialize)]

--- a/quickwit-indexing/failpoints/mod.rs
+++ b/quickwit-indexing/failpoints/mod.rs
@@ -1,22 +1,21 @@
-// Quickwit
-//  Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
 //
-//  Quickwit is offered under the AGPL v3.0 and as commercial software.
-//  For commercial licensing, contact us at hello@quickwit.io.
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
 //
-//  AGPL:
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU Affero General Public License as
-//  published by the Free Software Foundation, either version 3 of the
-//  License, or (at your option) any later version.
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
 //
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU Affero General Public License for more details.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
 //
-//  You should have received a copy of the GNU Affero General Public License
-//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 //! Fail points are a form of code instrumentation that allow errors and other behaviors
 //! to be injected dynamically at runtime, primarily for testing purposes. Fail
@@ -36,25 +35,20 @@
 //!
 //! Below we test panics at different steps in the indexing pipeline.
 
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
 use byte_unit::Byte;
 use fail::FailScenario;
 use quickwit_index_config::default_config_for_tests;
 use quickwit_indexing::actors::IndexerParams;
 use quickwit_indexing::index_data;
-use quickwit_indexing::models::CommitPolicy;
-use quickwit_indexing::models::ScratchDirectory;
+use quickwit_indexing::models::{CommitPolicy, ScratchDirectory};
 use quickwit_indexing::source::SourceConfig;
 use quickwit_metastore::checkpoint::Checkpoint;
-use quickwit_metastore::IndexMetadata;
-use quickwit_metastore::Metastore;
-use quickwit_metastore::SingleFileMetastore;
-use quickwit_metastore::SplitState;
-use quickwit_storage::quickwit_storage_uri_resolver;
-use quickwit_storage::StorageUriResolver;
+use quickwit_metastore::{IndexMetadata, Metastore, SingleFileMetastore, SplitState};
+use quickwit_storage::{quickwit_storage_uri_resolver, StorageUriResolver};
 use serde_json::json;
-use std::sync::Arc;
-use std::sync::Mutex;
-use std::time::Duration;
 
 #[tokio::test]
 async fn test_failpoint_no_failure() -> anyhow::Result<()> {

--- a/quickwit-indexing/src/actors/indexer.rs
+++ b/quickwit-indexing/src/actors/indexer.rs
@@ -1,22 +1,21 @@
-// Quickwit
-//  Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
 //
-//  Quickwit is offered under the AGPL v3.0 and as commercial software.
-//  For commercial licensing, contact us at hello@quickwit.io.
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
 //
-//  AGPL:
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU Affero General Public License as
-//  published by the Free Software Foundation, either version 3 of the
-//  License, or (at your option) any later version.
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
 //
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU Affero General Public License for more details.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
 //
-//  You should have received a copy of the GNU Affero General Public License
-//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::io;
 use std::ops::RangeInclusive;
@@ -25,25 +24,15 @@ use std::sync::Arc;
 use anyhow::Context;
 use byte_unit::Byte;
 use fail::fail_point;
-use quickwit_actors::Actor;
-use quickwit_actors::ActorContext;
-use quickwit_actors::ActorExitStatus;
-use quickwit_actors::Mailbox;
-use quickwit_actors::QueueCapacity;
-use quickwit_actors::SendError;
-use quickwit_actors::SyncActor;
+use quickwit_actors::{
+    Actor, ActorContext, ActorExitStatus, Mailbox, QueueCapacity, SendError, SyncActor,
+};
 use quickwit_index_config::IndexConfig;
-use tantivy::schema::Field;
-use tantivy::schema::Value;
+use tantivy::schema::{Field, Value};
 use tantivy::Document;
-use tracing::info;
-use tracing::warn;
+use tracing::{info, warn};
 
-use crate::models::CommitPolicy;
-use crate::models::IndexedSplit;
-use crate::models::IndexerMessage;
-use crate::models::RawDocBatch;
-use crate::models::ScratchDirectory;
+use crate::models::{CommitPolicy, IndexedSplit, IndexerMessage, RawDocBatch, ScratchDirectory};
 
 #[derive(Clone, Default, Debug, Eq, PartialEq)]
 pub struct IndexerCounters {
@@ -400,19 +389,14 @@ mod tests {
     use std::sync::Arc;
     use std::time::Duration;
 
-    use crate::actors::indexer::record_timestamp;
-    use crate::actors::indexer::IndexerCounters;
-    use crate::actors::IndexerParams;
-    use crate::models::CommitPolicy;
-    use crate::models::IndexerMessage;
-    use crate::models::RawDocBatch;
-    use crate::models::ScratchDirectory;
     use byte_unit::Byte;
-    use quickwit_actors::create_test_mailbox;
-    use quickwit_actors::Universe;
+    use quickwit_actors::{create_test_mailbox, Universe};
     use quickwit_metastore::checkpoint::CheckpointDelta;
 
     use super::Indexer;
+    use crate::actors::indexer::{record_timestamp, IndexerCounters};
+    use crate::actors::IndexerParams;
+    use crate::models::{CommitPolicy, IndexerMessage, RawDocBatch, ScratchDirectory};
 
     #[test]
     fn test_record_timestamp() {
@@ -470,7 +454,7 @@ mod tests {
                 num_valid_docs: 2,
                 num_splits_emitted: 0,
                 num_docs_in_split: 2, //< we have not reached the commit limit yet.
-                overall_num_bytes: 103,
+                overall_num_bytes: 103
             }
         );
         universe
@@ -492,7 +476,7 @@ mod tests {
                 num_valid_docs: 3,
                 num_splits_emitted: 1,
                 num_docs_in_split: 0, //< the num docs in split counter has been reset.
-                overall_num_bytes: 146,
+                overall_num_bytes: 146
             }
         );
         let output_messages = inbox.drain_available_message_for_test();
@@ -541,7 +525,7 @@ mod tests {
                 num_valid_docs: 1,
                 num_splits_emitted: 0,
                 num_docs_in_split: 1,
-                overall_num_bytes: 42,
+                overall_num_bytes: 42
             }
         );
         universe.simulate_time_shift(Duration::from_secs(61)).await;
@@ -554,7 +538,7 @@ mod tests {
                 num_valid_docs: 1,
                 num_splits_emitted: 1,
                 num_docs_in_split: 0,
-                overall_num_bytes: 42,
+                overall_num_bytes: 42
             }
         );
         let output_messages = inbox.drain_available_message_for_test();
@@ -600,7 +584,7 @@ mod tests {
                 num_valid_docs: 1,
                 num_splits_emitted: 1,
                 num_docs_in_split: 0,
-                overall_num_bytes: 42,
+                overall_num_bytes: 42
             }
         );
         let output_messages = inbox.drain_available_message_for_test();

--- a/quickwit-indexing/src/actors/mod.rs
+++ b/quickwit-indexing/src/actors/mod.rs
@@ -1,22 +1,21 @@
-// Quickwit
-//  Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
 //
-//  Quickwit is offered under the AGPL v3.0 and as commercial software.
-//  For commercial licensing, contact us at hello@quickwit.io.
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
 //
-//  AGPL:
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU Affero General Public License as
-//  published by the Free Software Foundation, either version 3 of the
-//  License, or (at your option) any later version.
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
 //
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU Affero General Public License for more details.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
 //
-//  You should have received a copy of the GNU Affero General Public License
-//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 mod indexer;
 mod packager;
@@ -24,10 +23,11 @@ mod pipeline_supervisor;
 mod publisher;
 mod uploader;
 
+pub use pipeline_supervisor::{
+    IndexingPipelineHandler, IndexingPipelineParams, IndexingPipelineSupervisor,
+};
+
 pub use self::indexer::{Indexer, IndexerCounters, IndexerParams};
 pub use self::packager::Packager;
 pub use self::publisher::{Publisher, PublisherCounters};
 pub use self::uploader::{Uploader, UploaderCounters};
-pub use pipeline_supervisor::{
-    IndexingPipelineHandler, IndexingPipelineParams, IndexingPipelineSupervisor,
-};

--- a/quickwit-indexing/src/actors/packager.rs
+++ b/quickwit-indexing/src/actors/packager.rs
@@ -1,22 +1,21 @@
-// Quickwit
-//  Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
 //
-//  Quickwit is offered under the AGPL v3.0 and as commercial software.
-//  For commercial licensing, contact us at hello@quickwit.io.
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
 //
-//  AGPL:
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU Affero General Public License as
-//  published by the Free Software Foundation, either version 3 of the
-//  License, or (at your option) any later version.
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
 //
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU Affero General Public License for more details.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
 //
-//  You should have received a copy of the GNU Affero General Public License
-//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::collections::HashSet;
 use std::fs::File;
@@ -25,23 +24,16 @@ use std::io::Write;
 use std::ops::Range;
 use std::path::PathBuf;
 
-use crate::models::IndexedSplit;
-use crate::models::PackagedSplit;
-use crate::models::ScratchDirectory;
 use anyhow::Context;
 use fail::fail_point;
-use quickwit_actors::Actor;
-use quickwit_actors::ActorContext;
-use quickwit_actors::Mailbox;
-use quickwit_actors::QueueCapacity;
-use quickwit_actors::SyncActor;
+use quickwit_actors::{Actor, ActorContext, Mailbox, QueueCapacity, SyncActor};
 use quickwit_directories::write_hotcache;
-use quickwit_storage::BundleStorageBuilder;
-use quickwit_storage::BUNDLE_FILENAME;
+use quickwit_storage::{BundleStorageBuilder, BUNDLE_FILENAME};
 use tantivy::common::CountingWriter;
-use tantivy::SegmentId;
-use tantivy::SegmentMeta;
+use tantivy::{SegmentId, SegmentMeta};
 use tracing::*;
+
+use crate::models::{IndexedSplit, PackagedSplit, ScratchDirectory};
 
 /// The role of the packager is to get an index writer and
 /// produce a split file.
@@ -276,19 +268,13 @@ mod tests {
     use std::ops::RangeInclusive;
     use std::time::Instant;
 
-    use quickwit_actors::create_test_mailbox;
-    use quickwit_actors::ObservationType;
-    use quickwit_actors::Universe;
+    use quickwit_actors::{create_test_mailbox, ObservationType, Universe};
     use quickwit_metastore::checkpoint::CheckpointDelta;
-    use tantivy::doc;
-    use tantivy::schema::Schema;
-    use tantivy::schema::FAST;
-    use tantivy::schema::TEXT;
-    use tantivy::Index;
-
-    use crate::models::ScratchDirectory;
+    use tantivy::schema::{Schema, FAST, TEXT};
+    use tantivy::{doc, Index};
 
     use super::*;
+    use crate::models::ScratchDirectory;
 
     fn make_indexed_split_for_test(segments_timestamps: &[&[i64]]) -> anyhow::Result<IndexedSplit> {
         let split_scratch_directory = ScratchDirectory::try_new_temp()?;

--- a/quickwit-indexing/src/actors/pipeline_supervisor.rs
+++ b/quickwit-indexing/src/actors/pipeline_supervisor.rs
@@ -1,50 +1,38 @@
-// Quickwit
-//  Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
 //
-//  Quickwit is offered under the AGPL v3.0 and as commercial software.
-//  For commercial licensing, contact us at hello@quickwit.io.
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
 //
-//  AGPL:
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU Affero General Public License as
-//  published by the Free Software Foundation, either version 3 of the
-//  License, or (at your option) any later version.
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
 //
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU Affero General Public License for more details.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
 //
-//  You should have received a copy of the GNU Affero General Public License
-//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use crate::actors::Indexer;
-use crate::actors::IndexerParams;
-use crate::actors::Packager;
-use crate::actors::Publisher;
-use crate::actors::Uploader;
-use crate::models::IndexingStatistics;
-use crate::source::quickwit_supported_sources;
-use crate::source::SourceActor;
-use crate::source::SourceConfig;
+use std::sync::Arc;
+use std::time::Duration;
+
 use async_trait::async_trait;
-use quickwit_actors::Actor;
-use quickwit_actors::ActorContext;
-use quickwit_actors::ActorExitStatus;
-use quickwit_actors::ActorHandle;
-use quickwit_actors::AsyncActor;
-use quickwit_actors::Health;
-use quickwit_actors::KillSwitch;
-use quickwit_actors::Supervisable;
+use quickwit_actors::{
+    Actor, ActorContext, ActorExitStatus, ActorHandle, AsyncActor, Health, KillSwitch, Supervisable,
+};
 use quickwit_metastore::Metastore;
 use quickwit_storage::StorageUriResolver;
 use smallvec::SmallVec;
-use std::sync::Arc;
-use std::time::Duration;
 use tokio::join;
-use tracing::debug;
-use tracing::error;
-use tracing::info;
+use tracing::{debug, error, info};
+
+use crate::actors::{Indexer, IndexerParams, Packager, Publisher, Uploader};
+use crate::models::IndexingStatistics;
+use crate::source::{quickwit_supported_sources, SourceActor, SourceConfig};
 
 pub struct IndexingPipelineHandler {
     pub source: ActorHandle<SourceActor>,
@@ -233,9 +221,9 @@ impl IndexingPipelineSupervisor {
             // TODO Accept errors in spawning. See #463.
             self.spawn_pipeline(ctx).await?;
             // if let Err(spawn_error) = self.spawn_pipeline(ctx).await {
-            //     // only retry n-times.
-            //     error!(err=?spawn_error, "Error while spawning");
-            //     self.terminate().await;
+            //    // only retry n-times.
+            //    error!(err=?spawn_error, "Error while spawning");
+            //    self.terminate().await;
             // }
         } else {
             match self.healthcheck() {
@@ -302,19 +290,17 @@ pub struct IndexingPipelineParams {
 #[cfg(test)]
 mod tests {
 
-    use super::IndexingPipelineParams;
-    use super::IndexingPipelineSupervisor;
-    use crate::actors::IndexerParams;
-    use crate::source::SourceConfig;
+    use std::path::PathBuf;
+    use std::sync::Arc;
+
+    use quickwit_actors::Universe;
+    use quickwit_metastore::{IndexMetadata, MockMetastore, SplitState};
     use quickwit_storage::StorageUriResolver;
     use serde_json::json;
 
-    use quickwit_actors::Universe;
-    use quickwit_metastore::IndexMetadata;
-    use quickwit_metastore::MockMetastore;
-    use quickwit_metastore::SplitState;
-    use std::path::PathBuf;
-    use std::sync::Arc;
+    use super::{IndexingPipelineParams, IndexingPipelineSupervisor};
+    use crate::actors::IndexerParams;
+    use crate::source::SourceConfig;
 
     #[tokio::test]
     async fn test_indexing_pipeline() -> anyhow::Result<()> {

--- a/quickwit-indexing/src/actors/publisher.rs
+++ b/quickwit-indexing/src/actors/publisher.rs
@@ -1,35 +1,32 @@
-// Quickwit
-//  Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
 //
-//  Quickwit is offered under the AGPL v3.0 and as commercial software.
-//  For commercial licensing, contact us at hello@quickwit.io.
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
 //
-//  AGPL:
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU Affero General Public License as
-//  published by the Free Software Foundation, either version 3 of the
-//  License, or (at your option) any later version.
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
 //
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU Affero General Public License for more details.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
 //
-//  You should have received a copy of the GNU Affero General Public License
-//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::sync::Arc;
 
-use crate::models::UploadedSplit;
 use anyhow::Context;
 use async_trait::async_trait;
 use fail::fail_point;
-use quickwit_actors::Actor;
-use quickwit_actors::ActorContext;
-use quickwit_actors::AsyncActor;
-use quickwit_actors::QueueCapacity;
+use quickwit_actors::{Actor, ActorContext, AsyncActor, QueueCapacity};
 use quickwit_metastore::Metastore;
 use tokio::sync::oneshot::Receiver;
+
+use crate::models::UploadedSplit;
 
 #[derive(Debug, Clone, Default)]
 pub struct PublisherCounters {
@@ -72,7 +69,8 @@ impl AsyncActor for Publisher {
         fail_point!("publisher:before");
         let uploaded_split = uploaded_split_future
             .await
-            .with_context(|| "Upload apparently failed")?; //< splits must be published in order, so one uploaded failing means we should fail entirely.
+            .with_context(|| "Upload apparently failed")?; //< splits must be published in order, so one uploaded failing means we should fail
+                                                           //< entirely.
         self.metastore
             .publish_splits(
                 &uploaded_split.index_id,
@@ -89,11 +87,12 @@ impl AsyncActor for Publisher {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use quickwit_actors::Universe;
     use quickwit_metastore::checkpoint::CheckpointDelta;
     use quickwit_metastore::{MockMetastore, SplitMetadata, SplitMetadataAndFooterOffsets};
     use tokio::sync::oneshot;
+
+    use super::*;
 
     #[tokio::test]
     async fn test_publisher_publishes_in_order() {
@@ -141,7 +140,7 @@ mod tests {
                     },
                     footer_offsets: 1000..1200
                 },
-                checkpoint_delta: CheckpointDelta::from(3..7),
+                checkpoint_delta: CheckpointDelta::from(3..7)
             })
             .is_ok());
         assert!(split_future_tx1
@@ -154,7 +153,7 @@ mod tests {
                     },
                     footer_offsets: 1000..1200
                 },
-                checkpoint_delta: CheckpointDelta::from(1..3),
+                checkpoint_delta: CheckpointDelta::from(1..3)
             })
             .is_ok());
         let publisher_observation = publisher_handle.process_pending_and_observe().await.state;

--- a/quickwit-indexing/src/actors/uploader.rs
+++ b/quickwit-indexing/src/actors/uploader.rs
@@ -1,54 +1,40 @@
-// Quickwit
-//  Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
 //
-//  Quickwit is offered under the AGPL v3.0 and as commercial software.
-//  For commercial licensing, contact us at hello@quickwit.io.
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
 //
-//  AGPL:
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU Affero General Public License as
-//  published by the Free Software Foundation, either version 3 of the
-//  License, or (at your option) any later version.
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
 //
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU Affero General Public License for more details.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
 //
-//  You should have received a copy of the GNU Affero General Public License
-//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::mem;
 use std::path::PathBuf;
-use std::sync::atomic::AtomicU64;
-use std::sync::atomic::Ordering;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
 
-use crate::models::PackagedSplit;
-use crate::models::UploadedSplit;
-use crate::semaphore::Semaphore;
-use anyhow::bail;
-use anyhow::Context;
+use anyhow::{bail, Context};
 use async_trait::async_trait;
 use fail::fail_point;
-use quickwit_actors::Actor;
-use quickwit_actors::ActorContext;
-use quickwit_actors::ActorExitStatus;
-use quickwit_actors::AsyncActor;
-use quickwit_actors::Mailbox;
-use quickwit_actors::QueueCapacity;
-use quickwit_metastore::Metastore;
-use quickwit_metastore::SplitMetadata;
-use quickwit_metastore::SplitMetadataAndFooterOffsets;
-use quickwit_metastore::SplitState;
-use quickwit_storage::PutPayload;
-use quickwit_storage::Storage;
-use quickwit_storage::BUNDLE_FILENAME;
+use quickwit_actors::{Actor, ActorContext, ActorExitStatus, AsyncActor, Mailbox, QueueCapacity};
+use quickwit_metastore::{Metastore, SplitMetadata, SplitMetadataAndFooterOffsets, SplitState};
+use quickwit_storage::{PutPayload, Storage, BUNDLE_FILENAME};
 use tantivy::chrono::Utc;
 use tokio::sync::oneshot::Receiver;
-use tracing::info;
-use tracing::warn;
+use tracing::{info, warn};
+
+use crate::models::{PackagedSplit, UploadedSplit};
+use crate::semaphore::Semaphore;
 
 pub const MAX_CONCURRENT_SPLIT_UPLOAD: usize = 3;
 
@@ -219,16 +205,14 @@ impl AsyncActor for Uploader {
 
 #[cfg(test)]
 mod tests {
-    use crate::models::ScratchDirectory;
-    use quickwit_actors::create_test_mailbox;
-    use quickwit_actors::ObservationType;
-    use quickwit_actors::Universe;
+    use quickwit_actors::{create_test_mailbox, ObservationType, Universe};
     use quickwit_metastore::checkpoint::CheckpointDelta;
     use quickwit_metastore::MockMetastore;
     use quickwit_storage::RamStorage;
     use tantivy::SegmentId;
 
     use super::*;
+    use crate::models::ScratchDirectory;
 
     #[tokio::test]
     async fn test_uploader() -> anyhow::Result<()> {

--- a/quickwit-indexing/src/lib.rs
+++ b/quickwit-indexing/src/lib.rs
@@ -1,22 +1,21 @@
-// Quickwit
-//  Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
 //
-//  Quickwit is offered under the AGPL v3.0 and as commercial software.
-//  For commercial licensing, contact us at hello@quickwit.io.
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
 //
-//  AGPL:
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU Affero General Public License as
-//  published by the Free Software Foundation, either version 3 of the
-//  License, or (at your option) any later version.
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
 //
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU Affero General Public License for more details.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
 //
-//  You should have received a copy of the GNU Affero General Public License
-//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::sync::Arc;
 
@@ -25,9 +24,7 @@ use quickwit_actors::Universe;
 use quickwit_metastore::Metastore;
 use quickwit_storage::StorageUriResolver;
 
-use crate::actors::IndexerParams;
-use crate::actors::IndexingPipelineParams;
-use crate::actors::IndexingPipelineSupervisor;
+use crate::actors::{IndexerParams, IndexingPipelineParams, IndexingPipelineSupervisor};
 use crate::models::IndexingStatistics;
 use crate::source::SourceConfig;
 
@@ -38,8 +35,7 @@ pub(crate) mod semaphore;
 pub mod source;
 mod test_utils;
 
-pub use test_utils::mock_split_meta;
-pub use test_utils::TestSandbox;
+pub use test_utils::{mock_split_meta, TestSandbox};
 
 pub use self::merge_policy::{MergePolicy, StableMultitenantWithTimestampMergePolicy};
 

--- a/quickwit-indexing/src/merge_policy.rs
+++ b/quickwit-indexing/src/merge_policy.rs
@@ -1,22 +1,21 @@
-// Quickwit
-//  Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
 //
-//  Quickwit is offered under the AGPL v3.0 and as commercial software.
-//  For commercial licensing, contact us at hello@quickwit.io.
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
 //
-//  AGPL:
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU Affero General Public License as
-//  published by the Free Software Foundation, either version 3 of the
-//  License, or (at your option) any later version.
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
 //
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU Affero General Public License for more details.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
 //
-//  You should have received a copy of the GNU Affero General Public License
-//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::cmp::Reverse;
 use std::fmt;
@@ -86,7 +85,8 @@ pub trait MergePolicy: Send + Sync {
 /// As a result, each level interval is at least 3 times larger than the previous one,
 /// forming a logscale over the number of documents.
 ///
-/// Because we stop merging splits reaching a size larger than if it would result in a size larger than `target_num_docs`.
+/// Because we stop merging splits reaching a size larger than if it would result in a size larger
+/// than `target_num_docs`.
 #[derive(Clone)]
 pub struct StableMultitenantWithTimestampMergePolicy {
     pub target_demux_ops: usize,
@@ -295,7 +295,8 @@ mod tests {
     fn create_splits(num_docs_vec: Vec<usize>) -> Vec<SplitMetadata> {
         let num_records_with_timestamp = num_docs_vec
             .into_iter()
-            // we give the same timestamp to all of them and rely on stable sort to keep the split order.
+            // we give the same timestamp to all of them and rely on stable sort to keep the split
+            // order.
             .map(|num_records| (num_records, (1630563067..=1630564067)))
             .collect();
         create_splits_with_timestamps(num_records_with_timestamp)
@@ -453,7 +454,7 @@ mod tests {
         let merge_policy = StableMultitenantWithTimestampMergePolicy::default();
         let mut splits = create_splits(vec![
             100_000, 100_000, 100_000, 100_000, 100_000,
-            10_000_000, /* this split should not interfere with the merging of other splits */
+            10_000_000, // this split should not interfere with the merging of other splits
             100_000, 100_000, 100_000, 100_000, 100_000,
         ]);
         let merge_ops = merge_policy.operations(&mut splits);

--- a/quickwit-indexing/src/models/commit_policy.rs
+++ b/quickwit-indexing/src/models/commit_policy.rs
@@ -1,22 +1,21 @@
-// Quickwit
-//  Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
 //
-//  Quickwit is offered under the AGPL v3.0 and as commercial software.
-//  For commercial licensing, contact us at hello@quickwit.io.
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
 //
-//  AGPL:
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU Affero General Public License as
-//  published by the Free Software Foundation, either version 3 of the
-//  License, or (at your option) any later version.
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
 //
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU Affero General Public License for more details.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
 //
-//  You should have received a copy of the GNU Affero General Public License
-//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 const DEFAULT_COMMIT_TIMEOUT: Duration = Duration::from_secs(60);
 const DEFAULT_NUM_DOCS_COMMIT_THRESHOLD: u64 = 10_000_000;

--- a/quickwit-indexing/src/models/indexed_split.rs
+++ b/quickwit-indexing/src/models/indexed_split.rs
@@ -1,22 +1,21 @@
-// Quickwit
-//  Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
 //
-//  Quickwit is offered under the AGPL v3.0 and as commercial software.
-//  For commercial licensing, contact us at hello@quickwit.io.
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
 //
-//  AGPL:
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU Affero General Public License as
-//  published by the Free Software Foundation, either version 3 of the
-//  License, or (at your option) any later version.
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
 //
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU Affero General Public License for more details.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
 //
-//  You should have received a copy of the GNU Affero General Public License
-//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::fmt;
 use std::ops::RangeInclusive;
@@ -25,8 +24,7 @@ use std::time::Instant;
 
 use quickwit_metastore::checkpoint::CheckpointDelta;
 use tantivy::merge_policy::NoMergePolicy;
-use tantivy::schema::Field;
-use tantivy::schema::Schema;
+use tantivy::schema::{Field, Schema};
 
 use crate::actors::IndexerParams;
 use crate::models::ScratchDirectory;

--- a/quickwit-indexing/src/models/indexer_message.rs
+++ b/quickwit-indexing/src/models/indexer_message.rs
@@ -1,22 +1,21 @@
-// Quickwit
-//  Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
 //
-//  Quickwit is offered under the AGPL v3.0 and as commercial software.
-//  For commercial licensing, contact us at hello@quickwit.io.
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
 //
-//  AGPL:
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU Affero General Public License as
-//  published by the Free Software Foundation, either version 3 of the
-//  License, or (at your option) any later version.
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
 //
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU Affero General Public License for more details.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
 //
-//  You should have received a copy of the GNU Affero General Public License
-//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use crate::models::RawDocBatch;
 

--- a/quickwit-indexing/src/models/indexing_statistics.rs
+++ b/quickwit-indexing/src/models/indexing_statistics.rs
@@ -1,30 +1,25 @@
-/*
-    Quickwit
-    Copyright (C) 2021 Quickwit Inc.
-
-    Quickwit is offered under the AGPL v3.0 and as commercial software.
-    For commercial licensing, contact us at hello@quickwit.io.
-
-    AGPL:
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation, either version 3 of the
-    License, or (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::sync::atomic::Ordering;
 
-use crate::actors::IndexerCounters;
-use crate::actors::PublisherCounters;
-use crate::actors::UploaderCounters;
+use crate::actors::{IndexerCounters, PublisherCounters, UploaderCounters};
 
 /// A Struct that holds all statistical data about indexing
 #[derive(Debug, Default, Clone)]
@@ -39,7 +34,7 @@ pub struct IndexingStatistics {
     pub num_staged_splits: u64,
     /// Number of uploaded splits
     pub num_uploaded_splits: u64,
-    ///Number of published splits
+    /// Number of published splits
     pub num_published_splits: u64,
     /// Size in byte of document processed
     pub total_bytes_processed: u64,

--- a/quickwit-indexing/src/models/mod.rs
+++ b/quickwit-indexing/src/models/mod.rs
@@ -1,22 +1,21 @@
-// Quickwit
-//  Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
 //
-//  Quickwit is offered under the AGPL v3.0 and as commercial software.
-//  For commercial licensing, contact us at hello@quickwit.io.
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
 //
-//  AGPL:
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU Affero General Public License as
-//  published by the Free Software Foundation, either version 3 of the
-//  License, or (at your option) any later version.
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
 //
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU Affero General Public License for more details.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
 //
-//  You should have received a copy of the GNU Affero General Public License
-//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 mod commit_policy;
 mod indexed_split;

--- a/quickwit-indexing/src/models/packaged_split.rs
+++ b/quickwit-indexing/src/models/packaged_split.rs
@@ -1,28 +1,29 @@
-// Quickwit
-//  Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
 //
-//  Quickwit is offered under the AGPL v3.0 and as commercial software.
-//  For commercial licensing, contact us at hello@quickwit.io.
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
 //
-//  AGPL:
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU Affero General Public License as
-//  published by the Free Software Foundation, either version 3 of the
-//  License, or (at your option) any later version.
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
 //
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU Affero General Public License for more details.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
 //
-//  You should have received a copy of the GNU Affero General Public License
-//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use crate::models::ScratchDirectory;
-use quickwit_metastore::checkpoint::CheckpointDelta;
 use std::collections::HashSet;
 use std::ops::{Range, RangeInclusive};
+
+use quickwit_metastore::checkpoint::CheckpointDelta;
 use tantivy::SegmentId;
+
+use crate::models::ScratchDirectory;
 
 #[derive(Debug)]
 pub struct PackagedSplit {

--- a/quickwit-indexing/src/models/raw_doc_batch.rs
+++ b/quickwit-indexing/src/models/raw_doc_batch.rs
@@ -1,21 +1,21 @@
-// Quickwit
-//  Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
 //
-//  Quickwit is offered under the AGPL v3.0 and as commercial software.
-//  For commercial licensing, contact us at hello@quickwit.io.
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
 //
-//  AGPL:
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU Affero General Public License as
-//  published by the Free Software Foundation, either version 3 of the
-//  License, or (at your option) any later version.
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
 //
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU Affero General Public License for more details.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
 //
-//  You should have received a copy of the GNU Affero General Public License
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use quickwit_metastore::checkpoint::CheckpointDelta;
 

--- a/quickwit-indexing/src/models/scratch_directory.rs
+++ b/quickwit-indexing/src/models/scratch_directory.rs
@@ -1,28 +1,25 @@
-// Quickwit
-//  Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
 //
-//  Quickwit is offered under the AGPL v3.0 and as commercial software.
-//  For commercial licensing, contact us at hello@quickwit.io.
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
 //
-//  AGPL:
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU Affero General Public License as
-//  published by the Free Software Foundation, either version 3 of the
-//  License, or (at your option) any later version.
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
 //
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU Affero General Public License for more details.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
 //
-//  You should have received a copy of the GNU Affero General Public License
-//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use std::fmt;
-use std::io;
-use std::path::Path;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::{fmt, io};
 enum ScratchDirectoryType {
     Path(PathBuf),
     TempDir(tempfile::TempDir),
@@ -108,8 +105,9 @@ impl ScratchDirectory {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::mem;
+
+    use super::*;
 
     #[test]
     fn test_scratch_directory() -> io::Result<()> {

--- a/quickwit-indexing/src/models/uploaded_split.rs
+++ b/quickwit-indexing/src/models/uploaded_split.rs
@@ -1,22 +1,21 @@
-// Quickwit
-//  Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
 //
-//  Quickwit is offered under the AGPL v3.0 and as commercial software.
-//  For commercial licensing, contact us at hello@quickwit.io.
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
 //
-//  AGPL:
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU Affero General Public License as
-//  published by the Free Software Foundation, either version 3 of the
-//  License, or (at your option) any later version.
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
 //
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU Affero General Public License for more details.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
 //
-//  You should have received a copy of the GNU Affero General Public License
-//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use quickwit_metastore::checkpoint::CheckpointDelta;
 use quickwit_metastore::SplitMetadataAndFooterOffsets;

--- a/quickwit-indexing/src/semaphore.rs
+++ b/quickwit-indexing/src/semaphore.rs
@@ -1,22 +1,21 @@
-// Quickwit
-//  Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
 //
-//  Quickwit is offered under the AGPL v3.0 and as commercial software.
-//  For commercial licensing, contact us at hello@quickwit.io.
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
 //
-//  AGPL:
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU Affero General Public License as
-//  published by the Free Software Foundation, either version 3 of the
-//  License, or (at your option) any later version.
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
 //
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU Affero General Public License for more details.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
 //
-//  You should have received a copy of the GNU Affero General Public License
-//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::sync::Arc;
 
@@ -67,10 +66,10 @@ impl Drop for SemaphoreGuard {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::mem;
-    use std::sync::atomic::AtomicUsize;
-    use std::sync::atomic::Ordering;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use super::*;
 
     #[tokio::test]
     async fn test_semaphore() {
@@ -79,9 +78,10 @@ mod tests {
         let semaphore = Semaphore::new(NUM_CONCURRENT_TASKS);
         for i in 1..1_000 {
             let guard = semaphore.acquire().await;
-            // Thanks to the semaphore we have the guarantee that at most NUM_CONCURRENT_TASKS tasks are running
-            // at the same time.
-            // In other words, upon acquisition of guard, we know that at least (i - 3) tasks have terminated.
+            // Thanks to the semaphore we have the guarantee that at most NUM_CONCURRENT_TASKS tasks
+            // are running at the same time.
+            // In other words, upon acquisition of guard, we know that at least (i - 3) tasks have
+            // terminated.
             assert!(finished_task.load(Ordering::SeqCst) + NUM_CONCURRENT_TASKS >= i);
             let finished_task_clone = finished_task.clone();
             tokio::task::spawn(async move {

--- a/quickwit-indexing/src/source/file_source.rs
+++ b/quickwit-indexing/src/source/file_source.rs
@@ -1,44 +1,37 @@
-//  Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
 //
-//  Quickwit is offered under the AGPL v3.0 and as commercial software.
-//  For commercial licensing, contact us at hello@quickwit.io.
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
 //
-//  AGPL:
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU Affero General Public License as
-//  published by the Free Software Foundation, either version 3 of the
-//  License, or (at your option) any later version.
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
 //
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU Affero General Public License for more details.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
 //
-//  You should have received a copy of the GNU Affero General Public License
-//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use crate::models::IndexerMessage;
-use crate::models::RawDocBatch;
-use crate::source::Source;
-use crate::source::SourceContext;
-use crate::source::TypedSourceFactory;
-use anyhow::Context;
-use async_trait::async_trait;
-use quickwit_actors::ActorExitStatus;
-use quickwit_actors::Mailbox;
-use quickwit_metastore::checkpoint::CheckpointDelta;
-use quickwit_metastore::checkpoint::PartitionId;
-use quickwit_metastore::checkpoint::Position;
-use serde::{Deserialize, Serialize};
 use std::io;
 use std::io::SeekFrom;
 use std::path::PathBuf;
+
+use anyhow::Context;
+use async_trait::async_trait;
+use quickwit_actors::{ActorExitStatus, Mailbox};
+use quickwit_metastore::checkpoint::{CheckpointDelta, PartitionId, Position};
+use serde::{Deserialize, Serialize};
 use tokio::fs::File;
-use tokio::io::AsyncBufReadExt;
-use tokio::io::AsyncRead;
-use tokio::io::AsyncSeekExt;
-use tokio::io::BufReader;
+use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncSeekExt, BufReader};
 use tracing::info;
+
+use crate::models::{IndexerMessage, RawDocBatch};
+use crate::source::{Source, SourceContext, TypedSourceFactory};
 
 /// Cut a new batch as soon as we have read BATCH_NUM_BYTES_THRESHOLD.
 const BATCH_NUM_BYTES_THRESHOLD: u64 = 500_000u64;
@@ -186,12 +179,11 @@ impl TypedSourceFactory for FileSourceFactory {
 mod tests {
     use std::io::Write;
 
-    use crate::source::SourceActor;
+    use quickwit_actors::{create_test_mailbox, Universe};
+    use quickwit_metastore::checkpoint::Checkpoint;
 
     use super::*;
-    use quickwit_actors::create_test_mailbox;
-    use quickwit_actors::Universe;
-    use quickwit_metastore::checkpoint::Checkpoint;
+    use crate::source::SourceActor;
 
     #[tokio::test]
     async fn test_file_source() -> anyhow::Result<()> {

--- a/quickwit-indexing/src/source/mod.rs
+++ b/quickwit-indexing/src/source/mod.rs
@@ -1,22 +1,21 @@
-// Quickwit
-//  Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
 //
-//  Quickwit is offered under the AGPL v3.0 and as commercial software.
-//  For commercial licensing, contact us at hello@quickwit.io.
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
 //
-//  AGPL:
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU Affero General Public License as
-//  published by the Free Software Foundation, either version 3 of the
-//  License, or (at your option) any later version.
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
 //
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU Affero General Public License for more details.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
 //
-//  You should have received a copy of the GNU Affero General Public License
-//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 mod file_source;
 #[cfg(feature = "kafka")]
@@ -24,21 +23,18 @@ mod kafka_source;
 mod source_factory;
 mod vec_source;
 
-use crate::models::IndexerMessage;
-use async_trait::async_trait;
-use once_cell::sync::OnceCell;
-use quickwit_actors::Actor;
-use quickwit_actors::ActorContext;
-use quickwit_actors::ActorExitStatus;
-use quickwit_actors::AsyncActor;
-use quickwit_actors::Mailbox;
 use std::fmt;
 
+use async_trait::async_trait;
 pub use file_source::{FileSource, FileSourceFactory, FileSourceParams};
 #[cfg(feature = "kafka")]
 pub use kafka_source::{KafkaSource, KafkaSourceFactory, KafkaSourceParams};
+use once_cell::sync::OnceCell;
+use quickwit_actors::{Actor, ActorContext, ActorExitStatus, AsyncActor, Mailbox};
 pub use source_factory::{SourceFactory, SourceLoader, TypedSourceFactory};
 pub use vec_source::{VecSource, VecSourceFactory, VecSourceParams};
+
+use crate::models::IndexerMessage;
 
 pub type SourceContext = ActorContext<Loop>;
 
@@ -55,9 +51,9 @@ pub type SourceContext = ActorContext<Loop>;
 /// ```ignore
 /// source.initialize(ctx)?
 /// let exit_status = loop {
-///    if let Err(exit_status) = source.emit_batches()? {
-///       break exit_status;
-////   }
+///   if let Err(exit_status) = source.emit_batches()? {
+///      break exit_status;
+////  }
 /// };
 /// source.finalize(exit_status)?;
 /// ```

--- a/quickwit-indexing/src/source/source_factory.rs
+++ b/quickwit-indexing/src/source/source_factory.rs
@@ -1,30 +1,31 @@
-// Quickwit
-//  Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
 //
-//  Quickwit is offered under the AGPL v3.0 and as commercial software.
-//  For commercial licensing, contact us at hello@quickwit.io.
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
 //
-//  AGPL:
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU Affero General Public License as
-//  published by the Free Software Foundation, either version 3 of the
-//  License, or (at your option) any later version.
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
 //
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU Affero General Public License for more details.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
 //
-//  You should have received a copy of the GNU Affero General Public License
-//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use super::Source;
-use crate::source::SourceConfig;
+use std::collections::HashMap;
+
 use async_trait::async_trait;
 use itertools::Itertools;
 use quickwit_metastore::checkpoint::Checkpoint;
-use std::collections::HashMap;
 use thiserror::Error;
+
+use super::Source;
+use crate::source::SourceConfig;
 
 #[async_trait]
 pub trait SourceFactory: 'static + Send + Sync {
@@ -65,7 +66,10 @@ pub struct SourceLoader {
 
 #[derive(Error, Debug)]
 pub enum SourceLoaderError {
-    #[error("Unknown source type `{requested_source_type}` (available source types are {available_source_types}).")]
+    #[error(
+        "Unknown source type `{requested_source_type}` (available source types are \
+         {available_source_types})."
+    )]
     UnknownSourceType {
         requested_source_type: String,
         available_source_types: String, //< a comma separated list with the available source_type.
@@ -115,9 +119,10 @@ impl SourceLoader {
 
 #[cfg(test)]
 mod tests {
+    use serde_json::json;
+
     use super::*;
     use crate::source::quickwit_supported_sources;
-    use serde_json::json;
 
     #[tokio::test]
     async fn test_source_loader_success() -> anyhow::Result<()> {

--- a/quickwit-indexing/src/source/vec_source.rs
+++ b/quickwit-indexing/src/source/vec_source.rs
@@ -1,37 +1,30 @@
-// Quickwit
-//  Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
 //
-//  Quickwit is offered under the AGPL v3.0 and as commercial software.
-//  For commercial licensing, contact us at hello@quickwit.io.
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
 //
-//  AGPL:
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU Affero General Public License as
-//  published by the Free Software Foundation, either version 3 of the
-//  License, or (at your option) any later version.
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
 //
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU Affero General Public License for more details.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
 //
-//  You should have received a copy of the GNU Affero General Public License
-//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use crate::models::IndexerMessage;
-use crate::models::RawDocBatch;
-use crate::source::Source;
-use crate::source::SourceContext;
-use crate::source::TypedSourceFactory;
 use async_trait::async_trait;
-use quickwit_actors::ActorExitStatus;
-use quickwit_actors::Mailbox;
-use quickwit_metastore::checkpoint::Checkpoint;
-use quickwit_metastore::checkpoint::CheckpointDelta;
-use quickwit_metastore::checkpoint::PartitionId;
-use quickwit_metastore::checkpoint::Position;
+use quickwit_actors::{ActorExitStatus, Mailbox};
+use quickwit_metastore::checkpoint::{Checkpoint, CheckpointDelta, PartitionId, Position};
 use serde::{Deserialize, Serialize};
 use tracing::info;
+
+use crate::models::{IndexerMessage, RawDocBatch};
+use crate::source::{Source, SourceContext, TypedSourceFactory};
 
 #[derive(Deserialize, Serialize)]
 pub struct VecSourceParams {
@@ -120,11 +113,11 @@ impl Source for VecSource {
 
 #[cfg(test)]
 mod tests {
+    use quickwit_actors::{create_test_mailbox, Universe};
+    use serde_json::json;
+
     use super::*;
     use crate::source::SourceActor;
-    use quickwit_actors::create_test_mailbox;
-    use quickwit_actors::Universe;
-    use serde_json::json;
 
     #[tokio::test]
     async fn test_vec_source() -> anyhow::Result<()> {

--- a/quickwit-indexing/src/test_utils.rs
+++ b/quickwit-indexing/src/test_utils.rs
@@ -1,32 +1,26 @@
-/*
- * Copyright (C) 2021 Quickwit Inc.
- *
- * Quickwit is offered under the AGPL v3.0 and as commercial software.
- * For commercial licensing, contact us at hello@quickwit.io.
- *
- * AGPL:
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
-use crate::actors::IndexerParams;
-use crate::index_data;
-use crate::models::{CommitPolicy, IndexingStatistics, ScratchDirectory};
-use crate::source::{SourceConfig, VecSourceParams};
 use byte_unit::Byte;
 use quickwit_index_config::IndexConfig;
 use quickwit_metastore::checkpoint::Checkpoint;
@@ -35,6 +29,11 @@ use quickwit_metastore::{
     SplitState,
 };
 use quickwit_storage::StorageUriResolver;
+
+use crate::actors::IndexerParams;
+use crate::index_data;
+use crate::models::{CommitPolicy, IndexingStatistics, ScratchDirectory};
+use crate::source::{SourceConfig, VecSourceParams};
 
 /// Creates a Test environment.
 ///
@@ -150,8 +149,9 @@ pub fn mock_split_meta(split_id: &str) -> SplitMetadataAndFooterOffsets {
 mod tests {
     use std::sync::Arc;
 
-    use super::TestSandbox;
     use quickwit_index_config::WikipediaIndexConfig;
+
+    use super::TestSandbox;
 
     #[tokio::test]
     async fn test_test_sandbox() -> anyhow::Result<()> {

--- a/quickwit-metastore/src/checkpoint.rs
+++ b/quickwit-metastore/src/checkpoint.rs
@@ -1,26 +1,22 @@
-// Quickwit
-//  Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
 //
-//  Quickwit is offered under the AGPL v3.0 and as commercial software.
-//  For commercial licensing, contact us at hello@quickwit.io.
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
 //
-//  AGPL:
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU Affero General Public License as
-//  published by the Free Software Foundation, either version 3 of the
-//  License, or (at your option) any later version.
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
 //
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU Affero General Public License for more details.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
 //
-//  You should have received a copy of the GNU Affero General Public License
-//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use serde::ser::SerializeMap;
-use serde::Deserialize;
-use serde::Serialize;
 use std::cmp::Ordering;
 use std::collections::btree_map::Entry;
 use std::collections::BTreeMap;
@@ -28,9 +24,11 @@ use std::fmt;
 use std::iter::FromIterator;
 use std::ops::Range;
 use std::sync::Arc;
+
+use serde::ser::SerializeMap;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use tracing::info;
-use tracing::warn;
+use tracing::{info, warn};
 
 /// PartitionId identifies a partition for a given source.
 #[derive(Debug, Default, Clone, Eq, PartialEq, Ord, PartialOrd)]
@@ -172,9 +170,7 @@ impl Checkpoint {
 /// ```
 impl FromIterator<(PartitionId, Position)> for Checkpoint {
     fn from_iter<I>(iter: I) -> Checkpoint
-    where
-        I: IntoIterator<Item = (PartitionId, Position)>,
-    {
+    where I: IntoIterator<Item = (PartitionId, Position)> {
         Checkpoint {
             per_partition: iter.into_iter().collect(),
         }
@@ -183,9 +179,7 @@ impl FromIterator<(PartitionId, Position)> for Checkpoint {
 
 impl Serialize for Checkpoint {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
+    where S: serde::Serializer {
         let mut map = serializer.serialize_map(Some(self.per_partition.len()))?;
         for (partition, position) in &self.per_partition {
             map.serialize_entry(&*partition.0, &*position.as_str())?;
@@ -196,9 +190,7 @@ impl Serialize for Checkpoint {
 
 impl<'de> Deserialize<'de> for Checkpoint {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
+    where D: serde::Deserializer<'de> {
         let string_to_string_map: BTreeMap<String, String> = BTreeMap::deserialize(deserializer)?;
         let per_partition: BTreeMap<PartitionId, Position> = string_to_string_map
             .into_iter()
@@ -214,7 +206,10 @@ impl<'de> Deserialize<'de> for Checkpoint {
 /// compatible. ie: the checkpoint delta starts from a point anterior to
 /// the checkpoint.
 #[derive(Error, Debug, PartialEq)]
-#[error("IncompatibleChkptDelta at partition: {partition_id:?} cur_pos:{current_position:?} delta_pos:{delta_position_from:?}")]
+#[error(
+    "IncompatibleChkptDelta at partition: {partition_id:?} cur_pos:{current_position:?} \
+     delta_pos:{delta_position_from:?}"
+)]
 pub struct IncompatibleCheckpointDelta {
     /// One PartitionId for which the incompatibility has been detected.
     pub partition_id: PartitionId,
@@ -274,11 +269,11 @@ impl Checkpoint {
     /// as gaps may happen. For instance, assuming a Kafka source, if the indexing
     /// pipeline is down for more than the retention period.
     ///
-    ///    |    Checkpoint & Delta        | Outcome                     |
-    ///    |------------------------------|-----------------------------|
-    ///    |  (..a] (b..c] with a = b     | Compatible                  |
-    ///    |  (..a] (b..c] with b > a     | Compatible                  |
-    ///    |  (..a] (b..c] with b < a     | Incompatible                |
+    ///   |    Checkpoint & Delta        | Outcome                     |
+    ///   |------------------------------|-----------------------------|
+    ///   |  (..a] (b..c] with a = b     | Compatible                  |
+    ///   |  (..a] (b..c] with b > a     | Compatible                  |
+    ///   |  (..a] (b..c] with b < a     | Incompatible                |
     ///
     /// If the delta is compatible, returns an error without modifying the original checkpoint.
     pub fn try_apply_delta(
@@ -613,7 +608,7 @@ mod tests {
             Err(IncompatibleCheckpointDelta {
                 partition_id: PartitionId::from("a"),
                 current_position: Position::from("00128"),
-                delta_position_from: Position::from("00130"),
+                delta_position_from: Position::from("00130")
             })
         );
         Ok(())

--- a/quickwit-metastore/src/error.rs
+++ b/quickwit-metastore/src/error.rs
@@ -1,24 +1,21 @@
-/*
-    Quickwit
-    Copyright (C) 2021 Quickwit Inc.
-
-    Quickwit is offered under the AGPL v3.0 and as commercial software.
-    For commercial licensing, contact us at hello@quickwit.io.
-
-    AGPL:
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation, either version 3 of the
-    License, or (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::io;
 

--- a/quickwit-metastore/src/lib.rs
+++ b/quickwit-metastore/src/lib.rs
@@ -1,32 +1,29 @@
-/*
-    Quickwit
-    Copyright (C) 2021 Quickwit Inc.
-
-    Quickwit is offered under the AGPL v3.0 and as commercial software.
-    For commercial licensing, contact us at hello@quickwit.io.
-
-    AGPL:
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation, either version 3 of the
-    License, or (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 #![warn(missing_docs)]
 #![allow(clippy::bool_assert_comparison)]
 
-/*! `quickwit-metastore` is the abstraction used in quickwit to interface itself to different metastore:
-- single file metastore
-etc.
-*/
+//! `quickwit-metastore` is the abstraction used in quickwit to interface itself to different
+//! metastore:
+//! - single file metastore
+//! etc.
 
 #[macro_use]
 mod tests;
@@ -39,10 +36,9 @@ mod metastore_resolver;
 
 pub use error::{MetastoreError, MetastoreResolverError, MetastoreResult};
 pub use metastore::single_file_metastore::SingleFileMetastore;
+#[cfg(feature = "testsuite")]
+pub use metastore::MockMetastore;
 pub use metastore::{
     IndexMetadata, MetadataSet, Metastore, SplitMetadata, SplitMetadataAndFooterOffsets, SplitState,
 };
 pub use metastore_resolver::{MetastoreFactory, MetastoreUriResolver};
-
-#[cfg(feature = "testsuite")]
-pub use metastore::MockMetastore;

--- a/quickwit-metastore/src/metastore.rs
+++ b/quickwit-metastore/src/metastore.rs
@@ -1,31 +1,28 @@
-/*
-    Quickwit
-    Copyright (C) 2021 Quickwit Inc.
-
-    Quickwit is offered under the AGPL v3.0 and as commercial software.
-    For commercial licensing, contact us at hello@quickwit.io.
-
-    AGPL:
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation, either version 3 of the
-    License, or (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 pub mod single_file_metastore;
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
 use std::ops::{Range, RangeInclusive};
-use std::{collections::HashMap, sync::Arc};
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use chrono::Utc;
@@ -144,13 +141,13 @@ pub struct MetadataSet {
 ///
 /// The split state goes through the following life cycle:
 /// 1. `New`
-///   - Create new split and start indexing.
+///  - Create new split and start indexing.
 /// 2. `Staged`
-///   - Start uploading the split files.
+///  - Start uploading the split files.
 /// 3. `Published`
-///   - Uploading the split files is complete and the split is searchable.
+///  - Uploading the split files is complete and the split is searchable.
 /// 4. `ScheduledForDeletion`
-///   - Mark the split for deletion.
+///  - Mark the split for deletion.
 ///
 /// If a split has a file in the storage, it MUST be registered in the metastore,
 /// and its state can be as follows:
@@ -158,10 +155,11 @@ pub struct MetadataSet {
 /// - `Published`: The split is ready and published.
 /// - `ScheduledForDeletion`: The split is scheduled for deletion.
 ///
-/// Before creating any file, we need to stage the split. If there is a failure, upon recovery, we schedule for deletion all the staged splits.
-/// A client may not necessarily remove files from storage right after marking it as deleted.
-/// A CLI client may delete files right away, but a more serious deployment should probably
-/// only delete those files after a grace period so that the running search queries can complete.
+/// Before creating any file, we need to stage the split. If there is a failure, upon recovery, we
+/// schedule for deletion all the staged splits. A client may not necessarily remove files from
+/// storage right after marking it as deleted. A CLI client may delete files right away, but a more
+/// serious deployment should probably only delete those files after a grace period so that the
+/// running search queries can complete.
 #[cfg_attr(any(test, feature = "testsuite"), mockall::automock)]
 #[async_trait]
 pub trait Metastore: Send + Sync + 'static {
@@ -233,8 +231,8 @@ pub trait Metastore: Send + Sync + 'static {
     ) -> MetastoreResult<Vec<SplitMetadataAndFooterOffsets>>;
 
     /// Marks a list of splits as deleted.
-    /// This API will change the state to `ScheduledForDeletion` so that it is not referenced by the client.
-    /// It actually does not remove the split from storage.
+    /// This API will change the state to `ScheduledForDeletion` so that it is not referenced by the
+    /// client. It actually does not remove the split from storage.
     /// An error will occur if you specify an index or split that does not exist in the storage.
     async fn mark_splits_as_deleted<'a>(
         &self,
@@ -244,8 +242,9 @@ pub trait Metastore: Send + Sync + 'static {
 
     /// Deletes a list of splits.
     /// This API only takes a split that is in `Staged` or `ScheduledForDeletion` state.
-    /// This removes the split metadata from the metastore, but does not remove the split from storage.
-    /// An error will occur if you specify an index or split that does not exist in the storage.
+    /// This removes the split metadata from the metastore, but does not remove the split from
+    /// storage. An error will occur if you specify an index or split that does not exist in the
+    /// storage.
     async fn delete_splits<'a>(&self, index_id: &str, split_ids: &[&'a str])
         -> MetastoreResult<()>;
 

--- a/quickwit-metastore/src/metastore/single_file_metastore.rs
+++ b/quickwit-metastore/src/metastore/single_file_metastore.rs
@@ -1,24 +1,21 @@
-/*
-    Quickwit
-    Copyright (C) 2021 Quickwit Inc.
-
-    Quickwit is offered under the AGPL v3.0 and as commercial software.
-    For commercial licensing, contact us at hello@quickwit.io.
-
-    AGPL:
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation, either version 3 of the
-    License, or (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::collections::HashMap;
 use std::ops::{Range, RangeInclusive};
@@ -27,18 +24,17 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use chrono::Utc;
+use quickwit_storage::{
+    quickwit_storage_uri_resolver, PutPayload, Storage, StorageErrorKind, StorageResolverError,
+    StorageUriResolver,
+};
 use tokio::sync::RwLock;
 
-use quickwit_storage::StorageUriResolver;
-use quickwit_storage::{quickwit_storage_uri_resolver, StorageResolverError};
-use quickwit_storage::{PutPayload, Storage, StorageErrorKind};
-
 use crate::checkpoint::CheckpointDelta;
-use crate::MetastoreFactory;
-use crate::MetastoreResolverError;
 use crate::{
-    IndexMetadata, MetadataSet, Metastore, MetastoreError, MetastoreResult, SplitMetadata,
-    SplitMetadataAndFooterOffsets, SplitState,
+    IndexMetadata, MetadataSet, Metastore, MetastoreError, MetastoreFactory,
+    MetastoreResolverError, MetastoreResult, SplitMetadata, SplitMetadataAndFooterOffsets,
+    SplitState,
 };
 
 /// Metadata file managed by [`SingleFileMetastore`].

--- a/quickwit-metastore/src/metastore_resolver.rs
+++ b/quickwit-metastore/src/metastore_resolver.rs
@@ -1,24 +1,21 @@
-/*
-    Quickwit
-    Copyright (C) 2021 Quickwit Inc.
-
-    Quickwit is offered under the AGPL v3.0 and as commercial software.
-    For commercial licensing, contact us at hello@quickwit.io.
-
-    AGPL:
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation, either version 3 of the
-    License, or (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/quickwit-metastore/src/tests.rs
+++ b/quickwit-metastore/src/tests.rs
@@ -1,24 +1,21 @@
-/*
-    Quickwit
-    Copyright (C) 2021 Quickwit Inc.
-
-    Quickwit is offered under the AGPL v3.0 and as commercial software.
-    For commercial licensing, contact us at hello@quickwit.io.
-
-    AGPL:
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation, either version 3 of the
-    License, or (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::collections::HashSet;
 use std::ops::{Range, RangeInclusive};
@@ -26,9 +23,8 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use chrono::Utc;
-use tokio::time::{sleep, Duration};
-
 use quickwit_index_config::AllFlattenIndexConfig;
+use tokio::time::{sleep, Duration};
 
 use crate::checkpoint::{Checkpoint, CheckpointDelta};
 use crate::{

--- a/quickwit-proto/build.rs
+++ b/quickwit-proto/build.rs
@@ -1,22 +1,21 @@
-//  Quickwit
-//  Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
 //
-//  Quickwit is offered under the AGPL v3.0 and as commercial software.
-//  For commercial licensing, contact us at hello@quickwit.io.
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
 //
-//  AGPL:
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU Affero General Public License as
-//  published by the Free Software Foundation, either version 3 of the
-//  License, or (at your option) any later version.
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
 //
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU Affero General Public License for more details.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
 //
-//  You should have received a copy of the GNU Affero General Public License
-//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("cargo:rerun-if-changed=proto/cluster.proto");

--- a/quickwit-proto/src/lib.rs
+++ b/quickwit-proto/src/lib.rs
@@ -1,22 +1,21 @@
-//  Quickwit
-//  Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
 //
-//  Quickwit is offered under the AGPL v3.0 and as commercial software.
-//  For commercial licensing, contact us at hello@quickwit.io.
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
 //
-//  AGPL:
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU Affero General Public License as
-//  published by the Free Software Foundation, either version 3 of the
-//  License, or (at your option) any later version.
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
 //
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU Affero General Public License for more details.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
 //
-//  You should have received a copy of the GNU Affero General Public License
-//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 mod cluster;
 mod quickwit;

--- a/quickwit-search/src/client.rs
+++ b/quickwit-search/src/client.rs
@@ -1,39 +1,35 @@
-/*
- * Copyright (C) 2021 Quickwit Inc.
- *
- * Quickwit is offered under the AGPL v3.0 and as commercial software.
- * For commercial licensing, contact us at hello@quickwit.io.
- *
- * AGPL:
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use futures::StreamExt;
-use futures::TryStreamExt;
-use http::Uri;
-use quickwit_proto::LeafSearchStreamResult;
 use std::fmt;
 use std::net::SocketAddr;
 use std::sync::Arc;
+
+use futures::{StreamExt, TryStreamExt};
+use http::Uri;
+use quickwit_proto::LeafSearchStreamResult;
 use tokio_stream::wrappers::UnboundedReceiverStream;
-use tonic::transport::Channel;
-use tonic::transport::Endpoint;
+use tonic::transport::{Channel, Endpoint};
 use tonic::Request;
 
 use crate::error::parse_grpc_error;
-use crate::SearchError;
-use crate::SearchService;
+use crate::{SearchError, SearchService};
 
 /// Impl is an enumeration that meant to manage Quickwit's search service client types.
 #[derive(Clone)]
@@ -43,7 +39,8 @@ enum SearchServiceClientImpl {
 }
 
 /// A search service client.
-/// It contains the client implementation and the gRPC address of the node to which the client connects.
+/// It contains the client implementation and the gRPC address of the node to which the client
+/// connects.
 #[derive(Clone)]
 pub struct SearchServiceClient {
     client_impl: SearchServiceClientImpl,

--- a/quickwit-search/src/client_pool.rs
+++ b/quickwit-search/src/client_pool.rs
@@ -1,27 +1,26 @@
-/*
- * Copyright (C) 2021 Quickwit Inc.
- *
- * Quickwit is offered under the AGPL v3.0 and as commercial software.
- * For commercial licensing, contact us at hello@quickwit.io.
- *
- * AGPL:
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 pub mod search_client_pool;
 
-use std::{collections::HashSet, net::SocketAddr};
+use std::collections::HashSet;
+use std::net::SocketAddr;
 
 use async_trait::async_trait;
 use quickwit_metastore::SplitMetadataAndFooterOffsets;

--- a/quickwit-search/src/client_pool/search_client_pool.rs
+++ b/quickwit-search/src/client_pool/search_client_pool.rs
@@ -1,23 +1,21 @@
-/*
- * Copyright (C) 2021 Quickwit Inc.
- *
- * Quickwit is offered under the AGPL v3.0 and as commercial software.
- * For commercial licensing, contact us at hello@quickwit.io.
- *
- * AGPL:
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::cmp::Ordering;
 use std::collections::hash_map::Entry;
@@ -26,17 +24,15 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use quickwit_cluster::cluster::Cluster;
 use tokio::sync::RwLock;
 use tokio_stream::StreamExt;
 use tracing::*;
 
-use quickwit_cluster::cluster::Cluster;
-
 use crate::client::create_search_service_client;
 use crate::client_pool::{ClientPool, Job};
 use crate::rendezvous_hasher::{sort_by_rendez_vous_hash, Node};
-use crate::swim_addr_to_grpc_addr;
-use crate::SearchServiceClient;
+use crate::{swim_addr_to_grpc_addr, SearchServiceClient};
 
 /// Search client pool implementation.
 #[derive(Clone)]
@@ -233,8 +229,7 @@ mod tests {
     use std::collections::HashSet;
     use std::net::{IpAddr, Ipv4Addr, SocketAddr};
     use std::sync::Arc;
-    use std::thread;
-    use std::time;
+    use std::{thread, time};
 
     use quickwit_cluster::cluster::{read_host_key, Cluster};
     use quickwit_cluster::test_utils::{available_port, test_cluster};
@@ -242,8 +237,7 @@ mod tests {
 
     use crate::client_pool::search_client_pool::create_search_service_client;
     use crate::client_pool::{ClientPool, Job};
-    use crate::swim_addr_to_grpc_addr;
-    use crate::SearchClientPool;
+    use crate::{swim_addr_to_grpc_addr, SearchClientPool};
 
     #[tokio::test]
     async fn test_search_client_pool_single_node() -> anyhow::Result<()> {

--- a/quickwit-search/src/collector.rs
+++ b/quickwit-search/src/collector.rs
@@ -1,50 +1,38 @@
-// Quickwit
-//  Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
 //
-//  Quickwit is offered under the AGPL v3.0 and as commercial software.
-//  For commercial licensing, contact us at hello@quickwit.io.
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
 //
-//  AGPL:
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU Affero General Public License as
-//  published by the Free Software Foundation, either version 3 of the
-//  License, or (at your option) any later version.
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
 //
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU Affero General Public License for more details.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
 //
-//  You should have received a copy of the GNU Affero General Public License
-//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use std::cmp::Ordering;
+use std::collections::{BinaryHeap, HashSet};
 
 use itertools::Itertools;
-use std::cmp::Ordering;
-use std::collections::BinaryHeap;
-use std::collections::HashSet;
-use tantivy::schema::Schema;
-
-use quickwit_index_config::IndexConfig;
-use quickwit_index_config::SortBy;
-use quickwit_index_config::SortOrder;
-use quickwit_proto::LeafSearchResult;
-use quickwit_proto::PartialHit;
-use quickwit_proto::SearchRequest;
-use tantivy::collector::Collector;
-use tantivy::collector::SegmentCollector;
-use tantivy::fastfield::DynamicFastFieldReader;
-use tantivy::fastfield::FastFieldReader;
-use tantivy::schema::Field;
-use tantivy::DocId;
-use tantivy::Score;
-use tantivy::SegmentOrdinal;
-use tantivy::SegmentReader;
+use quickwit_index_config::{IndexConfig, SortBy, SortOrder};
+use quickwit_proto::{LeafSearchResult, PartialHit, SearchRequest};
+use tantivy::collector::{Collector, SegmentCollector};
+use tantivy::fastfield::{DynamicFastFieldReader, FastFieldReader};
+use tantivy::schema::{Field, Schema};
+use tantivy::{DocId, Score, SegmentOrdinal, SegmentReader};
 
 use crate::filters::TimestampFilter;
 use crate::partial_hit_sorting_key;
 
-/// The `SortingFieldComputer` can be seen as the specialization of `SortBy` applied to a specific `SegmentReader`.
-/// Its role is to compute the sorting field given a `DocId`.
+/// The `SortingFieldComputer` can be seen as the specialization of `SortBy` applied to a specific
+/// `SegmentReader`. Its role is to compute the sorting field given a `DocId`.
 enum SortingFieldComputer {
     SortByFastField {
         fast_field_reader: DynamicFastFieldReader<u64>,
@@ -66,7 +54,8 @@ impl SortingFieldComputer {
                 match order {
                     // Descending is our most common case.
                     SortOrder::Desc => field_val,
-                    // We get Ascending order by using a decreasing mapping over u64 as the sorting_field.
+                    // We get Ascending order by using a decreasing mapping over u64 as the
+                    // sorting_field.
                     SortOrder::Asc => u64::MAX - field_val,
                 }
             }
@@ -402,11 +391,12 @@ pub fn make_merge_collector(search_request: &SearchRequest) -> QuickwitCollector
 
 #[cfg(test)]
 mod tests {
-    use crate::collector::top_k_partial_hits;
+    use std::cmp::Ordering;
+
     use quickwit_proto::PartialHit;
 
     use super::PartialHitHeapItem;
-    use std::cmp::Ordering;
+    use crate::collector::top_k_partial_hits;
 
     #[test]
     fn test_partial_hit_ordered_by_sorting_field() {

--- a/quickwit-search/src/error.rs
+++ b/quickwit-search/src/error.rs
@@ -1,31 +1,29 @@
-/*
- * Copyright (C) 2021 Quickwit Inc.
- *
- * Quickwit is offered under the AGPL v3.0 and as commercial software.
- * For commercial licensing, contact us at hello@quickwit.io.
- *
- * AGPL:
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
-use serde::{Deserialize, Serialize};
-use tantivy::TantivyError;
-use thiserror::Error;
-use tokio::task::JoinError;
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use quickwit_index_config::QueryParserError;
 use quickwit_metastore::MetastoreError;
 use quickwit_storage::StorageResolverError;
+use serde::{Deserialize, Serialize};
+use tantivy::TantivyError;
+use thiserror::Error;
+use tokio::task::JoinError;
 
 /// Possible SearchError
 #[allow(missing_docs)]

--- a/quickwit-search/src/fetch_docs.rs
+++ b/quickwit-search/src/fetch_docs.rs
@@ -1,35 +1,30 @@
-// Quickwit
-//  Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
 //
-//  Quickwit is offered under the AGPL v3.0 and as commercial software.
-//  For commercial licensing, contact us at hello@quickwit.io.
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
 //
-//  AGPL:
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU Affero General Public License as
-//  published by the Free Software Foundation, either version 3 of the
-//  License, or (at your option) any later version.
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
 //
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU Affero General Public License for more details.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
 //
-//  You should have received a copy of the GNU Affero General Public License
-//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::collections::HashMap;
 use std::sync::Arc;
 
 use anyhow::Context;
 use itertools::Itertools;
-use quickwit_proto::FetchDocsResult;
-use quickwit_proto::Hit;
-use quickwit_proto::PartialHit;
-use quickwit_proto::SplitIdAndFooterOffsets;
+use quickwit_proto::{FetchDocsResult, Hit, PartialHit, SplitIdAndFooterOffsets};
 use quickwit_storage::Storage;
-use tantivy::IndexReader;
-use tantivy::ReloadPolicy;
+use tantivy::{IndexReader, ReloadPolicy};
 
 use crate::leaf::open_index;
 use crate::GlobalDocAddress;

--- a/quickwit-search/src/filters.rs
+++ b/quickwit-search/src/filters.rs
@@ -1,29 +1,27 @@
-// Quickwit
-//  Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
 //
-//  Quickwit is offered under the AGPL v3.0 and as commercial software.
-//  For commercial licensing, contact us at hello@quickwit.io.
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
 //
-//  AGPL:
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU Affero General Public License as
-//  published by the Free Software Foundation, either version 3 of the
-//  License, or (at your option) any later version.
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
 //
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU Affero General Public License for more details.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
 //
-//  You should have received a copy of the GNU Affero General Public License
-//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::ops::{Bound, RangeBounds};
 
 use tantivy::fastfield::{DynamicFastFieldReader, FastFieldReader};
-use tantivy::schema::Type;
-use tantivy::DocId;
-use tantivy::{schema::Field, SegmentReader, TantivyError};
+use tantivy::schema::{Field, Type};
+use tantivy::{DocId, SegmentReader, TantivyError};
 
 /// A filter that only retains docs within a time range.
 #[derive(Clone)]

--- a/quickwit-search/src/leaf.rs
+++ b/quickwit-search/src/leaf.rs
@@ -1,25 +1,27 @@
-//  Quickwit
-//  Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
 //
-//  Quickwit is offered under the AGPL v3.0 and as commercial software.
-//  For commercial licensing, contact us at hello@quickwit.io.
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
 //
-//  AGPL:
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU Affero General Public License as
-//  published by the Free Software Foundation, either version 3 of the
-//  License, or (at your option) any later version.
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
 //
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU Affero General Public License for more details.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
 //
-//  You should have received a copy of the GNU Affero General Public License
-//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use crate::collector::{make_collector_for_split, make_merge_collector, GenericQuickwitCollector};
-use crate::SearchError;
+use std::collections::{BTreeMap, HashSet};
+use std::convert::TryInto;
+use std::path::PathBuf;
+use std::sync::Arc;
+
 use anyhow::Context;
 use bytes::Bytes;
 use futures::future::try_join_all;
@@ -29,13 +31,13 @@ use quickwit_directories::{CachingDirectory, HotDirectory, StorageDirectory};
 use quickwit_index_config::IndexConfig;
 use quickwit_proto::{LeafSearchResult, SearchRequest, SplitIdAndFooterOffsets, SplitSearchError};
 use quickwit_storage::{BundleStorage, MemorySizedCache, Storage};
-use std::collections::{BTreeMap, HashSet};
-use std::convert::TryInto;
-use std::path::PathBuf;
-
-use std::sync::Arc;
-use tantivy::{collector::Collector, query::Query, Index, ReloadPolicy, Searcher, Term};
+use tantivy::collector::Collector;
+use tantivy::query::Query;
+use tantivy::{Index, ReloadPolicy, Searcher, Term};
 use tokio::task::spawn_blocking;
+
+use crate::collector::{make_collector_for_split, make_merge_collector, GenericQuickwitCollector};
+use crate::SearchError;
 
 fn global_split_footer_cache() -> &'static MemorySizedCache<String> {
     static INSTANCE: OnceCell<MemorySizedCache<String>> = OnceCell::new();

--- a/quickwit-search/src/lib.rs
+++ b/quickwit-search/src/lib.rs
@@ -1,23 +1,21 @@
-/*
- * Copyright (C) 2021 Quickwit Inc.
- *
- * Quickwit is offered under the AGPL v3.0 and as commercial software.
- * For commercial licensing, contact us at hello@quickwit.io.
- *
- * AGPL:
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 //! This projects implements quickwit's search API.
 #![warn(missing_docs)]
@@ -36,7 +34,6 @@ mod search_result_json;
 mod search_stream;
 mod service;
 
-///
 /// Refer to this as `crate::Result<T>`.
 pub type Result<T> = std::result::Result<T, SearchError>;
 
@@ -45,16 +42,12 @@ use std::net::SocketAddr;
 use std::ops::Range;
 
 use anyhow::Context;
+use quickwit_metastore::{Metastore, MetastoreResult, SplitMetadataAndFooterOffsets, SplitState};
+use quickwit_proto::{PartialHit, SearchRequest, SearchResult, SplitIdAndFooterOffsets};
+use quickwit_storage::StorageUriResolver;
 use tantivy::DocAddress;
 
-use quickwit_metastore::SplitState;
-use quickwit_metastore::{Metastore, MetastoreResult, SplitMetadataAndFooterOffsets};
-use quickwit_proto::{PartialHit, SearchResult};
-use quickwit_proto::{SearchRequest, SplitIdAndFooterOffsets};
-use quickwit_storage::StorageUriResolver;
-
-pub use crate::client::create_search_service_client;
-pub use crate::client::SearchServiceClient;
+pub use crate::client::{create_search_service_client, SearchServiceClient};
 pub use crate::client_pool::search_client_pool::SearchClientPool;
 pub use crate::client_pool::ClientPool;
 pub use crate::error::SearchError;
@@ -63,8 +56,7 @@ use crate::leaf::leaf_search;
 pub use crate::root::root_search;
 pub use crate::search_result_json::SearchResultJson;
 pub use crate::search_stream::root_search_stream;
-pub use crate::service::MockSearchService;
-pub use crate::service::{SearchService, SearchServiceImpl};
+pub use crate::service::{MockSearchService, SearchService, SearchServiceImpl};
 
 /// Compute the SWIM port from the HTTP port.
 /// Add 1 to the HTTP port to get the SWIM port.
@@ -203,9 +195,9 @@ mod tests {
     use assert_json_diff::assert_json_include;
     use quickwit_index_config::{DefaultIndexConfigBuilder, WikipediaIndexConfig};
     use quickwit_indexing::TestSandbox;
+    use serde_json::json;
 
     use super::*;
-    use serde_json::json;
 
     #[tokio::test]
     async fn test_single_node_simple() -> anyhow::Result<()> {
@@ -245,9 +237,7 @@ mod tests {
 
     // TODO remove me once `Iterator::is_sorted_by_key` is stabilized.
     fn is_sorted<E, I: Iterator<Item = E>>(mut it: I) -> bool
-    where
-        E: Ord,
-    {
+    where E: Ord {
         let mut previous_el = if let Some(first_el) = it.next() {
             first_el
         } else {

--- a/quickwit-search/src/rendezvous_hasher.rs
+++ b/quickwit-search/src/rendezvous_hasher.rs
@@ -1,23 +1,21 @@
-/*
- * Copyright (C) 2021 Quickwit Inc.
- *
- * Quickwit is offered under the AGPL v3.0 and as commercial software.
- * For commercial licensing, contact us at hello@quickwit.io.
- *
- * AGPL:
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
@@ -64,8 +62,7 @@ pub fn sort_by_rendez_vous_hash(nodes: &mut [Node], key: &str) {
 
 #[cfg(test)]
 mod tests {
-    use std::net::IpAddr;
-    use std::net::Ipv4Addr;
+    use std::net::{IpAddr, Ipv4Addr};
 
     use super::*;
 

--- a/quickwit-search/src/search_result_json.rs
+++ b/quickwit-search/src/search_result_json.rs
@@ -1,22 +1,21 @@
-// Quickwit
-//  Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
 //
-//  Quickwit is offered under the AGPL v3.0 and as commercial software.
-//  For commercial licensing, contact us at hello@quickwit.io.
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
 //
-//  AGPL:
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU Affero General Public License as
-//  published by the Free Software Foundation, either version 3 of the
-//  License, or (at your option) any later version.
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
 //
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU Affero General Public License for more details.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
 //
-//  You should have received a copy of the GNU Affero General Public License
-//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use serde::Serialize;
 use tracing::error;

--- a/quickwit-search/src/search_stream/collector.rs
+++ b/quickwit-search/src/search_stream/collector.rs
@@ -1,36 +1,32 @@
-// Quickwit
-//  Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
 //
-//  Quickwit is offered under the AGPL v3.0 and as commercial software.
-//  For commercial licensing, contact us at hello@quickwit.io.
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
 //
-//  AGPL:
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU Affero General Public License as
-//  published by the Free Software Foundation, either version 3 of the
-//  License, or (at your option) any later version.
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
 //
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU Affero General Public License for more details.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
 //
-//  You should have received a copy of the GNU Affero General Public License
-//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::collections::HashSet;
 use std::marker::PhantomData;
 
+use tantivy::collector::{Collector, SegmentCollector};
+use tantivy::fastfield::{DynamicFastFieldReader, FastFieldReader, FastValue};
+use tantivy::schema::{Field, Type};
+use tantivy::{DocId, Score, SegmentOrdinal, SegmentReader, TantivyError};
+
 use crate::filters::TimestampFilter;
 use crate::SearchError;
-use tantivy::fastfield::FastFieldReader;
-use tantivy::schema::Type;
-use tantivy::{
-    collector::{Collector, SegmentCollector},
-    fastfield::{DynamicFastFieldReader, FastValue},
-    schema::Field,
-    DocId, Score, SegmentOrdinal, SegmentReader, TantivyError,
-};
 
 #[derive(Clone)]
 pub struct FastFieldSegmentCollector<Item: FastValue> {

--- a/quickwit-search/src/search_stream/leaf.rs
+++ b/quickwit-search/src/search_stream/leaf.rs
@@ -1,44 +1,41 @@
-// Quickwit
-//  Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
 //
-//  Quickwit is offered under the AGPL v3.0 and as commercial software.
-//  For commercial licensing, contact us at hello@quickwit.io.
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
 //
-//  AGPL:
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU Affero General Public License as
-//  published by the Free Software Foundation, either version 3 of the
-//  License, or (at your option) any later version.
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
 //
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU Affero General Public License for more details.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
 //
-//  You should have received a copy of the GNU Affero General Public License
-//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use super::FastFieldCollectorBuilder;
-use crate::leaf::open_index;
-use crate::leaf::warmup;
-use crate::SearchError;
+use std::sync::Arc;
+
 use futures::{FutureExt, StreamExt};
 use quickwit_index_config::IndexConfig;
-use quickwit_proto::LeafSearchStreamResult;
-use quickwit_proto::OutputFormat;
-use quickwit_proto::SearchRequest;
-use quickwit_proto::SearchStreamRequest;
-use quickwit_proto::SplitIdAndFooterOffsets;
+use quickwit_proto::{
+    LeafSearchStreamResult, OutputFormat, SearchRequest, SearchStreamRequest,
+    SplitIdAndFooterOffsets,
+};
 use quickwit_storage::Storage;
-use std::sync::Arc;
 use tantivy::query::Query;
 use tantivy::schema::Type;
-use tantivy::LeasedItem;
-use tantivy::ReloadPolicy;
-use tantivy::Searcher;
+use tantivy::{LeasedItem, ReloadPolicy, Searcher};
 use tokio::task::spawn_blocking;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tracing::error;
+
+use super::FastFieldCollectorBuilder;
+use crate::leaf::{open_index, warmup};
+use crate::SearchError;
 
 // TODO: buffer of 5 seems to be sufficient to do the job locally, needs to be tested on a cluster.
 const CONCURRENT_SPLIT_SEARCH_STREAM: usize = 5;
@@ -197,13 +194,14 @@ fn collect_fast_field_values(
 
 #[cfg(test)]
 mod tests {
-    use std::{str::from_utf8, sync::Arc};
+    use std::str::from_utf8;
+    use std::sync::Arc;
 
     use quickwit_index_config::DefaultIndexConfigBuilder;
     use quickwit_indexing::TestSandbox;
+    use serde_json::json;
 
     use super::*;
-    use serde_json::json;
 
     #[tokio::test]
     async fn test_leaf_search_stream_to_csv_output_with_filtering() -> anyhow::Result<()> {

--- a/quickwit-search/src/search_stream/mod.rs
+++ b/quickwit-search/src/search_stream/mod.rs
@@ -1,35 +1,34 @@
-// Quickwit
-//  Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
 //
-//  Quickwit is offered under the AGPL v3.0 and as commercial software.
-//  For commercial licensing, contact us at hello@quickwit.io.
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
 //
-//  AGPL:
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU Affero General Public License as
-//  published by the Free Software Foundation, either version 3 of the
-//  License, or (at your option) any later version.
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
 //
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU Affero General Public License for more details.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
 //
-//  You should have received a copy of the GNU Affero General Public License
-//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 mod collector;
 mod leaf;
 mod root;
 
+use std::fmt::Display;
+use std::io;
+use std::io::Write;
+
 pub use collector::{FastFieldCollector, FastFieldCollectorBuilder};
 pub use leaf::leaf_search_stream;
 use quickwit_proto::OutputFormat;
 pub use root::root_search_stream;
-
-use std::fmt::Display;
-use std::io;
-use std::io::Write;
 use tantivy::fastfield::FastValue;
 
 /// Serialize the values into the `buffer` as bytes.

--- a/quickwit-search/src/search_stream/root.rs
+++ b/quickwit-search/src/search_stream/root.rs
@@ -1,47 +1,37 @@
-// Quickwit
-//  Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
 //
-//  Quickwit is offered under the AGPL v3.0 and as commercial software.
-//  For commercial licensing, contact us at hello@quickwit.io.
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
 //
-//  AGPL:
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU Affero General Public License as
-//  published by the Free Software Foundation, either version 3 of the
-//  License, or (at your option) any later version.
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
 //
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU Affero General Public License for more details.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
 //
-//  You should have received a copy of the GNU Affero General Public License
-//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use std::collections::HashMap;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use bytes::Bytes;
 use futures::StreamExt;
-use itertools::Either;
-use itertools::Itertools;
-use quickwit_metastore::SplitMetadataAndFooterOffsets;
-use quickwit_proto::LeafSearchStreamRequest;
-use quickwit_proto::SearchStreamRequest;
-use quickwit_proto::SplitIdAndFooterOffsets;
+use itertools::{Either, Itertools};
+use quickwit_metastore::{Metastore, SplitMetadataAndFooterOffsets};
+use quickwit_proto::{
+    LeafSearchStreamRequest, SearchRequest, SearchStreamRequest, SplitIdAndFooterOffsets,
+};
 use tracing::*;
 
-use quickwit_metastore::Metastore;
-use quickwit_proto::SearchRequest;
-
 use crate::client_pool::Job;
-use crate::list_relevant_splits;
-use crate::root::job_for_splits;
-use crate::root::NodeSearchError;
-use crate::ClientPool;
-use crate::SearchClientPool;
-use crate::SearchError;
+use crate::root::{job_for_splits, NodeSearchError};
+use crate::{list_relevant_splits, ClientPool, SearchClientPool, SearchError};
 
 /// Perform a distributed search stream.
 pub async fn root_search_stream(
@@ -138,16 +128,17 @@ pub async fn root_search_stream(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     use std::ops::Range;
 
-    use crate::MockSearchService;
     use quickwit_index_config::WikipediaIndexConfig;
     use quickwit_indexing::mock_split_meta;
-    use quickwit_metastore::{checkpoint::Checkpoint, IndexMetadata, MockMetastore, SplitState};
+    use quickwit_metastore::checkpoint::Checkpoint;
+    use quickwit_metastore::{IndexMetadata, MockMetastore, SplitState};
     use quickwit_proto::OutputFormat;
     use tokio_stream::wrappers::UnboundedReceiverStream;
+
+    use super::*;
+    use crate::MockSearchService;
 
     #[tokio::test]
     async fn test_root_search_stream_single_split() -> anyhow::Result<()> {
@@ -248,7 +239,11 @@ mod tests {
             Arc::new(SearchClientPool::from_mocks(vec![Arc::new(mock_search_service)]).await?);
         let result = root_search_stream(&request, &metastore, &client_pool).await;
         assert_eq!(result.is_err(), true);
-        assert_eq!(result.unwrap_err().to_string(), "Internal error: `[NodeSearchError { search_error: InternalError(\"error\"), split_ids: [\"split1\"] }]`.");
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Internal error: `[NodeSearchError { search_error: InternalError(\"error\"), \
+             split_ids: [\"split1\"] }]`."
+        );
         Ok(())
     }
 }

--- a/quickwit-search/src/service.rs
+++ b/quickwit-search/src/service.rs
@@ -1,44 +1,39 @@
-/*
- * Copyright (C) 2021 Quickwit Inc.
- *
- * Quickwit is offered under the AGPL v3.0 and as commercial software.
- * For commercial licensing, contact us at hello@quickwit.io.
- *
- * AGPL:
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use bytes::Bytes;
 use quickwit_index_config::IndexConfig;
 use quickwit_metastore::Metastore;
 use quickwit_proto::{
-    FetchDocsRequest, FetchDocsResult, LeafSearchRequest, LeafSearchResult, SearchRequest,
-    SearchResult,
+    FetchDocsRequest, FetchDocsResult, LeafSearchRequest, LeafSearchResult,
+    LeafSearchStreamRequest, LeafSearchStreamResult, SearchRequest, SearchResult,
+    SearchStreamRequest,
 };
-use quickwit_proto::{LeafSearchStreamRequest, LeafSearchStreamResult, SearchStreamRequest};
 use quickwit_storage::StorageUriResolver;
-use std::sync::Arc;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tracing::info;
 
-use crate::fetch_docs;
-use crate::leaf_search;
-use crate::root_search;
 use crate::search_stream::{leaf_search_stream, root_search_stream};
-use crate::SearchClientPool;
-use crate::SearchError;
+use crate::{fetch_docs, leaf_search, root_search, SearchClientPool, SearchError};
 
 #[derive(Clone)]
 /// The search service implementation.

--- a/quickwit-serve/src/args.rs
+++ b/quickwit-serve/src/args.rs
@@ -1,23 +1,21 @@
-/*
- * Copyright (C) 2021 Quickwit Inc.
- *
- * Quickwit is offered under the AGPL v3.0 and as commercial software.
- * For commercial licensing, contact us at hello@quickwit.io.
- *
- * AGPL:
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::net::SocketAddr;
 use std::path::PathBuf;

--- a/quickwit-serve/src/error.rs
+++ b/quickwit-serve/src/error.rs
@@ -1,31 +1,28 @@
-/*
- * Copyright (C) 2021 Quickwit Inc.
- *
- * Quickwit is offered under the AGPL v3.0 and as commercial software.
- * For commercial licensing, contact us at hello@quickwit.io.
- *
- * AGPL:
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+use quickwit_cluster::error::ClusterError;
+use quickwit_search::SearchError;
 use serde::ser::SerializeMap;
 use thiserror::Error;
 use warp::http;
 use warp::hyper::StatusCode;
-
-use quickwit_cluster::error::ClusterError;
-use quickwit_search::SearchError;
 
 #[derive(Debug, Error)]
 pub enum ApiError {
@@ -67,9 +64,7 @@ impl ApiError {
 // TODO implement nicer serialization of errors.
 impl serde::Serialize for ApiError {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
+    where S: serde::Serializer {
         let mut map = serializer.serialize_map(Some(2))?;
         map.serialize_key("error")?;
         map.serialize_value(&self.message())?;

--- a/quickwit-serve/src/grpc.rs
+++ b/quickwit-serve/src/grpc.rs
@@ -1,31 +1,28 @@
-/*
- * Copyright (C) 2021 Quickwit Inc.
- *
- * Quickwit is offered under the AGPL v3.0 and as commercial software.
- * For commercial licensing, contact us at hello@quickwit.io.
- *
- * AGPL:
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::net::SocketAddr;
 
-use tonic::transport::Server;
-use tracing::*;
-
 use quickwit_proto::cluster_service_server::ClusterServiceServer;
 use quickwit_proto::search_service_server::SearchServiceServer;
+use tonic::transport::Server;
+use tracing::*;
 
 use crate::grpc_adapter::cluster_adapter::GrpcClusterAdapter;
 use crate::grpc_adapter::search_adapter::GrpcSearchAdapter;

--- a/quickwit-serve/src/grpc_adapter.rs
+++ b/quickwit-serve/src/grpc_adapter.rs
@@ -1,23 +1,21 @@
-/*
- * Copyright (C) 2021 Quickwit Inc.
- *
- * Quickwit is offered under the AGPL v3.0 and as commercial software.
- * For commercial licensing, contact us at hello@quickwit.io.
- *
- * AGPL:
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 pub mod cluster_adapter;
 pub mod search_adapter;

--- a/quickwit-serve/src/grpc_adapter/cluster_adapter.rs
+++ b/quickwit-serve/src/grpc_adapter/cluster_adapter.rs
@@ -1,28 +1,25 @@
-/*
- * Copyright (C) 2021 Quickwit Inc.
- *
- * Quickwit is offered under the AGPL v3.0 and as commercial software.
- * For commercial licensing, contact us at hello@quickwit.io.
- *
- * AGPL:
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::sync::Arc;
 
 use async_trait::async_trait;
-
 use quickwit_cluster::error::ClusterError;
 use quickwit_cluster::service::{ClusterService, ClusterServiceImpl};
 use quickwit_proto::cluster_service_server as grpc;

--- a/quickwit-serve/src/grpc_adapter/search_adapter.rs
+++ b/quickwit-serve/src/grpc_adapter/search_adapter.rs
@@ -1,29 +1,26 @@
-/*
- * Copyright (C) 2021 Quickwit Inc.
- *
- * Quickwit is offered under the AGPL v3.0 and as commercial software.
- * For commercial licensing, contact us at hello@quickwit.io.
- *
- * AGPL:
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::sync::Arc;
 
 use async_trait::async_trait;
 use futures::TryStreamExt;
-
 use quickwit_proto::{
     search_service_server as grpc, LeafSearchStreamRequest, LeafSearchStreamResult,
 };

--- a/quickwit-serve/src/http_handler.rs
+++ b/quickwit-serve/src/http_handler.rs
@@ -1,23 +1,21 @@
-/*
- * Copyright (C) 2021 Quickwit Inc.
- *
- * Quickwit is offered under the AGPL v3.0 and as commercial software.
- * For commercial licensing, contact us at hello@quickwit.io.
- *
- * AGPL:
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 pub mod cluster;
 pub mod health_check;

--- a/quickwit-serve/src/http_handler/cluster.rs
+++ b/quickwit-serve/src/http_handler/cluster.rs
@@ -1,32 +1,28 @@
-/*
- * Copyright (C) 2021 Quickwit Inc.
- *
- * Quickwit is offered under the AGPL v3.0 and as commercial software.
- * For commercial licensing, contact us at hello@quickwit.io.
- *
- * AGPL:
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::convert::Infallible;
 use std::sync::Arc;
 
-use serde::Deserialize;
-use warp::Filter;
-use warp::Rejection;
-
 use quickwit_cluster::service::ClusterService;
+use serde::Deserialize;
+use warp::{Filter, Rejection};
 
 use crate::rest::Format;
 use crate::ApiError;

--- a/quickwit-serve/src/http_handler/health_check.rs
+++ b/quickwit-serve/src/http_handler/health_check.rs
@@ -1,23 +1,21 @@
-/*
- * Copyright (C) 2021 Quickwit Inc.
- *
- * Quickwit is offered under the AGPL v3.0 and as commercial software.
- * For commercial licensing, contact us at hello@quickwit.io.
- *
- * AGPL:
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::fmt;
 

--- a/quickwit-serve/src/lib.rs
+++ b/quickwit-serve/src/lib.rs
@@ -1,23 +1,21 @@
-/*
- * Copyright (C) 2021 Quickwit Inc.
- *
- * Quickwit is offered under the AGPL v3.0 and as commercial software.
- * For commercial licensing, contact us at hello@quickwit.io.
- *
- * AGPL:
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 mod args;
 mod error;
@@ -27,14 +25,11 @@ mod http_handler;
 mod quickwit_cache;
 mod rest;
 
-use quickwit_cache::QuickwitCache;
 use std::io::Write;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
-use termcolor::{self, Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
-use tracing::debug;
-
+use quickwit_cache::QuickwitCache;
 use quickwit_cluster::cluster::{read_host_key, Cluster};
 use quickwit_cluster::service::ClusterServiceImpl;
 use quickwit_metastore::MetastoreUriResolver;
@@ -46,13 +41,14 @@ use quickwit_storage::{
     StorageWithCacheFactory,
 };
 use quickwit_telemetry::payload::{ServeEvent, TelemetryEvent};
+use termcolor::{self, Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
+use tracing::debug;
 
 pub use crate::args::ServeArgs;
 pub use crate::error::ApiError;
 use crate::grpc::start_grpc_service;
 use crate::grpc_adapter::cluster_adapter::GrpcClusterAdapter;
 use crate::grpc_adapter::search_adapter::GrpcSearchAdapter;
-
 use crate::rest::start_rest_service;
 
 fn display_help_message(
@@ -153,12 +149,17 @@ pub async fn serve_cli(args: ServeArgs) -> anyhow::Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use std::{array::IntoIter, collections::HashMap, ops::Range, sync::Arc};
+    use std::array::IntoIter;
+    use std::collections::HashMap;
+    use std::ops::Range;
+    use std::sync::Arc;
 
     use quickwit_index_config::WikipediaIndexConfig;
     use quickwit_indexing::mock_split_meta;
-    use quickwit_metastore::{checkpoint::Checkpoint, IndexMetadata, MockMetastore, SplitState};
-    use quickwit_proto::{search_service_server::SearchServiceServer, OutputFormat};
+    use quickwit_metastore::checkpoint::Checkpoint;
+    use quickwit_metastore::{IndexMetadata, MockMetastore, SplitState};
+    use quickwit_proto::search_service_server::SearchServiceServer;
+    use quickwit_proto::OutputFormat;
     use quickwit_search::{
         create_search_service_client, root_search_stream, MockSearchService, SearchError,
         SearchService,
@@ -237,7 +238,11 @@ mod tests {
         });
         let search_result = root_search_stream(&request, &metastore, &client_pool).await;
         assert!(search_result.is_err());
-        assert_eq!(search_result.unwrap_err().to_string(), "Internal error: `[NodeSearchError { search_error: InternalError(\"error\"), split_ids: [\"split1\"] }]`.");
+        assert_eq!(
+            search_result.unwrap_err().to_string(),
+            "Internal error: `[NodeSearchError { search_error: InternalError(\"error\"), \
+             split_ids: [\"split1\"] }]`."
+        );
         Ok(())
     }
 }

--- a/quickwit-serve/src/quickwit_cache.rs
+++ b/quickwit-serve/src/quickwit_cache.rs
@@ -1,32 +1,30 @@
-// Quickwit
-//  Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
 //
-//  Quickwit is offered under the AGPL v3.0 and as commercial software.
-//  For commercial licensing, contact us at hello@quickwit.io.
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
 //
-//  AGPL:
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU Affero General Public License as
-//  published by the Free Software Foundation, either version 3 of the
-//  License, or (at your option) any later version.
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
 //
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU Affero General Public License for more details.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
 //
-//  You should have received a copy of the GNU Affero General Public License
-//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use std::ops::Range;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use bytes::Bytes;
 use quickwit_common::HOTCACHE_FILENAME;
-use quickwit_storage::Cache;
-use quickwit_storage::SliceCache;
-use std::ops::Range;
-use std::path::Path;
-use std::path::PathBuf;
-use std::sync::Arc;
+use quickwit_storage::{Cache, SliceCache};
 
 const FULL_SLICE: Range<usize> = 0..usize::MAX;
 
@@ -151,10 +149,10 @@ mod tests {
     use std::path::Path;
     use std::sync::Arc;
 
-    use super::QuickwitCache;
     use bytes::Bytes;
-    use quickwit_storage::Cache;
-    use quickwit_storage::MockCache;
+    use quickwit_storage::{Cache, MockCache};
+
+    use super::QuickwitCache;
 
     #[tokio::test]
     async fn test_quickwit_cache_get_all() {

--- a/quickwit-serve/src/rest.rs
+++ b/quickwit-serve/src/rest.rs
@@ -1,23 +1,21 @@
-/*
- * Copyright (C) 2021 Quickwit Inc.
- *
- * Quickwit is offered under the AGPL v3.0 and as commercial software.
- * For commercial licensing, contact us at hello@quickwit.io.
- *
- * AGPL:
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::convert::Infallible;
 use std::net::SocketAddr;
@@ -25,15 +23,14 @@ use std::sync::Arc;
 
 use bytes::Bytes;
 use futures::stream::{self, StreamExt};
+use quickwit_cluster::service::ClusterServiceImpl;
+use quickwit_proto::OutputFormat;
+use quickwit_search::{SearchResultJson, SearchService, SearchServiceImpl};
 use serde::{Deserialize, Deserializer};
 use tracing::*;
 use warp::hyper::header::CONTENT_TYPE;
 use warp::hyper::StatusCode;
 use warp::{reply, Filter, Rejection, Reply};
-
-use quickwit_cluster::service::ClusterServiceImpl;
-use quickwit_proto::OutputFormat;
-use quickwit_search::{SearchResultJson, SearchService, SearchServiceImpl};
 
 use crate::http_handler::cluster::cluster_handler;
 use crate::http_handler::health_check::liveness_check_handler;
@@ -309,9 +306,7 @@ async fn recover_fn(rejection: Rejection) -> Result<impl Reply, Rejection> {
 }
 
 fn from_simple_list<'de, D>(deserializer: D) -> Result<Option<Vec<String>>, D::Error>
-where
-    D: Deserializer<'de>,
-{
+where D: Deserializer<'de> {
     let str_sequence = String::deserialize(deserializer)?;
     Ok(Some(
         str_sequence
@@ -324,11 +319,12 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use assert_json_diff::assert_json_include;
     use mockall::predicate;
     use quickwit_search::{MockSearchService, SearchError};
     use serde_json::json;
+
+    use super::*;
 
     #[test]
     fn test_serialize_search_results() -> anyhow::Result<()> {
@@ -351,10 +347,13 @@ mod tests {
     async fn test_rest_search_api_route_simple() {
         let rest_search_api_filter = search_filter();
         let (index, req) = warp::test::request()
-        .path("/api/v1/quickwit-demo-index/search?query=*&endTimestamp=1450720000&maxHits=10&startOffset=22")
-        .filter(&rest_search_api_filter)
-        .await
-        .unwrap();
+            .path(
+                "/api/v1/quickwit-demo-index/search?query=*&endTimestamp=1450720000&maxHits=10&\
+                 startOffset=22",
+            )
+            .filter(&rest_search_api_filter)
+            .await
+            .unwrap();
         assert_eq!(&index, "quickwit-demo-index");
         assert_eq!(
             &req,
@@ -366,7 +365,7 @@ mod tests {
                 max_hits: 10,
                 start_offset: 22,
                 format: Format::default(),
-                tags: None,
+                tags: None
             }
         );
     }
@@ -375,7 +374,10 @@ mod tests {
     async fn test_rest_search_api_route_simple_default_num_hits_default_offset() {
         let rest_search_api_filter = search_filter();
         let (index, req) = warp::test::request()
-            .path("/api/v1/quickwit-demo-index/search?query=*&endTimestamp=1450720000&searchField=title,body")
+            .path(
+                "/api/v1/quickwit-demo-index/search?query=*&endTimestamp=1450720000&\
+                 searchField=title,body",
+            )
             .filter(&rest_search_api_filter)
             .await
             .unwrap();
@@ -390,7 +392,7 @@ mod tests {
                 max_hits: 20,
                 start_offset: 0,
                 format: Format::default(),
-                tags: None,
+                tags: None
             }
         );
     }
@@ -414,7 +416,7 @@ mod tests {
                 start_offset: 0,
                 format: Format::Json,
                 search_fields: None,
-                tags: None,
+                tags: None
             }
         );
     }
@@ -587,7 +589,7 @@ mod tests {
                 end_timestamp: None,
                 fast_field: "external_id".to_string(),
                 output_format: OutputFormat::Csv,
-                tags: None,
+                tags: None
             }
         );
     }
@@ -595,7 +597,10 @@ mod tests {
     #[tokio::test]
     async fn test_rest_search_stream_api_click_house_row_binary() {
         let (index, req) = warp::test::request()
-            .path("/api/v1/my-index/search/stream?query=obama&fastField=external_id&outputFormat=clickHouseRowBinary&tags=lang:english")
+            .path(
+                "/api/v1/my-index/search/stream?query=obama&fastField=external_id&\
+                 outputFormat=clickHouseRowBinary&tags=lang:english",
+            )
             .filter(&super::search_stream_filter())
             .await
             .unwrap();
@@ -609,7 +614,7 @@ mod tests {
                 end_timestamp: None,
                 fast_field: "external_id".to_string(),
                 output_format: OutputFormat::ClickHouseRowBinary,
-                tags: Some(vec!["lang:english".to_string()]),
+                tags: Some(vec!["lang:english".to_string()])
             }
         );
     }
@@ -617,11 +622,18 @@ mod tests {
     #[tokio::test]
     async fn test_rest_search_stream_api_error() {
         let rejection = warp::test::request()
-            .path("/api/v1/my-index/search/stream?query=obama&fastField=external_id&outputFormat=click_house_row_binary")
+            .path(
+                "/api/v1/my-index/search/stream?query=obama&fastField=external_id&\
+                 outputFormat=click_house_row_binary",
+            )
             .filter(&super::search_stream_filter())
             .await
             .unwrap_err();
         let parse_error = rejection.find::<serde_qs::Error>().unwrap();
-        assert_eq!(parse_error.to_string(), "failed with reason: unknown variant `click_house_row_binary`, expected `csv` or `clickHouseRowBinary`");
+        assert_eq!(
+            parse_error.to_string(),
+            "failed with reason: unknown variant `click_house_row_binary`, expected `csv` or \
+             `clickHouseRowBinary`"
+        );
     }
 }

--- a/quickwit-storage/src/bundle_storage.rs
+++ b/quickwit-storage/src/bundle_storage.rs
@@ -1,31 +1,22 @@
-/*
-    Quickwit
-    Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-    Quickwit is offered under the AGPL v3.0 and as commercial software.
-    For commercial licensing, contact us at hello@quickwit.io.
-
-    AGPL:
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation, either version 3 of the
-    License, or (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
-
-use crate::Storage;
-use crate::{StorageError, StorageResult};
-use async_trait::async_trait;
-use bytes::Bytes;
-use serde::Deserialize;
-use serde::Serialize;
 use std::collections::HashMap;
 use std::convert::TryInto;
 use std::fmt;
@@ -35,11 +26,17 @@ use std::io::{self, ErrorKind, Read, Write};
 use std::ops::Range;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use serde::{Deserialize, Serialize};
 use tantivy::common::CountingWriter;
 use tantivy::directory::FileSlice;
 use tantivy::HasLen;
 use thiserror::Error;
 use tracing::error;
+
+use crate::{Storage, StorageError, StorageResult};
 
 /// Filename used for the bundle.
 pub const BUNDLE_FILENAME: &str = "bundle";
@@ -55,7 +52,8 @@ pub struct BundleStorage {
 impl BundleStorage {
     /// Creates a new BundleStorage.
     ///
-    /// The provided data must include the footer_bytes at the end of the slice, but it can have more up front.
+    /// The provided data must include the footer_bytes at the end of the slice, but it can have
+    /// more up front.
     pub fn new(
         storage: Arc<dyn Storage>,
         bundle_filepath: PathBuf,
@@ -268,9 +266,8 @@ impl<W: io::Write> BundleStorageBuilder<W> {
 mod tests {
     use std::fs;
 
-    use crate::RamStorageBuilder;
-
     use super::*;
+    use crate::RamStorageBuilder;
 
     #[tokio::test]
     async fn bundle_storage_file_offsets() -> anyhow::Result<()> {

--- a/quickwit-storage/src/cache/in_ram_slice_cache.rs
+++ b/quickwit-storage/src/cache/in_ram_slice_cache.rs
@@ -1,22 +1,21 @@
-// Quickwit
-//  Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
 //
-//  Quickwit is offered under the AGPL v3.0 and as commercial software.
-//  For commercial licensing, contact us at hello@quickwit.io.
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
 //
-//  AGPL:
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU Affero General Public License as
-//  published by the Free Software Foundation, either version 3 of the
-//  License, or (at your option) any later version.
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
 //
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU Affero General Public License for more details.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
 //
-//  You should have received a copy of the GNU Affero General Public License
-//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::hash::Hash;
 use std::ops::Range;

--- a/quickwit-storage/src/cache/memory_sized_cache.rs
+++ b/quickwit-storage/src/cache/memory_sized_cache.rs
@@ -1,22 +1,21 @@
-// Quickwit
-//  Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
 //
-//  Quickwit is offered under the AGPL v3.0 and as commercial software.
-//  For commercial licensing, contact us at hello@quickwit.io.
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
 //
-//  AGPL:
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU Affero General Public License as
-//  published by the Free Software Foundation, either version 3 of the
-//  License, or (at your option) any later version.
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
 //
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU Affero General Public License for more details.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
 //
-//  You should have received a copy of the GNU Affero General Public License
-//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::borrow::Borrow;
 use std::hash::Hash;
@@ -25,6 +24,7 @@ use std::sync::Mutex;
 use bytes::Bytes;
 use lru::{KeyRef, LruCache};
 use tracing::{error, warn};
+
 #[derive(Clone, Copy, Debug)]
 enum Capacity {
     Unlimited,
@@ -86,7 +86,11 @@ impl<K: Hash + Eq> NeedMutMemorySizedCache<K> {
             if let Some((_, bytes)) = self.lru_cache.pop_lru() {
                 self.num_bytes -= bytes.len();
             } else {
-                error!("Logical error. Even after removing all of the items in the cache the capacity is insufficient. This case is guarded against and should never happen.");
+                error!(
+                    "Logical error. Even after removing all of the items in the cache the \
+                     capacity is insufficient. This case is guarded against and should never \
+                     happen."
+                );
                 return;
             }
         }

--- a/quickwit-storage/src/cache/mod.rs
+++ b/quickwit-storage/src/cache/mod.rs
@@ -1,34 +1,35 @@
-// Quickwit
-//  Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
 //
-//  Quickwit is offered under the AGPL v3.0 and as commercial software.
-//  For commercial licensing, contact us at hello@quickwit.io.
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
 //
-//  AGPL:
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU Affero General Public License as
-//  published by the Free Software Foundation, either version 3 of the
-//  License, or (at your option) any later version.
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
 //
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU Affero General Public License for more details.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
 //
-//  You should have received a copy of the GNU Affero General Public License
-//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 mod in_ram_slice_cache;
 mod memory_sized_cache;
 mod storage_with_cache;
 
+use std::ops::Range;
+use std::path::{Path, PathBuf};
+
+use async_trait::async_trait;
+use bytes::Bytes;
+
 pub use self::in_ram_slice_cache::SliceCache;
 pub use self::memory_sized_cache::MemorySizedCache;
 pub use self::storage_with_cache::StorageWithCacheFactory;
-use async_trait::async_trait;
-use bytes::Bytes;
-use std::ops::Range;
-use std::path::{Path, PathBuf};
 
 /// The `Cache` trait is the abstraction used to describe the caching logic
 /// used in front of a storage. See `StorageWithCache`.

--- a/quickwit-storage/src/cache/storage_with_cache.rs
+++ b/quickwit-storage/src/cache/storage_with_cache.rs
@@ -1,31 +1,30 @@
-//  Quickwit
-//  Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
 //
-//  Quickwit is offered under the AGPL v3.0 and as commercial software.
-//  For commercial licensing, contact us at hello@quickwit.io.
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
 //
-//  AGPL:
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU Affero General Public License as
-//  published by the Free Software Foundation, either version 3 of the
-//  License, or (at your option) any later version.
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
 //
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU Affero General Public License for more details.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
 //
-//  You should have received a copy of the GNU Affero General Public License
-//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use async_trait::async_trait;
-use bytes::Bytes;
 use std::ops::Range;
 use std::path::Path;
 use std::sync::Arc;
 
-use crate::Cache;
-use crate::{PutPayload, Storage, StorageFactory, StorageResult};
+use async_trait::async_trait;
+use bytes::Bytes;
+
+use crate::{Cache, PutPayload, Storage, StorageFactory, StorageResult};
 
 /// Use with care, StorageWithCache is read-only.
 struct StorageWithCache {
@@ -121,8 +120,7 @@ mod tests {
     use std::sync::Mutex;
 
     use super::*;
-    use crate::MockCache;
-    use crate::MockStorage;
+    use crate::{MockCache, MockStorage};
 
     #[tokio::test]
     async fn put_in_cache_test() {

--- a/quickwit-storage/src/error.rs
+++ b/quickwit-storage/src/error.rs
@@ -1,28 +1,25 @@
-/*
-    Quickwit
-    Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-    Quickwit is offered under the AGPL v3.0 and as commercial software.
-    For commercial licensing, contact us at hello@quickwit.io.
-
-    AGPL:
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation, either version 3 of the
-    License, or (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
+use std::{fmt, io};
 
 use serde::{Deserialize, Serialize};
-use std::fmt;
-use std::io;
 use thiserror::Error;
 
 /// Storage error kind.
@@ -65,9 +62,7 @@ pub enum StorageResolverError {
 impl StorageErrorKind {
     /// Creates a StorageError.
     pub fn with_error<E>(self, source: E) -> StorageError
-    where
-        anyhow::Error: From<E>,
-    {
+    where anyhow::Error: From<E> {
         StorageError {
             kind: self,
             source: From::from(source),
@@ -101,9 +96,7 @@ pub type StorageResult<T> = Result<T, StorageError>;
 impl StorageError {
     /// Add some context to the wrapper error.
     pub fn add_context<C>(self, ctx: C) -> Self
-    where
-        C: fmt::Display + Send + Sync + 'static,
-    {
+    where C: fmt::Display + Send + Sync + 'static {
         StorageError {
             kind: self.kind,
             source: self.source.context(ctx),

--- a/quickwit-storage/src/lib.rs
+++ b/quickwit-storage/src/lib.rs
@@ -1,37 +1,33 @@
-/*
-    Quickwit
-    Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-    Quickwit is offered under the AGPL v3.0 and as commercial software.
-    For commercial licensing, contact us at hello@quickwit.io.
-
-    AGPL:
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation, either version 3 of the
-    License, or (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
 #![warn(missing_docs)]
 #![allow(clippy::bool_assert_comparison)]
 
-/*! `quickwit-storage` is the abstraction used in quickwit to interface itself
-to different storage:
-- object storages (S3)
-- local filesystem
-- distributed filesystems.
-etc.
-
-- The `BundleStorage` bundles together multiple files into a single file.
-
-*/
+//! `quickwit-storage` is the abstraction used in quickwit to interface itself
+//! to different storage:
+//! - object storages (S3)
+//! - local filesystem
+//! - distributed filesystems.
+//! etc.
+//!
+//! - The `BundleStorage` bundles together multiple files into a single file.
 mod cache;
 mod storage;
 pub use self::storage::{PutPayload, Storage};
@@ -48,37 +44,34 @@ mod storage_resolver;
 pub use self::bundle_storage::{
     BundleStorage, BundleStorageBuilder, BundleStorageFileOffsets, BUNDLE_FILENAME,
 };
+#[cfg(any(test, feature = "testsuite"))]
+pub use self::cache::MockCache;
 pub use self::local_file_storage::{LocalFileStorage, LocalFileStorageFactory};
 pub use self::object_storage::{
     MultiPartPolicy, RegionProvider, S3CompatibleObjectStorage, S3CompatibleObjectStorageFactory,
 };
 pub use self::prefix_storage::add_prefix_to_storage;
 pub use self::ram_storage::{RamStorage, RamStorageBuilder};
-pub use self::storage_resolver::{
-    quickwit_storage_uri_resolver, StorageFactory, StorageUriResolver,
-};
-pub use crate::cache::{Cache, MemorySizedCache, SliceCache, StorageWithCacheFactory};
-pub use crate::error::{StorageError, StorageErrorKind, StorageResolverError, StorageResult};
-
-#[cfg(any(test, feature = "testsuite"))]
-pub use self::cache::MockCache;
 #[cfg(any(test, feature = "testsuite"))]
 pub use self::storage::MockStorage;
 #[cfg(any(test, feature = "testsuite"))]
 pub use self::storage_resolver::MockStorageFactory;
-
+pub use self::storage_resolver::{
+    quickwit_storage_uri_resolver, StorageFactory, StorageUriResolver,
+};
 #[cfg(feature = "testsuite")]
 pub use self::tests::storage_test_suite;
+pub use crate::cache::{Cache, MemorySizedCache, SliceCache, StorageWithCacheFactory};
+pub use crate::error::{StorageError, StorageErrorKind, StorageResolverError, StorageResult};
 
 #[cfg(any(test, feature = "testsuite"))]
 pub(crate) mod tests {
 
-    use anyhow::Context;
-
-    use crate::PutPayload;
     use std::path::Path;
 
-    use crate::{Storage, StorageErrorKind};
+    use anyhow::Context;
+
+    use crate::{PutPayload, Storage, StorageErrorKind};
 
     async fn test_get_inexistent_file(storage: &mut dyn Storage) -> anyhow::Result<()> {
         let err = storage

--- a/quickwit-storage/src/local_file_storage.rs
+++ b/quickwit-storage/src/local_file_storage.rs
@@ -1,37 +1,36 @@
-/*
-    Quickwit
-    Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-    Quickwit is offered under the AGPL v3.0 and as commercial software.
-    For commercial licensing, contact us at hello@quickwit.io.
-
-    AGPL:
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation, either version 3 of the
-    License, or (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
-
-use crate::{PutPayload, Storage, StorageErrorKind, StorageFactory, StorageResult};
-use async_trait::async_trait;
-use bytes::Bytes;
-use futures::future::{BoxFuture, FutureExt};
 use std::io::{ErrorKind, SeekFrom};
 use std::ops::Range;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::{fmt, io};
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use futures::future::{BoxFuture, FutureExt};
 use tokio::fs;
 use tokio::io::{AsyncReadExt, AsyncSeekExt};
 use tracing::warn;
+
+use crate::{PutPayload, Storage, StorageErrorKind, StorageFactory, StorageResult};
 
 /// File system compatible storage implementation.
 #[derive(Clone)]
@@ -237,7 +236,8 @@ mod tests {
     use tempfile::tempdir;
 
     use super::*;
-    use crate::{tests::storage_test_suite, StorageError};
+    use crate::tests::storage_test_suite;
+    use crate::StorageError;
 
     #[tokio::test]
     async fn test_storage() -> anyhow::Result<()> {

--- a/quickwit-storage/src/object_storage/error.rs
+++ b/quickwit-storage/src/object_storage/error.rs
@@ -1,28 +1,24 @@
-/*
-    Quickwit
-    Copyright (C) 2021 Quickwit Inc.
-
-    Quickwit is offered under the AGPL v3.0 and as commercial software.
-    For commercial licensing, contact us at hello@quickwit.io.
-
-    AGPL:
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation, either version 3 of the
-    License, or (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::error::Error as StdError;
-use std::fmt;
-use std::io;
+use std::{fmt, io};
 
 use rusoto_core::RusotoError;
 use rusoto_s3::{
@@ -77,8 +73,7 @@ impl<T: StdError> IsRetryable for RusotoErrorWrapper<T> {
 }
 
 impl<T> From<RusotoErrorWrapper<T>> for StorageError
-where
-    T: Send + Sync + std::error::Error + 'static + ToStorageErrorKind,
+where T: Send + Sync + std::error::Error + 'static + ToStorageErrorKind
 {
     fn from(err: RusotoErrorWrapper<T>) -> StorageError {
         let error_kind = match &err.0 {

--- a/quickwit-storage/src/object_storage/file_slice_stream.rs
+++ b/quickwit-storage/src/object_storage/file_slice_stream.rs
@@ -1,24 +1,21 @@
-/*
-    Quickwit
-    Copyright (C) 2021 Quickwit Inc.
-
-    Quickwit is offered under the AGPL v3.0 and as commercial software.
-    For commercial licensing, contact us at hello@quickwit.io.
-
-    AGPL:
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation, either version 3 of the
-    License, or (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::io::{self, SeekFrom};
 use std::ops::Range;
@@ -40,8 +37,7 @@ pub struct FileSliceStream<R> {
 }
 
 impl<R> FileSliceStream<R>
-where
-    R: AsyncRead + AsyncSeek + Unpin,
+where R: AsyncRead + AsyncSeek + Unpin
 {
     pub async fn try_new(mut reader: R, range: Range<u64>) -> io::Result<Self> {
         if range.end < range.start {
@@ -62,8 +58,7 @@ where
 }
 
 impl<R> Stream for FileSliceStream<R>
-where
-    R: AsyncRead + Unpin,
+where R: AsyncRead + Unpin
 {
     type Item = io::Result<Bytes>;
 
@@ -85,9 +80,10 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::io::Cursor;
+
     use bytes::Bytes;
     use futures::StreamExt;
-    use std::io::Cursor;
 
     use crate::object_storage::file_slice_stream::FileSliceStream;
 

--- a/quickwit-storage/src/object_storage/mod.rs
+++ b/quickwit-storage/src/object_storage/mod.rs
@@ -1,24 +1,21 @@
-/*
-    Quickwit
-    Copyright (C) 2021 Quickwit Inc.
-
-    Quickwit is offered under the AGPL v3.0 and as commercial software.
-    For commercial licensing, contact us at hello@quickwit.io.
-
-    AGPL:
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation, either version 3 of the
-    License, or (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 mod error;
 mod file_slice_stream;

--- a/quickwit-storage/src/object_storage/policy.rs
+++ b/quickwit-storage/src/object_storage/policy.rs
@@ -1,24 +1,21 @@
-/*
-    Quickwit
-    Copyright (C) 2021 Quickwit Inc.
-
-    Quickwit is offered under the AGPL v3.0 and as commercial software.
-    For commercial licensing, contact us at hello@quickwit.io.
-
-    AGPL:
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation, either version 3 of the
-    License, or (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 /// The multipart policy defines when and how multipart upload / download should happen.
 ///

--- a/quickwit-storage/src/object_storage/s3_compatible_storage.rs
+++ b/quickwit-storage/src/object_storage/s3_compatible_storage.rs
@@ -1,24 +1,21 @@
-/*
-    Quickwit
-    Copyright (C) 2021 Quickwit Inc.
-
-    Quickwit is offered under the AGPL v3.0 and as commercial software.
-    For commercial licensing, contact us at hello@quickwit.io.
-
-    AGPL:
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation, either version 3 of the
-    License, or (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::fmt::{self, Debug};
 use std::io;
@@ -29,14 +26,9 @@ use std::time::Duration;
 use anyhow::Context;
 use async_trait::async_trait;
 use bytes::Bytes;
-use futures::stream;
-use futures::StreamExt;
+use futures::{stream, StreamExt};
 use once_cell::sync::OnceCell;
 use regex::Regex;
-use tokio::fs::File;
-use tokio_util::io::ReaderStream;
-use tracing::warn;
-
 use rusoto_core::credential::{AutoRefreshingProvider, ChainProvider};
 use rusoto_core::{ByteStream, HttpClient, HttpConfig, Region, RusotoError};
 use rusoto_s3::{
@@ -45,15 +37,16 @@ use rusoto_s3::{
     GetObjectRequest, HeadObjectError, HeadObjectRequest, PutObjectError, PutObjectRequest,
     S3Client, UploadPartRequest, S3,
 };
+use tokio::fs::File;
 use tokio::io::{AsyncReadExt, AsyncWriteExt, BufReader};
+use tokio_util::io::ReaderStream;
+use tracing::warn;
 
 use super::error::RusotoErrorWrapper;
-
 use crate::object_storage::file_slice_stream::FileSliceStream;
 use crate::object_storage::MultiPartPolicy;
 use crate::retry::{retry, IsRetryable, Retry};
-use crate::{PutPayload, Storage, StorageErrorKind};
-use crate::{StorageError, StorageResult};
+use crate::{PutPayload, Storage, StorageError, StorageErrorKind, StorageResult};
 
 /// A credential timeout.
 const CREDENTIAL_TIMEOUT: u64 = 5;
@@ -276,7 +269,8 @@ impl S3CompatibleObjectStorage {
     ) -> io::Result<Vec<Part>> {
         assert!(len > 0);
         let chunks = split_range_into_chunks(len, part_len);
-        // Note that it should really be the first chunk, but who knows... and it is very cheap to compute this anyway.
+        // Note that it should really be the first chunk, but who knows... and it is very cheap to
+        // compute this anyway.
         let largest_chunk_num_bytes = chunks
             .iter()
             .map(|chunk| chunk.end - chunk.start)
@@ -619,8 +613,9 @@ impl Storage for S3CompatibleObjectStorage {
 
 #[cfg(test)]
 mod tests {
-    use crate::object_storage::s3_compatible_storage::split_range_into_chunks;
     use std::path::PathBuf;
+
+    use crate::object_storage::s3_compatible_storage::split_range_into_chunks;
 
     #[test]
     fn test_split_range_into_chunks_inexact() {

--- a/quickwit-storage/src/object_storage/s3_compatible_storage_uri_resolver.rs
+++ b/quickwit-storage/src/object_storage/s3_compatible_storage_uri_resolver.rs
@@ -1,31 +1,29 @@
-/*
-    Quickwit
-    Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-    Quickwit is offered under the AGPL v3.0 and as commercial software.
-    For commercial licensing, contact us at hello@quickwit.io.
-
-    AGPL:
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation, either version 3 of the
-    License, or (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
+use std::str::FromStr;
+use std::sync::Arc;
 
 use ec2_instance_metadata::{InstanceMetadata, InstanceMetadataClient};
 use once_cell::sync::OnceCell;
 use quickwit_common::{get_quickwit_env, QuickwitEnv};
 pub use rusoto_core::Region;
-use std::str::FromStr;
-use std::sync::Arc;
 
 use crate::{S3CompatibleObjectStorage, StorageFactory};
 

--- a/quickwit-storage/src/prefix_storage.rs
+++ b/quickwit-storage/src/prefix_storage.rs
@@ -1,32 +1,28 @@
-/*
-    Quickwit
-    Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-    Quickwit is offered under the AGPL v3.0 and as commercial software.
-    For commercial licensing, contact us at hello@quickwit.io.
-
-    AGPL:
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation, either version 3 of the
-    License, or (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
+use std::ops::Range;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use bytes::Bytes;
-use std::{
-    ops::Range,
-    path::{Path, PathBuf},
-    sync::Arc,
-};
 
 use crate::Storage;
 

--- a/quickwit-storage/src/ram_storage.rs
+++ b/quickwit-storage/src/ram_storage.rs
@@ -1,37 +1,37 @@
-/*
-    Quickwit
-    Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-    Quickwit is offered under the AGPL v3.0 and as commercial software.
-    For commercial licensing, contact us at hello@quickwit.io.
-
-    AGPL:
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation, either version 3 of the
-    License, or (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
-
-use crate::add_prefix_to_storage;
-use crate::{PutPayload, Storage, StorageErrorKind, StorageFactory, StorageResult};
-use async_trait::async_trait;
-use bytes::Bytes;
 use std::collections::HashMap;
 use std::ops::Range;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::{fmt, io};
+
+use async_trait::async_trait;
+use bytes::Bytes;
 use tokio::fs::File;
 use tokio::io::AsyncWriteExt;
 use tokio::sync::RwLock;
+
+use crate::{
+    add_prefix_to_storage, PutPayload, Storage, StorageErrorKind, StorageFactory, StorageResult,
+};
 
 /// In Ram implementation of quickwit's storage.
 ///

--- a/quickwit-storage/src/retry.rs
+++ b/quickwit-storage/src/retry.rs
@@ -1,29 +1,27 @@
-/*
-    Quickwit
-    Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-    Quickwit is offered under the AGPL v3.0 and as commercial software.
-    For commercial licensing, contact us at hello@quickwit.io.
-
-    AGPL:
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation, either version 3 of the
-    License, or (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
+use std::fmt::Display;
+use std::time::Duration;
 
 use futures::Future;
 use rand::Rng;
-use std::fmt::Display;
-use std::time::Duration;
 use tracing::{debug, warn};
 
 const MAX_RETRY_ATTEMPTS: usize = 30;
@@ -74,8 +72,8 @@ impl<E> IsRetryable for Retry<E> {
 }
 
 // TODO define retry strategy
-/// Retry with exponential backoff and full jitter. Implementation and default values originate from the Java SDK.
-/// See also: https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/.
+/// Retry with exponential backoff and full jitter. Implementation and default values originate from
+/// the Java SDK. See also: https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/.
 pub async fn retry<F, U, E, Fut>(f: F) -> Result<U, E>
 where
     F: Fn() -> Fut,

--- a/quickwit-storage/src/storage.rs
+++ b/quickwit-storage/src/storage.rs
@@ -1,30 +1,28 @@
-/*
-    Quickwit
-    Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-    Quickwit is offered under the AGPL v3.0 and as commercial software.
-    For commercial licensing, contact us at hello@quickwit.io.
-
-    AGPL:
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation, either version 3 of the
-    License, or (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
-
-use async_trait::async_trait;
-use bytes::Bytes;
 use std::io;
 use std::ops::Range;
 use std::path::{Path, PathBuf};
+
+use async_trait::async_trait;
+use bytes::Bytes;
 
 use crate::{StorageErrorKind, StorageResult};
 

--- a/quickwit-storage/src/storage_resolver.rs
+++ b/quickwit-storage/src/storage_resolver.rs
@@ -1,31 +1,31 @@
-/*
-    Quickwit
-    Copyright (C) 2021 Quickwit Inc.
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-    Quickwit is offered under the AGPL v3.0 and as commercial software.
-    For commercial licensing, contact us at hello@quickwit.io.
-
-    AGPL:
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation, either version 3 of the
-    License, or (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
-use crate::local_file_storage::LocalFileStorageFactory;
-use crate::ram_storage::RamStorageFactory;
-use crate::{RegionProvider, S3CompatibleObjectStorageFactory, Storage, StorageResolverError};
-use once_cell::sync::OnceCell;
 use std::collections::HashMap;
 use std::error::Error;
 use std::sync::Arc;
+
+use once_cell::sync::OnceCell;
+
+use crate::local_file_storage::LocalFileStorageFactory;
+use crate::ram_storage::RamStorageFactory;
+use crate::{RegionProvider, S3CompatibleObjectStorageFactory, Storage, StorageResolverError};
 
 /// Quickwit supported storage resolvers.
 pub fn quickwit_storage_uri_resolver() -> &'static StorageUriResolver {
@@ -131,9 +131,8 @@ impl StorageUriResolver {
 mod tests {
     use std::path::Path;
 
-    use crate::RamStorage;
-
     use super::*;
+    use crate::RamStorage;
 
     #[tokio::test]
     async fn test_storage_resolver_simple() -> anyhow::Result<()> {

--- a/quickwit-storage/tests/s3_storage.rs
+++ b/quickwit-storage/tests/s3_storage.rs
@@ -1,24 +1,21 @@
-/*
-    Quickwit
-    Copyright (C) 2021 Quickwit Inc.
-
-    Quickwit is offered under the AGPL v3.0 and as commercial software.
-    For commercial licensing, contact us at hello@quickwit.io.
-
-    AGPL:
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation, either version 3 of the
-    License, or (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 // This file is an integration test that assumes that the environement
 // makes it possible to connect to Amazon S3's quickwit-integration-test bucket.

--- a/quickwit-swim/src/cluster.rs
+++ b/quickwit-swim/src/cluster.rs
@@ -1,22 +1,24 @@
+use std::convert::AsRef;
+use std::net::SocketAddr;
+
+use flume;
+use tracing::debug;
+use uuid::Uuid;
+
 use super::state::ArtilleryEpidemic;
 use crate::cluster_config::ClusterConfig;
 use crate::errors::*;
 use crate::state::{ArtilleryClusterEvent, ArtilleryClusterRequest};
-use flume;
-use std::convert::AsRef;
-use std::net::SocketAddr;
-use tracing::debug;
-use uuid::Uuid;
 
 #[derive(Debug)]
 pub struct Cluster {
-    comm: flume::Sender<ArtilleryClusterRequest>,
+    comm: flume::Sender<ArtilleryClusterRequest>
 }
 
 impl Cluster {
     pub fn create_and_start(
         host_key: Uuid,
-        config: ClusterConfig,
+        config: ClusterConfig
     ) -> Result<(Cluster, flume::Receiver<ArtilleryClusterEvent>)> {
         let (event_tx, event_rx) = flume::unbounded::<ArtilleryClusterEvent>();
         let (internal_tx, mut internal_rx) = flume::unbounded::<ArtilleryClusterRequest>();
@@ -42,7 +44,7 @@ impl Cluster {
         self.comm
             .send(ArtilleryClusterRequest::Payload(
                 id,
-                msg.as_ref().to_string(),
+                msg.as_ref().to_string()
             ))
             .unwrap();
     }

--- a/quickwit-swim/src/cluster_config.rs
+++ b/quickwit-swim/src/cluster_config.rs
@@ -1,7 +1,5 @@
-use std::{
-    net::{SocketAddr, ToSocketAddrs},
-    time::Duration,
-};
+use std::net::{SocketAddr, ToSocketAddrs};
+use std::time::Duration;
 
 // ARTIL = 27845
 /// Default Epidemic Port
@@ -19,7 +17,7 @@ pub struct ClusterConfig {
     pub network_mtu: usize,
     pub ping_request_host_count: usize,
     pub ping_timeout: Duration,
-    pub listen_addr: SocketAddr,
+    pub listen_addr: SocketAddr
 }
 
 impl Default for ClusterConfig {
@@ -32,7 +30,7 @@ impl Default for ClusterConfig {
             network_mtu: CONST_PACKET_SIZE,
             ping_request_host_count: 3,
             ping_timeout: Duration::from_secs(3),
-            listen_addr: directed.to_socket_addrs().unwrap().next().unwrap(),
+            listen_addr: directed.to_socket_addrs().unwrap().next().unwrap()
         }
     }
 }

--- a/quickwit-swim/src/errors.rs
+++ b/quickwit-swim/src/errors.rs
@@ -1,5 +1,5 @@
-use std::io;
-use std::result;
+use std::{io, result};
+
 use thiserror::Error;
 
 /// Result type for operations that could result in an `ArtilleryError`
@@ -21,7 +21,7 @@ pub enum ArtilleryError {
     #[error("Artillery :: Decoding Error: {}", _0)]
     Decoding(String),
     #[error("Artillery :: Numeric Cast Error: {}", _0)]
-    NumericCast(String),
+    NumericCast(String)
 }
 
 impl From<serde_json::error::Error> for ArtilleryError {

--- a/quickwit-swim/src/member.rs
+++ b/quickwit-swim/src/member.rs
@@ -1,9 +1,10 @@
-use serde::*;
 use std::cmp::Ordering;
 use std::fmt;
 use std::fmt::{Debug, Formatter};
 use std::net::SocketAddr;
 use std::time::{Duration, Instant};
+
+use serde::*;
 use uuid::Uuid;
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialOrd, Ord, PartialEq, Eq, Copy)]
@@ -19,7 +20,7 @@ pub enum ArtilleryMemberState {
     Down,
     /// Left the cluster
     #[serde(rename = "l")]
-    Left,
+    Left
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq)]
@@ -33,12 +34,12 @@ pub struct ArtilleryMember {
     #[serde(rename = "m")]
     member_state: ArtilleryMemberState,
     #[serde(rename = "t", skip, default = "Instant::now")]
-    last_state_change: Instant,
+    last_state_change: Instant
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialOrd, Ord, PartialEq, Eq)]
 pub struct ArtilleryStateChange {
-    member: ArtilleryMember,
+    member: ArtilleryMember
 }
 
 impl ArtilleryMember {
@@ -46,14 +47,14 @@ impl ArtilleryMember {
         host_key: Uuid,
         remote_host: SocketAddr,
         incarnation_number: u64,
-        known_state: ArtilleryMemberState,
+        known_state: ArtilleryMemberState
     ) -> Self {
         ArtilleryMember {
             host_key,
             remote_host: Some(remote_host),
             incarnation_number,
             member_state: known_state,
-            last_state_change: Instant::now(),
+            last_state_change: Instant::now()
         }
     }
 
@@ -63,7 +64,7 @@ impl ArtilleryMember {
             remote_host: None,
             incarnation_number: 0,
             member_state: ArtilleryMemberState::Alive,
-            last_state_change: Instant::now(),
+            last_state_change: Instant::now()
         }
     }
 
@@ -130,14 +131,14 @@ impl PartialOrd for ArtilleryMember {
             self.host_key.as_bytes(),
             format!("{:?}", self.remote_host),
             self.incarnation_number,
-            self.member_state,
+            self.member_state
         );
 
         let t2 = (
             rhs.host_key.as_bytes(),
             format!("{:?}", rhs.remote_host),
             rhs.incarnation_number,
-            rhs.member_state,
+            rhs.member_state
         );
 
         t1.partial_cmp(&t2)
@@ -158,14 +159,14 @@ impl Debug for ArtilleryMember {
             .field("state", &self.member_state)
             .field(
                 "drift_time_ms",
-                &self.last_state_change.elapsed().as_millis(),
+                &self.last_state_change.elapsed().as_millis()
             )
             .field(
                 "remote_host",
                 &self
                     .remote_host
                     .map_or(String::from("(current)"), |r| format!("{}", r))
-                    .as_str(),
+                    .as_str()
             )
             .finish()
     }
@@ -173,7 +174,7 @@ impl Debug for ArtilleryMember {
 
 pub fn most_uptodate_member_data<'a>(
     lhs: &'a ArtilleryMember,
-    rhs: &'a ArtilleryMember,
+    rhs: &'a ArtilleryMember
 ) -> &'a ArtilleryMember {
     // Don't apply clippy here.
     // It's important bit otherwise we won't understand.
@@ -183,7 +184,7 @@ pub fn most_uptodate_member_data<'a>(
         lhs.member_state,
         lhs.incarnation_number,
         rhs.member_state,
-        rhs.incarnation_number,
+        rhs.incarnation_number
     ) {
         (ArtilleryMemberState::Alive, i, ArtilleryMemberState::Suspect, j) => i > j,
         (ArtilleryMemberState::Alive, i, ArtilleryMemberState::Alive, j) => i > j,
@@ -192,7 +193,7 @@ pub fn most_uptodate_member_data<'a>(
         (ArtilleryMemberState::Down, _, ArtilleryMemberState::Alive, _) => true,
         (ArtilleryMemberState::Down, _, ArtilleryMemberState::Suspect, _) => true,
         (ArtilleryMemberState::Left, _, _, _) => true,
-        _ => false,
+        _ => false
     };
 
     if lhs_overrides {
@@ -204,10 +205,12 @@ pub fn most_uptodate_member_data<'a>(
 
 #[cfg(test)]
 mod test {
-    use super::{ArtilleryMember, ArtilleryMemberState};
     use std::str::FromStr;
     use std::time::{Duration, Instant};
+
     use uuid;
+
+    use super::{ArtilleryMember, ArtilleryMemberState};
 
     #[test]
     fn test_member_encode_decode() {
@@ -216,7 +219,7 @@ mod test {
             remote_host: Some(FromStr::from_str("127.0.0.1:1337").unwrap()),
             incarnation_number: 123,
             member_state: ArtilleryMemberState::Alive,
-            last_state_change: Instant::now() - Duration::from_secs(3600),
+            last_state_change: Instant::now() - Duration::from_secs(3600)
         };
 
         let encoded = bincode::serialize(&member).unwrap();

--- a/quickwit-swim/src/membership.rs
+++ b/quickwit-swim/src/membership.rs
@@ -10,14 +10,14 @@ use crate::member::{self, ArtilleryMember, ArtilleryMemberState, ArtilleryStateC
 
 pub struct ArtilleryMemberList {
     members: Vec<ArtilleryMember>,
-    periodic_index: usize,
+    periodic_index: usize
 }
 
 impl ArtilleryMemberList {
     pub fn new(current: ArtilleryMember) -> Self {
         ArtilleryMemberList {
             members: vec![current],
-            periodic_index: 0,
+            periodic_index: 0
         }
     }
 
@@ -79,7 +79,7 @@ impl ArtilleryMemberList {
 
     pub fn time_out_nodes(
         &mut self,
-        expired_hosts: &HashSet<SocketAddr>,
+        expired_hosts: &HashSet<SocketAddr>
     ) -> (Vec<ArtilleryMember>, Vec<ArtilleryMember>) {
         let mut suspect_members = Vec::new();
         let mut down_members = Vec::new();
@@ -129,7 +129,7 @@ impl ArtilleryMemberList {
     pub fn apply_state_changes(
         &mut self,
         state_changes: Vec<ArtilleryStateChange>,
-        from: &SocketAddr,
+        from: &SocketAddr
     ) -> (Vec<ArtilleryMember>, Vec<ArtilleryMember>) {
         let mut current_members = self.to_map();
 
@@ -179,13 +179,11 @@ impl ArtilleryMemberList {
         (new_nodes, changed_nodes)
     }
 
-    ///
-    ///
     /// Random ping enqueuing
     pub fn hosts_for_indirect_ping(
         &self,
         host_count: usize,
-        target: &SocketAddr,
+        target: &SocketAddr
     ) -> Vec<SocketAddr> {
         let mut possible_members: Vec<_> = self
             .members
@@ -217,7 +215,6 @@ impl ArtilleryMemberList {
         self.members.push(member)
     }
 
-    ///
     /// `get_member` will return artillery member if the given uuid is matches with any of the
     /// member in the cluster.
     pub fn get_member(&self, id: &Uuid) -> Option<ArtilleryMember> {

--- a/quickwit-telemetry/src/lib.rs
+++ b/quickwit-telemetry/src/lib.rs
@@ -1,34 +1,33 @@
-/*
- * Copyright (C) 2021 Quickwit Inc.
- *
- * Quickwit is offered under the AGPL v3.0 and as commercial software.
- * For commercial licensing, contact us at hello@quickwit.io.
- *
- * AGPL:
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
 #![allow(clippy::bool_assert_comparison)]
 pub mod payload;
 /// This crate contains  the code responsible for sending usage data to Quickwit inc's server.
 mod sender;
 pub(crate) mod sink;
 
-use crate::payload::TelemetryEvent;
-use crate::sender::{TelemetryLoopHandle, TelemetrySender};
 use once_cell::sync::OnceCell;
 
+use crate::payload::TelemetryEvent;
 pub use crate::sender::is_telemetry_enabled;
+use crate::sender::{TelemetryLoopHandle, TelemetrySender};
 
 pub fn start_telemetry_loop() -> TelemetryLoopHandle {
     get_telemetry_sender_singleton().start_loop()

--- a/quickwit-telemetry/src/payload.rs
+++ b/quickwit-telemetry/src/payload.rs
@@ -1,26 +1,26 @@
-/*
- * Copyright (C) 2021 Quickwit Inc.
- *
- * Quickwit is offered under the AGPL v3.0 and as commercial software.
- * For commercial licensing, contact us at hello@quickwit.io.
- *
- * AGPL:
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
-use serde::{Deserialize, Serialize};
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
 use std::env;
 use std::time::UNIX_EPOCH;
+
+use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 /// Represents the payload of the request sent with telemetry requests.

--- a/quickwit-telemetry/src/sender.rs
+++ b/quickwit-telemetry/src/sender.rs
@@ -1,39 +1,35 @@
-/*
- * Copyright (C) 2021 Quickwit Inc.
- *
- * Quickwit is offered under the AGPL v3.0 and as commercial software.
- * For commercial licensing, contact us at hello@quickwit.io.
- *
- * AGPL:
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
 use std::mem;
-use std::sync::atomic::AtomicBool;
-use std::sync::atomic::Ordering;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
+
 use tokio::sync::mpsc::{Receiver, Sender};
-use tokio::sync::oneshot;
-use tokio::sync::Mutex;
-use tokio::sync::RwLock;
+use tokio::sync::{oneshot, Mutex, RwLock};
 use tokio::task::JoinHandle;
 use tokio::time::Interval;
 use tracing::info;
 
 use crate::payload::{ClientInformation, EventWithTimestamp, TelemetryEvent, TelemetryPayload};
-use crate::sink::HttpClient;
-use crate::sink::Sink;
+use crate::sink::{HttpClient, Sink};
 
 /// At most 1 Request per minutes.
 const TELEMETRY_PUSH_COOLDOWN: Duration = Duration::from_secs(60);

--- a/quickwit-telemetry/src/sink.rs
+++ b/quickwit-telemetry/src/sink.rs
@@ -1,27 +1,27 @@
-/*
- * Copyright (C) 2021 Quickwit Inc.
- *
- * Quickwit is offered under the AGPL v3.0 and as commercial software.
- * For commercial licensing, contact us at hello@quickwit.io.
- *
- * AGPL:
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use std::time::Duration;
+
 use async_trait::async_trait;
 use reqwest::redirect::Policy;
 use reqwest::Client;
-use std::time::Duration;
 use tokio::sync::mpsc::UnboundedSender;
 
 use crate::payload::TelemetryPayload;

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,14 @@
+ignore = [
+  "quickwit-proto/src/cluster.rs",
+  "quickwit-proto/src/quickwit.rs",
+  "quickwit-swim",
+]
+
+comment_width = 120
+format_strings = true
+group_imports = "StdExternalCrate"
+imports_granularity = "Module"
+license_template_path = ".license_header.txt"
+normalize_comments = true
+where_single_line = true
+wrap_comments = true


### PR DESCRIPTION
I was looking into rustfmt options and found some interesting settings:
- enforce license header;
- organize comments and limit comment width;
- organize imports in groups (std, external, crate);
- remove trailing commas (or always add them if that's more to your liking).

This makes for a more consistent and eye-pleasing codebase. The major con is that some options are only available on the nightly channel. So, I added a `make fmt` command.

Let me know what you think and if we decide to go ahead with this, I can set this up in CI and update `make fmt` to display a nicer error message when nightly is not available with instructions on how to install it.