### PR TITLE
Rename `LeafSearchResult` to `LeafSearchResponse`

### DIFF
--- a/quickwit-proto/proto/search_api.proto
+++ b/quickwit-proto/proto/search_api.proto
@@ -37,7 +37,7 @@ service SearchService {
   // it to other nodes.
   // - it should be applied on the given subset of splits
   // - Hit content is not fetched, and we instead return so called `PartialHit`.
-  rpc LeafSearch(LeafSearchRequest) returns (LeafSearchResult);
+  rpc LeafSearch(LeafSearchRequest) returns (LeafSearchResponse);
 
   /// Fetches the documents contents from the document store.
   /// This methods takes `PartialHit`s and returns `Hit`s.
@@ -164,14 +164,14 @@ message PartialHit {
   uint32 doc_id = 4;
 }
 
-message LeafSearchResult {
+message LeafSearchResponse {
   // Total number of documents matched by the query.
   uint64 num_hits = 1;
 
   // List of the best top-K candidates for the given leaf query.
   repeated PartialHit partial_hits = 2;
 
-  // The list of splits that failed. LeafSearchResult can be an aggregation of results, so there may be multiple.
+  // The list of splits that failed. LeafSearchResponse can be an aggregation of results, so there may be multiple.
   repeated SplitSearchError failed_splits = 3;
 
   // Total number of splits the leaf(s) were in charge of.

--- a/quickwit-proto/src/quickwit.rs
+++ b/quickwit-proto/src/quickwit.rs
@@ -143,14 +143,14 @@ pub struct PartialHit {
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct LeafSearchResult {
+pub struct LeafSearchResponse {
     /// Total number of documents matched by the query.
     #[prost(uint64, tag = "1")]
     pub num_hits: u64,
     /// List of the best top-K candidates for the given leaf query.
     #[prost(message, repeated, tag = "2")]
     pub partial_hits: ::prost::alloc::vec::Vec<PartialHit>,
-    /// The list of splits that failed. LeafSearchResult can be an aggregation of results, so there may be multiple.
+    /// The list of splits that failed. LeafSearchResponse can be an aggregation of results, so there may be multiple.
     #[prost(message, repeated, tag = "3")]
     pub failed_splits: ::prost::alloc::vec::Vec<SplitSearchError>,
     /// Total number of splits the leaf(s) were in charge of.
@@ -350,7 +350,7 @@ pub mod search_service_client {
         pub async fn leaf_search(
             &mut self,
             request: impl tonic::IntoRequest<super::LeafSearchRequest>,
-        ) -> Result<tonic::Response<super::LeafSearchResult>, tonic::Status> {
+        ) -> Result<tonic::Response<super::LeafSearchResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
@@ -426,7 +426,7 @@ pub mod search_service_server {
         async fn leaf_search(
             &self,
             request: tonic::Request<super::LeafSearchRequest>,
-        ) -> Result<tonic::Response<super::LeafSearchResult>, tonic::Status>;
+        ) -> Result<tonic::Response<super::LeafSearchResponse>, tonic::Status>;
         #[doc = "/ Fetches the documents contents from the document store."]
         #[doc = "/ This methods takes `PartialHit`s and returns `Hit`s."]
         async fn fetch_docs(
@@ -518,7 +518,7 @@ pub mod search_service_server {
                     #[allow(non_camel_case_types)]
                     struct LeafSearchSvc<T: SearchService>(pub Arc<T>);
                     impl<T: SearchService> tonic::server::UnaryService<super::LeafSearchRequest> for LeafSearchSvc<T> {
-                        type Response = super::LeafSearchResult;
+                        type Response = super::LeafSearchResponse;
                         type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,

--- a/quickwit-search/src/lib.rs
+++ b/quickwit-search/src/lib.rs
@@ -167,7 +167,7 @@ pub async fn single_node_search(
     let split_metadata: Vec<SplitIdAndFooterOffsets> =
         metas.iter().map(extract_split_and_footer_offsets).collect();
     let index_config = index_metadata.index_config;
-    let leaf_search_result = leaf_search(
+    let leaf_search_response = leaf_search(
         search_request,
         index_storage.clone(),
         &split_metadata[..],
@@ -176,7 +176,7 @@ pub async fn single_node_search(
     .await
     .context("Failed to perform leaf search.")?;
     let fetch_docs_result = fetch_docs(
-        leaf_search_result.partial_hits,
+        leaf_search_response.partial_hits,
         index_storage,
         &split_metadata,
     )
@@ -184,7 +184,7 @@ pub async fn single_node_search(
     .context("Failed to perform fetch docs.")?;
     let elapsed = start_instant.elapsed();
     Ok(SearchResponse {
-        num_hits: leaf_search_result.num_hits,
+        num_hits: leaf_search_response.num_hits,
         hits: fetch_docs_result.hits,
         elapsed_time_micros: elapsed.as_micros() as u64,
         errors: vec![],

--- a/quickwit-search/src/retry/search_stream.rs
+++ b/quickwit-search/src/retry/search_stream.rs
@@ -70,7 +70,7 @@ impl
 #[cfg(test)]
 mod tests {
     use quickwit_proto::{
-        LeafSearchRequest, LeafSearchResult, SearchRequest, SplitIdAndFooterOffsets,
+        LeafSearchRequest, LeafSearchResponse, SearchRequest, SplitIdAndFooterOffsets,
         SplitSearchError,
     };
 
@@ -111,7 +111,7 @@ mod tests {
     fn test_should_retry_on_error() -> anyhow::Result<()> {
         let retry_policy = LeafSearchRetryPolicy {};
         let request = mock_leaf_search_request();
-        let result = Result::<LeafSearchResult, SearchError>::Err(SearchError::InternalError(
+        let result = Result::<LeafSearchResponse, SearchError>::Err(SearchError::InternalError(
             "test".to_string(),
         ));
         let retry = retry_policy
@@ -125,13 +125,13 @@ mod tests {
     fn test_should_not_retry_if_result_is_ok_and_no_failing_splits() -> anyhow::Result<()> {
         let retry_policy = LeafSearchRetryPolicy {};
         let request = mock_leaf_search_request();
-        let leaf_response = LeafSearchResult {
+        let leaf_response = LeafSearchResponse {
             num_hits: 0,
             partial_hits: vec![],
             failed_splits: vec![],
             num_attempted_splits: 1,
         };
-        let result = Result::<LeafSearchResult, SearchError>::Ok(leaf_response);
+        let result = Result::<LeafSearchResponse, SearchError>::Ok(leaf_response);
         let retry = retry_policy
             .retry_request(&request, result.as_ref())
             .is_some();
@@ -150,13 +150,13 @@ mod tests {
             split_id: "split_2".to_string(),
             retryable_error: true,
         };
-        let leaf_response = LeafSearchResult {
+        let leaf_response = LeafSearchResponse {
             num_hits: 0,
             partial_hits: vec![],
             failed_splits: vec![split_error],
             num_attempted_splits: 1,
         };
-        let result = Result::<LeafSearchResult, SearchError>::Ok(leaf_response);
+        let result = Result::<LeafSearchResponse, SearchError>::Ok(leaf_response);
         let retry_request = retry_policy.retry_request(&request, result.as_ref());
         assert!(retry_request.is_some());
         assert_eq!(retry_request.unwrap(), expected_retry_request);

--- a/quickwit-serve/src/grpc_adapter/search_adapter.rs
+++ b/quickwit-serve/src/grpc_adapter/search_adapter.rs
@@ -90,17 +90,17 @@ impl grpc::SearchService for GrpcSearchAdapter {
     async fn leaf_search(
         &self,
         request: tonic::Request<quickwit_proto::LeafSearchRequest>,
-    ) -> Result<tonic::Response<quickwit_proto::LeafSearchResult>, tonic::Status> {
+    ) -> Result<tonic::Response<quickwit_proto::LeafSearchResponse>, tonic::Status> {
         let parent_cx =
             global::get_text_map_propagator(|prop| prop.extract(&MetadataMap(request.metadata())));
         Span::current().set_parent(parent_cx);
         let leaf_search_request = request.into_inner();
-        let leaf_search_result = self
+        let leaf_search_response = self
             .0
             .leaf_search(leaf_search_request)
             .await
             .map_err(Into::<tonic::Status>::into)?;
-        Ok(tonic::Response::new(leaf_search_result))
+        Ok(tonic::Response::new(leaf_search_response))
     }
 
     #[instrument(skip(self, request))]


### PR DESCRIPTION
### Description
Rename `LeafSearchResult` to `LeafSearchResponse`.

### How was this PR tested?
`cargo test`
