### PR TITLE
Adding `Command::Success`.

### DIFF
--- a/quickwit-actors/src/actor.rs
+++ b/quickwit-actors/src/actor.rs
@@ -338,7 +338,7 @@ impl<Message: Send + Sync + fmt::Debug + 'static> ActorContext<Message> {
 
     /// Send the Success message to terminate the destination actor with the Success exit status.
     ///
-    /// The message is queued like any regular messages, so that pending message will be processed
+    /// The message is queued like any regular message, so that pending messages will be processed
     /// first.
     pub async fn send_success<M>(&self, mailbox: &Mailbox<M>) -> Result<(), crate::SendError> {
         let _guard = self.protect_zone();
@@ -348,7 +348,7 @@ impl<Message: Send + Sync + fmt::Debug + 'static> ActorContext<Message> {
             .await
     }
 
-    /// `async` version of `send_self_message`
+    /// `async` version of `send_self_message`.
     pub async fn send_self_message(&self, msg: Message) -> Result<(), crate::SendError> {
         debug!(self=%self.self_mailbox.actor_instance_id(), msg=?msg, "self_send");
         self.self_mailbox.send_message(msg).await

--- a/quickwit-actors/src/channel_with_priority.rs
+++ b/quickwit-actors/src/channel_with_priority.rs
@@ -252,6 +252,16 @@ impl<T> Receiver<T> {
         }
         messages
     }
+
+    /// Drain all of the pending low priority messages and return them.
+    pub fn drain_all(&mut self) -> Vec<T> {
+        let mut messages = Vec::new();
+        let timeout = Duration::from_millis(10);
+        while let Ok(msg) = self.recv_timeout_blocking(timeout) {
+            messages.push(msg);
+        }
+        messages
+    }
 }
 
 #[cfg(test)]

--- a/quickwit-actors/src/channel_with_priority.rs
+++ b/quickwit-actors/src/channel_with_priority.rs
@@ -253,7 +253,7 @@ impl<T> Receiver<T> {
         messages
     }
 
