### PR TITLE
Set up Docker Compose and make command for running external services

### DIFF
--- a/.localstack/init.sh
+++ b/.localstack/init.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -eu
+
+awslocal kinesis create-stream --stream-name quickwit-dev-stream --shard-count 3
+awslocal s3 mb s3://quickwit-dev
+awslocal s3 mb s3://quickwit-integration-tests && awslocal s3 rm --recursive s3://quickwit-integration-tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ In that case, simply mark the PR with the tag [WIP] (standing for work in progre
 
 # Signing the CLA
 Quickwit is an opensource project licensed a AGPLv3.
-It is also distributed under a commercial license by Quickwit Inc.
+It is also distributed under a commercial license by Quickwit, Inc.
 
 Contributors are required to sign a Contributor License Agreement.
 The process is simple and fast. Upon your first pull request, you will be prompted to
@@ -25,15 +25,16 @@ The process is simple and fast. Upon your first pull request, you will be prompt
 
 # Development
 ## Setup & run tests
-1. Install docker https://docs.docker.com/engine/install/
-2. Install localstack https://github.com/localstack/localstack#installing
-3. Install awslocal https://github.com/localstack/awscli-local
-4. Prepare s3 bucket used in tests, execute `./quickwit-cli/tests/prepare_tests.sh`
-5. `QUICKWIT_ENV=LOCAL cargo test --all-features`
+1. Install Docker (https://docs.docker.com/engine/install/) and Docker Compose (https://docs.docker.com/compose/install/)
+2. Install awslocal https://github.com/localstack/awscli-local
+3. Start the external services with `make docker-compose-up`
+5. Run `QUICKWIT_ENV=LOCAL cargo test --all-features`
 
-## Tracing with jaeger
-1. Start a jaeger instance
-```bash
-make jaeger-start
-```
-2. Open your browser [localhost:16686](http://localhost:16686/)
+## Running services such as Amazon Kinesis or S3, Kafka, or PostgreSQL locally.
+1. Ensure Docker and Docker Compose are correctly installed on your machine (see above)
+2. Run `make docker-compose-up` to launch all the services or `make docker-compose-up DOCKER_SERVICES=kafka,postgres` to launch a subset of services.
+
+## Tracing with Jaeger
+1. Ensure Docker and Docker Compose are correctly installed on your machine (see above)
+2. Start the Jaeger services (UI, collector, agent, ...) running the command `make docker-compose-up DOCKER_SERVICES=jaeger`
+3. Open your browser and visit [localhost:16686](http://localhost:16686/)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,17 @@
+DOCKER_SERVICES ?= all
+
 help:
 	@grep '^[^#[:space:]].*:' Makefile
+
+# Usage:
+# `make docker-compose-up` starts all the services.
+# `make docker-compose-up DOCKER_SERVICES='jaeger,localstack'` starts the subset of services matching the profiles.
+docker-compose-up:
+	@echo "Launching ${DOCKER_SERVICES} Docker service(s)..."
+	COMPOSE_PROFILES=$(DOCKER_SERVICES) docker-compose -f docker-compose.yml up --remove-orphans
+
+docker-compose-down:
+	docker-compose -f docker-compose.yml down
 
 license-check:
 	docker run -it --rm -v $(shell pwd):/github/workspace ghcr.io/apache/skywalking-eyes/license-eye header check
@@ -9,6 +21,3 @@ license-fix:
 
 fmt:
 	rustup toolchain list | grep nightly -q && cargo +nightly fmt || echo "Toolchain 'nightly' is not installed. Please install using 'rustup toolchain install nightly'."
-
-jaeger-start:
-	docker run -d -p6831:6831/udp -p6832:6832/udp -p16686:16686 jaegertracing/all-in-one:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,25 +9,64 @@ networks:
         gateway: 172.16.7.1
 
 services:
-  zookeeper:
-    image: confluentinc/cp-zookeeper:6.2.0
-    hostname: zookeeper
-    container_name: zookeeper
+  jaeger:
+    image: jaegertracing/all-in-one:latest
+    container_name: jaeger
+    profiles:
+      - all
+      - jaeger
     ports:
-      - "2181:2181"
+      - "5775:5775/udp"
+      - "5778:5778"
+      - "6831:6831/udp"
+      - "6832:6832/udp"
+      - "14250:14250"
+      - "14268:14268"
+      - "16686:16686"
+
+  localstack:
+    image: localstack/localstack:latest
+    container_name: localstack
+    ports:
+      - "4566:4566"
+      - "4571:4571"
+      - "8080:8080"
+    profiles:
+      - all
+      - localstack
     environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
-      ZOOKEEPER_TICK_TIME: 2000
+      DATA_DIR: /tmp/localstack/data
+      SERVICES: kinesis,s3
+    volumes:
+      - ".localstack:/docker-entrypoint-initaws.d"
+      - "${TMPDIR:-/tmp}/quickwit/services/localstack:/tmp/localstack"
+
+  postgres:
+    image: postgres:latest
+    container_name: postgres
+    ports:
+      - "5432:5432"
+    profiles:
+      - all
+      - postgres
+    environment:
+      PGDATA: /var/lib/postgresql/data/pgdata
+      POSTGRES_USER: ${POSTGRES_USER:-quickwit-dev}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-quickwit-dev}
+    volumes:
+      - "${TMPDIR:-/tmp}/quickwit/services/postgres:/var/lib/postgresql/data/pgdata"
 
   kafka-broker:
     image: confluentinc/cp-kafka:6.2.0
-    hostname: kafka-broker
     container_name: kafka-broker
     depends_on:
       - zookeeper
     ports:
       - "9092:9092"
       - "9101:9101"
+    profiles:
+      - all
+      - kafka
     environment:
       KAFKA_BROKER_ID: 1
       KAFKA_ZOOKEEPER_CONNECT: "zookeeper:2181"
@@ -40,3 +79,14 @@ services:
       KAFKA_JMX_PORT: 9101
       KAFKA_JMX_HOSTNAME: localhost
 
+  zookeeper:
+    image: confluentinc/cp-zookeeper:6.2.0
+    container_name: zookeeper
+    ports:
+      - "2181:2181"
+    profiles:
+      - all
+      - kafka
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000

--- a/quickwit-common/src/lib.rs
+++ b/quickwit-common/src/lib.rs
@@ -84,10 +84,8 @@ impl Default for QuickwitEnv {
 
 pub fn get_quickwit_env() -> QuickwitEnv {
     match std::env::var("QUICKWIT_ENV") {
-        Ok(val) if val == "LOCAL" => QuickwitEnv::LOCAL,
-        Ok(val) => {
-            panic!("unknown value set for QUICKWIT_ENV {}", val)
-        }
+        Ok(val) if val.to_lowercase().trim() == "local" => QuickwitEnv::LOCAL,
+        Ok(val) => panic!("QUICKWIT_ENV value `{}` is not supported", val),
         Err(_) => QuickwitEnv::UNSET,
     }
 }


### PR DESCRIPTION
### Description
Set up  Docker Compose to manage our growing list of external services.

### How was this PR tested?
Ran `make docker-compose-up` and `QUICKWIT_ENV=local cargo test --all-features` locally.
