### PR TITLE
Re-enable error message in `make fmt` command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ help:
 # `make docker-compose-up` starts all the services.
 # `make docker-compose-up DOCKER_SERVICES='jaeger,localstack'` starts the subset of services matching the profiles.
 docker-compose-up:
-	@echo "Launching ${DOCKER_SERVICES} Docker service(s)..."
+	@echo "Launching ${DOCKER_SERVICES} Docker service(s)"
 	COMPOSE_PROFILES=$(DOCKER_SERVICES) docker-compose -f docker-compose.yml up --remove-orphans
 
 docker-compose-down:
@@ -21,4 +21,4 @@ license-fix:
 
 fmt:
 	@echo "Formatting Rust files"
-	@cargo +nightly fmt 
+	@(rustup toolchain list | ( ! grep -q nightly && echo "Toolchain 'nightly' is not installed. Please install using 'rustup toolchain install nightly'.") ) || cargo +nightly fmt


### PR DESCRIPTION
### Description
Re-enable error message in `make fmt` command

### How was this PR tested?
```sh
guilload@modern14 ~/W/r/quickwit (guilload--re-enable-make-fmt-error-message)> rustup toolchain remove nightly
info: uninstalling toolchain 'nightly-x86_64-unknown-linux-gnu'
info: toolchain 'nightly-x86_64-unknown-linux-gnu' uninstalled
guilload@modern14 ~/W/r/quickwit (guilload--re-enable-make-fmt-error-message)> make fmt
Formatting Rust files
Toolchain 'nightly' is not installed. Please install using 'rustup toolchain install nightly'.
guilload@modern14 ~/W/r/quickwit (guilload--re-enable-make-fmt-error-message)> rustup toolchain install nightly
guilload@modern14 ~/W/r/quickwit (guilload--re-enable-make-fmt-error-message)> make fmt
Formatting Rust files
guilload@modern14 ~/W/r/quickwit (guilload--re-enable-make-fmt-error-message)> echo $status  # I use fish
0
guilload@modern14 ~/W/r/quickwit (guilload--re-enable-make-fmt-error-message)> vi quickwit-actors/src/actor.rs  # Messing up a file
guilload@modern14 ~/W/r/quickwit (guilload--re-enable-make-fmt-error-message)> make fmt
Formatting Rust files
error: expected one of `(`, `,`, `=`, `{`, or `}`, found doc comment `/// The actor tried to send a message to a dowstream actor and failed.`
  --> /home/guilload/Workspace/repositories/quickwit/quickwit-actors/src/actor.rs:65:5
   |
63 |     Quit
   |         -
   |         |
   |         expected one of `(`, `,`, `=`, `{`, or `}`
   |         help: missing `,`
64 | 
65 |     /// The actor tried to send a message to a dowstream actor and failed.
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unexpected token

Error writing files: failed to resolve mod `actor`: cannot parse /home/guilload/Workspace/repositories/quickwit/quickwit-actors/src/actor.rs
make: *** [Makefile:24: fmt] Error 1
```