-    /// Drain all of the pending low priority messages and return them.
+    /// Drains all the pending low priority messages and returns them.
     pub fn drain_all(&mut self) -> Vec<T> {
         let mut messages = Vec::new();
         let timeout = Duration::from_millis(10);

--- a/quickwit-actors/src/lib.rs
+++ b/quickwit-actors/src/lib.rs
@@ -55,7 +55,7 @@ pub use universe::Universe;
 pub use self::actor::ActorContext;
 pub use self::actor_state::ActorState;
 pub use self::channel_with_priority::{QueueCapacity, RecvError, SendError};
-pub use self::mailbox::{create_mailbox, create_test_mailbox, Mailbox};
+pub use self::mailbox::{create_mailbox, create_test_mailbox, Command, CommandOrMessage, Mailbox};
 
 /// Heartbeat used to verify that actors are progressing.
 ///

--- a/quickwit-actors/src/mailbox.rs
+++ b/quickwit-actors/src/mailbox.rs
@@ -116,8 +116,12 @@ pub enum Command {
 
     /// Stops the actor with a success exit status code.
     ///
+    /// Upstream `actors` that terminates should send the `ExitWithSuccess`
+    /// command to downstream actors to inform them that there are no more
+    /// incoming messages.
+    ///
     /// It is similar to `Quit`, except for the resulting exit status.
-    Success,
+    ExitWithSuccess,
 
     /// Asks the actor to update its ObservableState.
     /// Since it is a command, it will be treated with a higher priority than
@@ -161,7 +165,7 @@ impl fmt::Debug for Command {
             Command::Pause => write!(f, "Pause"),
             Command::Resume => write!(f, "Resume"),
             Command::Observe(_) => write!(f, "Observe"),
-            Command::Success => write!(f, "Success"),
+            Command::ExitWithSuccess => write!(f, "Success"),
             Command::Quit => write!(f, "Quit"),
             Command::Kill => write!(f, "Kill"),
         }

--- a/quickwit-actors/src/mailbox.rs
+++ b/quickwit-actors/src/mailbox.rs
@@ -114,9 +114,9 @@ pub enum Command {
     /// Semantically, it is similar to SIGCONT.
     Resume,
 
-    /// Stop the actor with a success exit statuscode.
+    /// Stops the actor with a success exit status code.
     ///
-    /// It is similar with `Quit`, except for the resulting exit status.
+    /// It is similar to `Quit`, except for the resulting exit status.
     Success,
 
     /// Asks the actor to update its ObservableState.
@@ -279,7 +279,7 @@ impl<Message: fmt::Debug> Inbox<Message> {
             .collect()
     }
 
-    /// Destroys the inbox and returns the list of pending messages or command.
+    /// Destroys the inbox and returns the list of pending messages or commands.
     ///
     /// Warning this iterator might never be exhausted if there is a living
     /// mailbox associated to it.

--- a/quickwit-actors/src/mailbox.rs
+++ b/quickwit-actors/src/mailbox.rs
@@ -61,9 +61,25 @@ impl<Message> Mailbox<Message> {
     }
 }
 
-pub(crate) enum CommandOrMessage<Message> {
+pub enum CommandOrMessage<Message> {
     Message(Message),
     Command(Command),
+}
+
+impl<Message> CommandOrMessage<Message> {
+    pub fn message(self) -> Option<Message> {
+        match self {
+            CommandOrMessage::Message(message) => Some(message),
+            CommandOrMessage::Command(_) => None,
+        }
+    }
+
+    pub fn command(self) -> Option<Command> {
+        match self {
+            CommandOrMessage::Message(_) => None,
+            CommandOrMessage::Command(command) => Some(command),
+        }
+    }
 }
 
 impl<Message> From<Command> for CommandOrMessage<Message> {
@@ -82,7 +98,7 @@ pub(crate) struct Inner<Message> {
 /// They are similar to UNIX signals.
 ///
 /// They are treated with a higher priority than regular actor messages.
-pub(crate) enum Command {
+pub enum Command {
     /// Temporarily pauses the actor. A paused actor only checks
     /// on its high priority channel and still shows "progress". It appears as
     /// healthy to the supervisor.
@@ -97,6 +113,11 @@ pub(crate) enum Command {
     ///
     /// Semantically, it is similar to SIGCONT.
     Resume,
+
+    /// Stop the actor with a success exit statuscode.
+    ///
+    /// It is similar with `Quit`, except for the resulting exit status.
+    Success,
 
     /// Asks the actor to update its ObservableState.
     /// Since it is a command, it will be treated with a higher priority than
@@ -140,8 +161,9 @@ impl fmt::Debug for Command {
             Command::Pause => write!(f, "Pause"),
             Command::Resume => write!(f, "Resume"),
             Command::Observe(_) => write!(f, "Observe"),
+            Command::Success => write!(f, "Success"),
             Command::Quit => write!(f, "Quit"),
-            Command::Kill => todo!(),
+            Command::Kill => write!(f, "Kill"),
         }
     }
 }
@@ -255,6 +277,14 @@ impl<Message: fmt::Debug> Inbox<Message> {
                 CommandOrMessage::Command(_) => None,
             })
             .collect()
+    }
+
+    /// Destroys the inbox and returns the list of pending messages or command.
+    ///
+    /// Warning this iterator might never be exhausted if there is a living
+    /// mailbox associated to it.
+    pub fn drain_available_message_or_command_for_test(mut self) -> Vec<CommandOrMessage<Message>> {
+        self.rx.drain_all()
     }
 }
 

--- a/quickwit-actors/src/universe.rs
+++ b/quickwit-actors/src/universe.rs
@@ -19,6 +19,8 @@
 
 use std::time::Duration;
 
+use crate::channel_with_priority::Priority;
+use crate::mailbox::{Command, CommandOrMessage};
 use crate::scheduler::{SchedulerMessage, TimeShift};
 use crate::spawn_builder::SpawnBuilder;
 use crate::{Actor, KillSwitch, Mailbox, QueueCapacity, Scheduler};
@@ -89,6 +91,13 @@ impl Universe {
         msg: M,
     ) -> Result<(), crate::SendError> {
         mailbox.send_message(msg).await
+    }
+
+    /// `async` version of `send_success`
+    pub async fn send_success<M>(&self, mailbox: &Mailbox<M>) -> Result<(), crate::SendError> {
+        mailbox
+            .send_with_priority(CommandOrMessage::Command(Command::Success), Priority::Low)
+            .await
     }
 }
 

--- a/quickwit-actors/src/universe.rs
+++ b/quickwit-actors/src/universe.rs
@@ -93,10 +93,17 @@ impl Universe {
         mailbox.send_message(msg).await
     }
 
-    /// `async` version of `send_success`
-    pub async fn send_success<M>(&self, mailbox: &Mailbox<M>) -> Result<(), crate::SendError> {
+    /// Inform an actor to process pending message and then stop processing new messages
+    /// and exit successfully.
+    pub async fn send_exit_with_success<M>(
+        &self,
+        mailbox: &Mailbox<M>,
+    ) -> Result<(), crate::SendError> {
         mailbox
-            .send_with_priority(CommandOrMessage::Command(Command::Success), Priority::Low)
+            .send_with_priority(
+                CommandOrMessage::Command(Command::ExitWithSuccess),
+                Priority::Low,
+            )
             .await
     }
 }

--- a/quickwit-indexing/src/actors/indexer.rs
+++ b/quickwit-indexing/src/actors/indexer.rs
@@ -561,7 +561,7 @@ mod tests {
                 .into(),
             )
             .await?;
-        universe.send_success(&indexer_mailbox).await?;
+        universe.send_exit_with_success(&indexer_mailbox).await?;
         let (exit_status, indexer_counters) = indexer_handle.join().await;
         assert!(exit_status.is_success());
         assert_eq!(

--- a/quickwit-indexing/src/actors/indexer.rs
+++ b/quickwit-indexing/src/actors/indexer.rs
@@ -261,9 +261,6 @@ impl SyncActor for Indexer {
             IndexerMessage::CommitTimeout { split_id } => {
                 self.process_commit_timeout(&split_id, ctx)?;
             }
-            IndexerMessage::EndOfSource => {
-                return Err(ActorExitStatus::Success);
-            }
         }
         Ok(())
     }
@@ -389,7 +386,7 @@ mod tests {
     use super::Indexer;
     use crate::actors::indexer::{record_timestamp, IndexerCounters};
     use crate::actors::IndexerParams;
-    use crate::models::{CommitPolicy, IndexerMessage, RawDocBatch, ScratchDirectory};
+    use crate::models::{CommitPolicy, RawDocBatch, ScratchDirectory};
 
     #[test]
     fn test_record_timestamp() {
@@ -564,9 +561,7 @@ mod tests {
                 .into(),
             )
             .await?;
-        universe
-            .send_message(&indexer_mailbox, IndexerMessage::EndOfSource)
-            .await?;
+        universe.send_success(&indexer_mailbox).await?;
         let (exit_status, indexer_counters) = indexer_handle.join().await;
         assert!(exit_status.is_success());
         assert_eq!(

--- a/quickwit-indexing/src/actors/packager.rs
+++ b/quickwit-indexing/src/actors/packager.rs
@@ -281,7 +281,7 @@ impl SyncActor for Packager {
         if let Some(merge_planner_mailbox) = self.merge_planner_mailbox_opt.as_ref() {
             // We are trying to stop the merge planner.
             // If the merge planner is already dead, this is not an error.
-            let _ = ctx.send_success_blocking(merge_planner_mailbox);
+            let _ = ctx.send_exit_with_success_blocking(merge_planner_mailbox);
         }
         Ok(())
     }
@@ -429,7 +429,7 @@ mod tests {
         let merge_planner_msg = merge_planner_msgs.into_iter().next().unwrap();
         assert!(matches!(
             merge_planner_msg,
-            CommandOrMessage::Command(Command::Success)
+            CommandOrMessage::Command(Command::ExitWithSuccess)
         ));
         Ok(())
     }

--- a/quickwit-indexing/src/actors/pipeline_supervisor.rs
+++ b/quickwit-indexing/src/actors/pipeline_supervisor.rs
@@ -338,7 +338,9 @@ impl IndexingPipelineSupervisor {
                             // Failing to send is fine here.
                             info!("Stopping the merge planner since the packager is dead.");
                             // If the message cannot be sent this is not necessarily an error.
-                            let _ = ctx.send_success(handlers.merge_planner.mailbox()).await;
+                            let _ = ctx
+                                .send_exit_with_success(handlers.merge_planner.mailbox())
+                                .await;
                         }
                     }
                 }

--- a/quickwit-indexing/src/actors/pipeline_supervisor.rs
+++ b/quickwit-indexing/src/actors/pipeline_supervisor.rs
@@ -34,7 +34,7 @@ use crate::actors::merge_split_downloader::MergeSplitDownloader;
 use crate::actors::{
     Indexer, IndexerParams, MergeExecutor, MergePlanner, Packager, Publisher, Uploader,
 };
-use crate::models::{IndexingStatistics, MergePlannerMessage};
+use crate::models::IndexingStatistics;
 use crate::source::{quickwit_supported_sources, SourceActor, SourceConfig};
 use crate::{MergePolicy, StableMultitenantWithTimestampMergePolicy};
 
@@ -338,12 +338,7 @@ impl IndexingPipelineSupervisor {
                             // Failing to send is fine here.
                             info!("Stopping the merge planner since the packager is dead.");
                             // If the message cannot be sent this is not necessarily an error.
-                            let _ = ctx
-                                .send_message(
-                                    handlers.merge_planner.mailbox(),
-                                    MergePlannerMessage::EndWithSuccess,
-                                )
-                                .await;
+                            let _ = ctx.send_success(handlers.merge_planner.mailbox()).await;
                         }
                     }
                 }

--- a/quickwit-indexing/src/actors/publisher.rs
+++ b/quickwit-indexing/src/actors/publisher.rs
@@ -134,7 +134,7 @@ impl AsyncActor for Publisher {
         let _ = ctx
             .send_message(
                 &self.merge_planner_mailbox,
-                MergePlannerMessage::NewSplits(new_splits),
+                MergePlannerMessage { new_splits },
             )
             .await;
         self.counters.num_published_splits += 1;
@@ -257,7 +257,7 @@ mod tests {
         assert_eq!(merge_planner_msgs.len(), 1);
         let merge_planner_msg = merge_planner_msgs.pop().unwrap();
         assert!(
-            matches!(merge_planner_msg, MergePlannerMessage::NewSplits(splits) if splits.len() == 1)
+            matches!(merge_planner_msg, MergePlannerMessage { new_splits } if new_splits.len() == 1)
         )
     }
 }

--- a/quickwit-indexing/src/models/indexer_message.rs
+++ b/quickwit-indexing/src/models/indexer_message.rs
@@ -23,7 +23,6 @@ use crate::models::RawDocBatch;
 pub enum IndexerMessage {
     Batch(RawDocBatch),
     CommitTimeout { split_id: String },
-    EndOfSource,
 }
 
 impl From<RawDocBatch> for IndexerMessage {

--- a/quickwit-indexing/src/models/merge_planner_message.rs
+++ b/quickwit-indexing/src/models/merge_planner_message.rs
@@ -20,7 +20,6 @@
 use quickwit_metastore::SplitMetadata;
 
 #[derive(Debug, Clone)]
-pub enum MergePlannerMessage {
-    NewSplits(Vec<SplitMetadata>),
-    EndWithSuccess,
+pub struct MergePlannerMessage {
+    pub new_splits: Vec<SplitMetadata>,
 }

--- a/quickwit-indexing/src/source/file_source.rs
+++ b/quickwit-indexing/src/source/file_source.rs
@@ -102,7 +102,7 @@ impl Source for FileSource {
         }
         if reached_eof {
             info!("EOF");
-            ctx.send_success(batch_sink).await?;
+            ctx.send_exit_with_success(batch_sink).await?;
             return Err(ActorExitStatus::Success);
         }
         Ok(())
@@ -213,7 +213,7 @@ mod tests {
         let batch = inbox.drain_available_message_or_command_for_test();
         assert!(matches!(
             batch[1],
-            CommandOrMessage::Command(Command::Success)
+            CommandOrMessage::Command(Command::ExitWithSuccess)
         ));
         assert_eq!(batch.len(), 2);
         Ok(())
@@ -270,7 +270,7 @@ mod tests {
         );
         assert!(matches!(
             &msg3,
-            &CommandOrMessage::Command(Command::Success)
+            &CommandOrMessage::Command(Command::ExitWithSuccess)
         ));
         Ok(())
     }

--- a/quickwit-indexing/src/source/vec_source.rs
+++ b/quickwit-indexing/src/source/vec_source.rs
@@ -83,8 +83,7 @@ impl Source for VecSource {
             .collect();
         if line_docs.is_empty() {
             info!("Reached end of source.");
-            ctx.send_message(batch_sink, IndexerMessage::EndOfSource)
-                .await?;
+            ctx.send_success(batch_sink).await?;
             return Err(ActorExitStatus::Success);
         }
         let from_item_idx = self.next_item_idx;
@@ -113,7 +112,7 @@ impl Source for VecSource {
 
 #[cfg(test)]
 mod tests {
-    use quickwit_actors::{create_test_mailbox, Universe};
+    use quickwit_actors::{create_test_mailbox, Command, CommandOrMessage, Universe};
     use serde_json::json;
 
     use super::*;
@@ -143,12 +142,15 @@ mod tests {
         let (actor_termination, last_observation) = vec_source_handle.join().await;
         assert!(actor_termination.is_success());
         assert_eq!(last_observation, json!({"next_item_idx": 100}));
-        let batches = inbox.drain_available_message_for_test();
+        let batches = inbox.drain_available_message_or_command_for_test();
         assert_eq!(batches.len(), 35);
         assert!(
-            matches!(&batches[1], &IndexerMessage::Batch(ref raw_batch) if format!("{:?}", raw_batch.checkpoint_delta) == "∆(partition:(00000000000000000002..00000000000000000005])")
+            matches!(&batches[1], &CommandOrMessage::Message(IndexerMessage::Batch(ref raw_batch)) if format!("{:?}", raw_batch.checkpoint_delta) == "∆(partition:(00000000000000000002..00000000000000000005])")
         );
-        assert!(matches!(&batches[34], &IndexerMessage::EndOfSource));
+        assert!(matches!(
+            &batches[34],
+            &CommandOrMessage::Command(Command::Success)
+        ));
         Ok(())
     }
 

--- a/quickwit-indexing/src/source/vec_source.rs
+++ b/quickwit-indexing/src/source/vec_source.rs
@@ -83,7 +83,7 @@ impl Source for VecSource {
             .collect();
         if line_docs.is_empty() {
             info!("Reached end of source.");
-            ctx.send_success(batch_sink).await?;
+            ctx.send_exit_with_success(batch_sink).await?;
             return Err(ActorExitStatus::Success);
         }
         let from_item_idx = self.next_item_idx;
@@ -149,7 +149,7 @@ mod tests {
         );
         assert!(matches!(
             &batches[34],
-            &CommandOrMessage::Command(Command::Success)
+            &CommandOrMessage::Command(Command::ExitWithSuccess)
         ));
         Ok(())
     }


### PR DESCRIPTION
Two of quickwit actors (the indexer and the merge planner)
have a special message to instruct them to exit and success.

This change makes it into an actual command.

The aim is not just to factorize the logic, it is also to make
it possible for the ParallelActor (in an upcoming PR) to properly
react to this command.

### Description
Describe the proposed changes made in this PR.

### How was this PR tested?
Describe how you tested this PR.
