### PR TITLE
Rename cluster RPCs *Result -> *Response

### DIFF
--- a/quickwit-cluster/src/service.rs
+++ b/quickwit-cluster/src/service.rs
@@ -20,7 +20,10 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use quickwit_proto::{LeaveRequest, LeaveResult, Member as PMember, MembersRequest, MembersResult};
+use quickwit_proto::{
+    LeaveClusterRequest, LeaveClusterResponse, ListMembersRequest, ListMembersResponse,
+    Member as PMember,
+};
 
 use crate::cluster::{Cluster, Member};
 use crate::error::ClusterError;
@@ -38,8 +41,14 @@ impl From<Member> for PMember {
 
 #[async_trait]
 pub trait ClusterService: 'static + Send + Sync {
-    async fn members(&self, request: MembersRequest) -> Result<MembersResult, ClusterError>;
-    async fn leave(&self, request: LeaveRequest) -> Result<LeaveResult, ClusterError>;
+    async fn list_members(
+        &self,
+        request: ListMembersRequest,
+    ) -> Result<ListMembersResponse, ClusterError>;
+    async fn leave_cluster(
+        &self,
+        request: LeaveClusterRequest,
+    ) -> Result<LeaveClusterResponse, ClusterError>;
 }
 
 /// Cluster service implementation.
@@ -58,20 +67,26 @@ impl ClusterServiceImpl {
 #[tonic::async_trait]
 impl ClusterService for ClusterServiceImpl {
     /// This is the API to get the list of cluster members.
-    async fn members(&self, _request: MembersRequest) -> Result<MembersResult, ClusterError> {
+    async fn list_members(
+        &self,
+        _request: ListMembersRequest,
+    ) -> Result<ListMembersResponse, ClusterError> {
         let members = self
             .cluster
             .members()
             .into_iter()
             .map(PMember::from)
             .collect();
-        Ok(MembersResult { members })
+        Ok(ListMembersResponse { members })
     }
 
     /// This is the API to leave the member from the cluster.
-    async fn leave(&self, _request: LeaveRequest) -> Result<LeaveResult, ClusterError> {
+    async fn leave_cluster(
+        &self,
+        _request: LeaveClusterRequest,
+    ) -> Result<LeaveClusterResponse, ClusterError> {
         self.cluster.leave().await;
-        Ok(LeaveResult {})
+        Ok(LeaveClusterResponse {})
     }
 }
 

--- a/quickwit-proto/proto/cluster.proto
+++ b/quickwit-proto/proto/cluster.proto
@@ -23,12 +23,12 @@ syntax = "proto3";
 package cluster;
 
 service ClusterService {
-  /// Retrieves members in the cluster.
-  rpc Members(MembersRequest) returns (MembersResult);
+  /// Retrieves members of the cluster.
+  rpc ListMembers(ListMembersRequest) returns (ListMembersResponse);
 
   /// Removes itself from the cluster.
   /// Removed node will be isolated from the cluster.
-  rpc Leave(LeaveRequest) returns (LeaveResult);
+  rpc LeaveCluster(LeaveClusterRequest) returns (LeaveClusterResponse);
 }
 
 /// The member information.
@@ -44,15 +44,15 @@ message Member {
   bool is_self = 3;
 }
 
-message MembersRequest {
+message ListMembersRequest {
 }
 
-message MembersResult {
+message ListMembersResponse {
   repeated Member members = 1;
 }
 
-message LeaveRequest {
+message LeaveClusterRequest {
 }
 
-message LeaveResult {
+message LeaveClusterResponse {
 }

--- a/quickwit-proto/src/cluster.rs
+++ b/quickwit-proto/src/cluster.rs
@@ -17,22 +17,22 @@ pub struct Member {
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MembersRequest {}
+pub struct ListMembersRequest {}
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MembersResult {
+pub struct ListMembersResponse {
     #[prost(message, repeated, tag = "1")]
     pub members: ::prost::alloc::vec::Vec<Member>,
 }
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct LeaveRequest {}
+pub struct LeaveClusterRequest {}
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct LeaveResult {}
+pub struct LeaveClusterResponse {}
 #[doc = r" Generated client implementations."]
 pub mod cluster_service_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
@@ -93,11 +93,11 @@ pub mod cluster_service_client {
             self.inner = self.inner.accept_gzip();
             self
         }
-        #[doc = "/ Retrieves members in the cluster."]
-        pub async fn members(
+        #[doc = "/ Retrieves members of the cluster."]
+        pub async fn list_members(
             &mut self,
-            request: impl tonic::IntoRequest<super::MembersRequest>,
-        ) -> Result<tonic::Response<super::MembersResult>, tonic::Status> {
+            request: impl tonic::IntoRequest<super::ListMembersRequest>,
+        ) -> Result<tonic::Response<super::ListMembersResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
@@ -105,15 +105,15 @@ pub mod cluster_service_client {
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/cluster.ClusterService/Members");
+            let path = http::uri::PathAndQuery::from_static("/cluster.ClusterService/ListMembers");
             self.inner.unary(request.into_request(), path, codec).await
         }
         #[doc = "/ Removes itself from the cluster."]
         #[doc = "/ Removed node will be isolated from the cluster."]
-        pub async fn leave(
+        pub async fn leave_cluster(
             &mut self,
-            request: impl tonic::IntoRequest<super::LeaveRequest>,
-        ) -> Result<tonic::Response<super::LeaveResult>, tonic::Status> {
+            request: impl tonic::IntoRequest<super::LeaveClusterRequest>,
+        ) -> Result<tonic::Response<super::LeaveClusterResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
@@ -121,7 +121,7 @@ pub mod cluster_service_client {
                 )
             })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/cluster.ClusterService/Leave");
+            let path = http::uri::PathAndQuery::from_static("/cluster.ClusterService/LeaveCluster");
             self.inner.unary(request.into_request(), path, codec).await
         }
     }
@@ -133,17 +133,17 @@ pub mod cluster_service_server {
     #[doc = "Generated trait containing gRPC methods that should be implemented for use with ClusterServiceServer."]
     #[async_trait]
     pub trait ClusterService: Send + Sync + 'static {
-        #[doc = "/ Retrieves members in the cluster."]
-        async fn members(
+        #[doc = "/ Retrieves members of the cluster."]
+        async fn list_members(
             &self,
-            request: tonic::Request<super::MembersRequest>,
-        ) -> Result<tonic::Response<super::MembersResult>, tonic::Status>;
+            request: tonic::Request<super::ListMembersRequest>,
+        ) -> Result<tonic::Response<super::ListMembersResponse>, tonic::Status>;
         #[doc = "/ Removes itself from the cluster."]
         #[doc = "/ Removed node will be isolated from the cluster."]
-        async fn leave(
+        async fn leave_cluster(
             &self,
-            request: tonic::Request<super::LeaveRequest>,
-        ) -> Result<tonic::Response<super::LeaveResult>, tonic::Status>;
+            request: tonic::Request<super::LeaveClusterRequest>,
+        ) -> Result<tonic::Response<super::LeaveClusterResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct ClusterServiceServer<T: ClusterService> {
@@ -184,18 +184,20 @@ pub mod cluster_service_server {
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
             let inner = self.inner.clone();
             match req.uri().path() {
-                "/cluster.ClusterService/Members" => {
+                "/cluster.ClusterService/ListMembers" => {
                     #[allow(non_camel_case_types)]
-                    struct MembersSvc<T: ClusterService>(pub Arc<T>);
-                    impl<T: ClusterService> tonic::server::UnaryService<super::MembersRequest> for MembersSvc<T> {
-                        type Response = super::MembersResult;
+                    struct ListMembersSvc<T: ClusterService>(pub Arc<T>);
+                    impl<T: ClusterService> tonic::server::UnaryService<super::ListMembersRequest>
+                        for ListMembersSvc<T>
+                    {
+                        type Response = super::ListMembersResponse;
                         type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
-                            request: tonic::Request<super::MembersRequest>,
+                            request: tonic::Request<super::ListMembersRequest>,
                         ) -> Self::Future {
                             let inner = self.0.clone();
-                            let fut = async move { (*inner).members(request).await };
+                            let fut = async move { (*inner).list_members(request).await };
                             Box::pin(fut)
                         }
                     }
@@ -204,7 +206,7 @@ pub mod cluster_service_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
-                        let method = MembersSvc(inner);
+                        let method = ListMembersSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec).apply_compression_config(
                             accept_compression_encodings,
@@ -215,18 +217,20 @@ pub mod cluster_service_server {
                     };
                     Box::pin(fut)
                 }
-                "/cluster.ClusterService/Leave" => {
+                "/cluster.ClusterService/LeaveCluster" => {
                     #[allow(non_camel_case_types)]
-                    struct LeaveSvc<T: ClusterService>(pub Arc<T>);
-                    impl<T: ClusterService> tonic::server::UnaryService<super::LeaveRequest> for LeaveSvc<T> {
-                        type Response = super::LeaveResult;
+                    struct LeaveClusterSvc<T: ClusterService>(pub Arc<T>);
+                    impl<T: ClusterService> tonic::server::UnaryService<super::LeaveClusterRequest>
+                        for LeaveClusterSvc<T>
+                    {
+                        type Response = super::LeaveClusterResponse;
                         type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
-                            request: tonic::Request<super::LeaveRequest>,
+                            request: tonic::Request<super::LeaveClusterRequest>,
                         ) -> Self::Future {
                             let inner = self.0.clone();
-                            let fut = async move { (*inner).leave(request).await };
+                            let fut = async move { (*inner).leave_cluster(request).await };
                             Box::pin(fut)
                         }
                     }
@@ -235,7 +239,7 @@ pub mod cluster_service_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
-                        let method = LeaveSvc(inner);
+                        let method = LeaveClusterSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec).apply_compression_config(
                             accept_compression_encodings,

--- a/quickwit-serve/src/grpc_adapter/cluster_adapter.rs
+++ b/quickwit-serve/src/grpc_adapter/cluster_adapter.rs
@@ -20,7 +20,6 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use quickwit_cluster::error::ClusterError;
 use quickwit_cluster::service::{ClusterService, ClusterServiceImpl};
 use quickwit_proto::cluster_service_server as grpc;
 
@@ -35,29 +34,29 @@ impl From<Arc<ClusterServiceImpl>> for GrpcClusterAdapter {
 
 #[async_trait]
 impl grpc::ClusterService for GrpcClusterAdapter {
-    async fn members(
+    async fn list_members(
         &self,
-        request: tonic::Request<quickwit_proto::MembersRequest>,
-    ) -> Result<tonic::Response<quickwit_proto::MembersResult>, tonic::Status> {
-        let members_request = request.into_inner();
-        let members_result = self
+        request: tonic::Request<quickwit_proto::ListMembersRequest>,
+    ) -> Result<tonic::Response<quickwit_proto::ListMembersResponse>, tonic::Status> {
+        let list_members_req = request.into_inner();
+        let list_members_resp = self
             .0
-            .members(members_request)
+            .list_members(list_members_req)
             .await
-            .map_err(ClusterError::convert_to_tonic_status)?;
-        Ok(tonic::Response::new(members_result))
+            .map_err(Into::<tonic::Status>::into)?;
+        Ok(tonic::Response::new(list_members_resp))
     }
 
-    async fn leave(
+    async fn leave_cluster(
         &self,
-        request: tonic::Request<quickwit_proto::LeaveRequest>,
-    ) -> Result<tonic::Response<quickwit_proto::LeaveResult>, tonic::Status> {
-        let leave_request = request.into_inner();
-        let leave_result = self
+        request: tonic::Request<quickwit_proto::LeaveClusterRequest>,
+    ) -> Result<tonic::Response<quickwit_proto::LeaveClusterResponse>, tonic::Status> {
+        let leave_cluster_req = request.into_inner();
+        let leave_cluster_resp = self
             .0
-            .leave(leave_request)
+            .leave_cluster(leave_cluster_req)
             .await
-            .map_err(ClusterError::convert_to_tonic_status)?;
-        Ok(tonic::Response::new(leave_result))
+            .map_err(Into::<tonic::Status>::into)?;
+        Ok(tonic::Response::new(leave_cluster_resp))
     }
 }

--- a/quickwit-serve/src/http_handler/cluster.rs
+++ b/quickwit-serve/src/http_handler/cluster.rs
@@ -32,41 +32,41 @@ use crate::ApiError;
 #[derive(Deserialize, Debug, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 #[serde(rename_all = "camelCase")]
-pub struct MembersRequestQueryString {
-    /// The output format.
+pub struct ListMembersRequestQueryString {
+    /// The output format requested.
     #[serde(default)]
     pub format: Format,
 }
 
-/// cluster handler.
+/// Cluster handler.
 pub fn cluster_handler<TClusterService: ClusterService>(
     cluster_service: Arc<TClusterService>,
 ) -> impl Filter<Extract = impl warp::Reply, Error = Rejection> + Clone {
-    members_filter()
+    list_members_filter()
         .and(warp::any().map(move || cluster_service.clone()))
-        .and_then(members)
+        .and_then(list_members)
 }
 
-fn members_filter() -> impl Filter<Extract = (MembersRequestQueryString,), Error = Rejection> + Clone
-{
+fn list_members_filter(
+) -> impl Filter<Extract = (ListMembersRequestQueryString,), Error = Rejection> + Clone {
     warp::path!("cluster" / "members")
         .and(warp::get())
         .and(serde_qs::warp::query(serde_qs::Config::default()))
 }
 
-async fn members<TClusterService: ClusterService>(
-    request: MembersRequestQueryString,
+async fn list_members<TClusterService: ClusterService>(
+    request: ListMembersRequestQueryString,
     cluster_service: Arc<TClusterService>,
 ) -> Result<impl warp::Reply, Infallible> {
     Ok(request
         .format
-        .make_reply(members_endpoint(&*cluster_service).await))
+        .make_reply(list_members_endpoint(&*cluster_service).await))
 }
 
-async fn members_endpoint<TClusterService: ClusterService>(
+async fn list_members_endpoint<TClusterService: ClusterService>(
     cluster_service: &TClusterService,
-) -> Result<quickwit_proto::MembersResult, ApiError> {
-    let members_request = quickwit_proto::MembersRequest {};
-    let members_result = cluster_service.members(members_request).await?;
-    Ok(members_result)
+) -> Result<quickwit_proto::ListMembersResponse, ApiError> {
+    let list_members_req = quickwit_proto::ListMembersRequest {};
+    let list_members_resp = cluster_service.list_members(list_members_req).await?;
+    Ok(list_members_resp)
 }


### PR DESCRIPTION
### Description
Rename gRPC structs such as `LeaveResult` to `LeaveResponse`. More renaming PRs will come. 

### How was this PR tested?
No new unit tests were added.
