### PR TITLE
Partitionned search stream

### DIFF
--- a/quickwit-proto/proto/search_api.proto
+++ b/quickwit-proto/proto/search_api.proto
@@ -212,8 +212,6 @@ enum OutputFormat {
     /// Format data by row in ClickHouse binary format.
     /// https://clickhouse.tech/docs/en/interfaces/formats/#rowbinary
     CLICK_HOUSE_ROW_BINARY = 1;
-    ///
-    PARTITIONNED_CLICKHOUSE_ROW_BINARY = 2;
 }
 
 message SearchStreamRequest {

--- a/quickwit-proto/proto/search_api.proto
+++ b/quickwit-proto/proto/search_api.proto
@@ -212,6 +212,8 @@ enum OutputFormat {
     /// Format data by row in ClickHouse binary format.
     /// https://clickhouse.tech/docs/en/interfaces/formats/#rowbinary
     CLICK_HOUSE_ROW_BINARY = 1;
+    ///
+    PARTITIONNED_CLICKHOUSE_ROW_BINARY = 2;
 }
 
 message SearchStreamRequest {
@@ -236,6 +238,9 @@ message SearchStreamRequest {
 
   // Split tag filter
   repeated string tags = 8;
+
+  // The field by which we want to partition
+  optional string partition_by_field = 9;
 }
 
 message LeafSearchStreamRequest {

--- a/quickwit-proto/src/quickwit.rs
+++ b/quickwit-proto/src/quickwit.rs
@@ -213,6 +213,9 @@ pub struct SearchStreamRequest {
     /// Split tag filter
     #[prost(string, repeated, tag = "8")]
     pub tags: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    /// The field by which we want to partition
+    #[prost(string, optional, tag = "9")]
+    pub partition_by_field: ::core::option::Option<::prost::alloc::string::String>,
 }
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -260,6 +263,8 @@ pub enum OutputFormat {
     //// Format data by row in ClickHouse binary format.
     //// https://clickhouse.tech/docs/en/interfaces/formats/#rowbinary
     ClickHouseRowBinary = 1,
+    ////
+    PartitionnedClickhouseRowBinary = 2,
 }
 #[doc = r" Generated client implementations."]
 pub mod search_service_client {

--- a/quickwit-proto/src/quickwit.rs
+++ b/quickwit-proto/src/quickwit.rs
@@ -263,8 +263,6 @@ pub enum OutputFormat {
     //// Format data by row in ClickHouse binary format.
     //// https://clickhouse.tech/docs/en/interfaces/formats/#rowbinary
     ClickHouseRowBinary = 1,
-    ////
-    PartitionnedClickhouseRowBinary = 2,
 }
 #[doc = r" Generated client implementations."]
 pub mod search_service_client {

--- a/quickwit-search/src/cluster_client.rs
+++ b/quickwit-search/src/cluster_client.rs
@@ -262,6 +262,7 @@ mod tests {
             end_timestamp: None,
             fast_field: "fast".to_string(),
             output_format: 0,
+            partition_by_field: None,
             tags: vec![],
         };
         LeafSearchStreamRequest {

--- a/quickwit-search/src/search_stream/collector.rs
+++ b/quickwit-search/src/search_stream/collector.rs
@@ -275,4 +275,3 @@ mod helpers {
         }
     }
 }
-

--- a/quickwit-search/src/search_stream/collector.rs
+++ b/quickwit-search/src/search_stream/collector.rs
@@ -18,6 +18,8 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::collections::HashSet;
+use std::collections::HashMap;
+use std::hash::Hash;
 use std::marker::PhantomData;
 
 use tantivy::collector::{Collector, SegmentCollector};
@@ -191,6 +193,247 @@ impl FastFieldCollectorBuilder {
     pub fn build_u64(&self) -> FastFieldCollector<u64> {
         // TODO: check type
         self.typed_build::<u64>()
+    }
+}
+
+
+#[derive(Clone)]
+pub struct PartionnedFastFieldCollectorBuilder {
+    fast_field_value_type: Type,
+    fast_field_name: String,
+    partition_by_fast_field_value_type: Type,
+    partition_by_fast_field_name: String,
+    timestamp_field_name: Option<String>,
+    timestamp_field: Option<Field>,
+    start_timestamp: Option<i64>,
+    end_timestamp: Option<i64>,
+}
+
+impl PartionnedFastFieldCollectorBuilder {
+    pub fn new(
+        fast_field_value_type: Type,
+        fast_field_name: String,
+        timestamp_field_name: Option<String>,
+        timestamp_field: Option<Field>,
+        start_timestamp: Option<i64>,
+        end_timestamp: Option<i64>,
+        partition_by_fast_field_value_type: Type,
+        partition_by_fast_field_name: String,
+    ) -> crate::Result<Self> {
+        match fast_field_value_type {
+            Type::U64 | Type::I64 => (),
+            _ => {
+                return Err(SearchError::InvalidQuery(format!(
+                    "Fast field type `{:?}` not supported",
+                    fast_field_value_type
+                )));
+            }
+        }
+        Ok(Self {
+            fast_field_value_type,
+            fast_field_name,
+            partition_by_fast_field_value_type,
+            partition_by_fast_field_name,
+            timestamp_field_name,
+            timestamp_field,
+            start_timestamp,
+            end_timestamp,
+        })
+    }
+
+    pub fn value_type(&self) -> (Type, Type) {
+        (
+            self.fast_field_value_type,
+            self.partition_by_fast_field_value_type,
+        )
+    }
+
+    pub fn fast_field_to_warm(&self) -> Vec<String> {
+        if let Some(timestamp_field_name) = &self.timestamp_field_name {
+            vec![
+                timestamp_field_name.clone(),
+                self.fast_field_name.clone(),
+                self.partition_by_fast_field_name.clone(),
+            ]
+        } else {
+            vec![self.fast_field_name.clone()]
+        }
+    }
+
+    pub fn typed_build<TFastValue: FastValue, TPartitionValue: FastValue>(
+        &self,
+    ) -> PartionnedFastFieldCollector<TFastValue, TPartitionValue> {
+        PartionnedFastFieldCollector::<TFastValue, TPartitionValue> {
+            fast_field_to_collect: self.fast_field_name.clone(),
+            partition_by_fast_field: self.partition_by_fast_field_name.clone(),
+            timestamp_field_opt: self.timestamp_field,
+            start_timestamp_opt: self.start_timestamp,
+            end_timestamp_opt: self.end_timestamp,
+            _marker: PhantomData,
+            _marker2: PhantomData,
+        }
+    }
+
+    pub fn build_i64_i64(&self) -> PartionnedFastFieldCollector<i64, i64> {
+        // TODO: check type
+        self.typed_build::<i64, i64>()
+    }
+
+    pub fn build_u64_u64(&self) -> PartionnedFastFieldCollector<u64, u64> {
+        // TODO: check type
+        self.typed_build::<u64, u64>()
+    }
+
+    pub fn build_i64_u64(&self) -> PartionnedFastFieldCollector<i64, u64> {
+        // TODO: check type
+        self.typed_build::<i64, u64>()
+    }
+
+    pub fn build_u64_i64(&self) -> PartionnedFastFieldCollector<u64, i64> {
+        // TODO: check type
+        self.typed_build::<u64, i64>()
+    }
+}
+
+#[derive(Clone)]
+pub struct PartionnedFastFieldCollector<Item: FastValue, PartitionItem: FastValue> {
+    pub fast_field_to_collect: String,
+    pub partition_by_fast_field: String,
+    pub timestamp_field_opt: Option<Field>,
+    pub start_timestamp_opt: Option<i64>,
+    pub end_timestamp_opt: Option<i64>,
+    _marker: PhantomData<Item>,
+    _marker2: PhantomData<PartitionItem>,
+}
+
+pub struct PartitionValues<Item: FastValue, PartitionItem: FastValue> {
+    pub partition_value: PartitionItem,
+    pub fast_field_values: Vec<Item>,
+}
+
+impl<Item: FastValue, PartitionItem: FastValue + Eq + Hash> Collector
+    for PartionnedFastFieldCollector<Item, PartitionItem>
+{
+    type Child = PartitionnedFastFieldSegmentCollector<Item, PartitionItem>;
+    type Fruit = Vec<PartitionValues<Item, PartitionItem>>;
+
+    fn for_segment(
+        &self,
+        _segment_ord: SegmentOrdinal,
+        segment_reader: &SegmentReader,
+    ) -> tantivy::Result<Self::Child> {
+        let timestamp_filter_opt = if let Some(timestamp_field) = self.timestamp_field_opt {
+            TimestampFilter::new(
+                timestamp_field,
+                self.start_timestamp_opt,
+                self.end_timestamp_opt,
+                segment_reader,
+            )?
+        } else {
+            None
+        };
+        let field = segment_reader
+            .schema()
+            .get_field(&self.fast_field_to_collect)
+            .ok_or_else(|| TantivyError::SchemaError("field does not exist".to_owned()))?;
+        // TODO: would be nice to access directly to typed_fast_field_reader
+        let fast_field_slice = segment_reader.fast_fields().fast_field_data(field, 0)?;
+        let fast_field_reader = DynamicFastFieldReader::open(fast_field_slice)?;
+
+        let partition_field = segment_reader
+            .schema()
+            .get_field(&self.partition_by_fast_field)
+            .ok_or_else(|| TantivyError::SchemaError("field does not exist".to_owned()))?;
+        let partition_by_fast_field_slice = segment_reader
+            .fast_fields()
+            .fast_field_data(partition_field, 0)?;
+
+        let partition_by_fast_field_reader =
+            DynamicFastFieldReader::open(partition_by_fast_field_slice)?;
+
+        Ok(PartitionnedFastFieldSegmentCollector::new(
+            fast_field_reader,
+            partition_by_fast_field_reader,
+            timestamp_filter_opt,
+        ))
+    }
+
+    fn requires_scoring(&self) -> bool {
+        // We do not need BM25 scoring in Quickwit.
+        false
+    }
+
+    fn merge_fruits(
+        &self,
+        segment_fruits: Vec<std::collections::HashMap<PartitionItem, Vec<Item>>>,
+    ) -> tantivy::Result<Self::Fruit> {
+        Ok(segment_fruits
+            .into_iter()
+            .flat_map(|e| e.into_iter())
+            .map(|(partition_value, values)| PartitionValues {
+                partition_value,
+                fast_field_values: values,
+            })
+            .collect())
+    }
+}
+
+#[derive(Clone)]
+pub struct PartitionnedFastFieldSegmentCollector<
+    Item: FastValue,
+    PartitionItem: FastValue + Eq + Hash,
+> {
+    fast_field_values: std::collections::HashMap<PartitionItem, Vec<Item>>,
+    fast_field_reader: DynamicFastFieldReader<Item>,
+    partition_by_fast_field_reader: DynamicFastFieldReader<PartitionItem>,
+    timestamp_filter_opt: Option<TimestampFilter>,
+}
+
+impl<Item: FastValue, PartitionItem: FastValue + Eq + Hash>
+    PartitionnedFastFieldSegmentCollector<Item, PartitionItem>
+{
+    pub fn new(
+        fast_field_reader: DynamicFastFieldReader<Item>,
+        partition_by_fast_field_reader: DynamicFastFieldReader<PartitionItem>,
+        timestamp_filter_opt: Option<TimestampFilter>,
+    ) -> Self {
+        Self {
+            fast_field_values: std::collections::HashMap::default(),
+            fast_field_reader,
+            partition_by_fast_field_reader,
+            timestamp_filter_opt,
+        }
+    }
+
+    fn accept_document(&self, doc_id: DocId) -> bool {
+        if let Some(ref timestamp_filter) = self.timestamp_filter_opt {
+            return timestamp_filter.is_within_range(doc_id);
+        }
+        true
+    }
+}
+
+impl<Item: FastValue, PartitionItem: FastValue + Hash + Eq> SegmentCollector
+    for PartitionnedFastFieldSegmentCollector<Item, PartitionItem>
+{
+    type Fruit = HashMap<PartitionItem, Vec<Item>>;
+
+    fn collect(&mut self, doc_id: DocId, _score: Score) {
+        if !self.accept_document(doc_id) {
+            return;
+        }
+        let fast_field_value = self.fast_field_reader.get(doc_id);
+        let fast_field_partition = &self.partition_by_fast_field_reader.get(doc_id);
+        if let Some(values) = self.fast_field_values.get_mut(fast_field_partition) {
+            values.push(fast_field_value);
+        } else {
+            self.fast_field_values
+                .insert(*fast_field_partition, vec![fast_field_value]);
+        }
+    }
+
+    fn harvest(self) -> Self::Fruit {
+        self.fast_field_values
     }
 }
 

--- a/quickwit-search/src/search_stream/collector.rs
+++ b/quickwit-search/src/search_stream/collector.rs
@@ -134,7 +134,7 @@ pub struct PartitionValues<Item: FastValue, PartitionItem: FastValue> {
 impl<Item: FastValue, PartitionItem: FastValue + Eq + Hash> Collector
     for PartionnedFastFieldCollector<Item, PartitionItem>
 {
-    type Child = PartitionnedFastFieldSegmentCollector<Item, PartitionItem>;
+    type Child = PartitionedFastFieldSegmentCollector<Item, PartitionItem>;
     type Fruit = Vec<PartitionValues<Item, PartitionItem>>;
 
     fn for_segment(
@@ -157,7 +157,7 @@ impl<Item: FastValue, PartitionItem: FastValue + Eq + Hash> Collector
             &self.partition_by_fast_field,
         )?;
 
-        Ok(PartitionnedFastFieldSegmentCollector::new(
+        Ok(PartitionedFastFieldSegmentCollector::new(
             fast_field_reader,
             partition_by_fast_field_reader,
             timestamp_filter_opt,
@@ -196,7 +196,7 @@ pub struct PartitionedFastFieldSegmentCollector<
 }
 
 impl<Item: FastValue, PartitionItem: FastValue + Eq + Hash>
-    PartitionnedFastFieldSegmentCollector<Item, PartitionItem>
+    PartitionedFastFieldSegmentCollector<Item, PartitionItem>
 {
     pub fn new(
         fast_field_reader: DynamicFastFieldReader<Item>,
@@ -220,7 +220,7 @@ impl<Item: FastValue, PartitionItem: FastValue + Eq + Hash>
 }
 
 impl<Item: FastValue, PartitionItem: FastValue + Hash + Eq> SegmentCollector
-    for PartitionnedFastFieldSegmentCollector<Item, PartitionItem>
+    for PartitionedFastFieldSegmentCollector<Item, PartitionItem>
 {
     type Fruit = HashMap<PartitionItem, Vec<Item>>;
 

--- a/quickwit-search/src/search_stream/collector.rs
+++ b/quickwit-search/src/search_stream/collector.rs
@@ -185,7 +185,7 @@ impl<Item: FastValue, PartitionItem: FastValue + Eq + Hash> Collector
 }
 
 #[derive(Clone)]
-pub struct PartitionnedFastFieldSegmentCollector<
+pub struct PartitionedFastFieldSegmentCollector<
     Item: FastValue,
     PartitionItem: FastValue + Eq + Hash,
 > {

--- a/quickwit-search/src/search_stream/collector.rs
+++ b/quickwit-search/src/search_stream/collector.rs
@@ -17,8 +17,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use std::collections::HashSet;
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::hash::Hash;
 use std::marker::PhantomData;
 
@@ -196,7 +196,6 @@ impl FastFieldCollectorBuilder {
     }
 }
 
-
 #[derive(Clone)]
 pub struct PartionnedFastFieldCollectorBuilder {
     fast_field_value_type: Type,
@@ -248,16 +247,14 @@ impl PartionnedFastFieldCollectorBuilder {
         )
     }
 
-    pub fn fast_field_to_warm(&self) -> Vec<String> {
+    pub fn fast_field_to_warm(&self) -> HashSet<String> {
+        let mut set = HashSet::new();
+        set.insert(self.fast_field_name.clone());
         if let Some(timestamp_field_name) = &self.timestamp_field_name {
-            vec![
-                timestamp_field_name.clone(),
-                self.fast_field_name.clone(),
-                self.partition_by_fast_field_name.clone(),
-            ]
-        } else {
-            vec![self.fast_field_name.clone()]
+            set.insert(timestamp_field_name.clone());
+            set.insert(self.partition_by_fast_field_name.clone());
         }
+        set
     }
 
     pub fn typed_build<TFastValue: FastValue, TPartitionValue: FastValue>(

--- a/quickwit-search/src/search_stream/collector.rs
+++ b/quickwit-search/src/search_stream/collector.rs
@@ -125,6 +125,7 @@ pub struct PartionnedFastFieldCollector<Item: FastValue, PartitionItem: FastValu
     pub _marker: PhantomData<(Item, PartitionItem)>,
 }
 
+#[derive(Debug, PartialEq, Eq)]
 pub struct PartitionValues<Item: FastValue, PartitionItem: FastValue> {
     pub partition_value: PartitionItem,
     pub fast_field_values: Vec<Item>,

--- a/quickwit-search/src/search_stream/leaf.rs
+++ b/quickwit-search/src/search_stream/leaf.rs
@@ -424,7 +424,7 @@ mod tests {
         let index_config =
             Arc::new(serde_json::from_str::<DefaultIndexConfigBuilder>(index_config)?.build()?);
         let index_id = "single-node-simple";
-        let test_sandbox = TestSandbox::create("single-node-simple", index_config.clone()).await?;
+        let test_sandbox = TestSandbox::create(index_id, index_config.clone()).await?;
 
         let mut docs = vec![];
         let mut filtered_timestamp_values = vec![];
@@ -508,8 +508,8 @@ mod tests {
         }"#;
         let index_config =
             Arc::new(serde_json::from_str::<DefaultIndexConfigBuilder>(index_config)?.build()?);
-        let index_id = "single-node-simple";
-        let test_sandbox = TestSandbox::create("single-node-simple", index_config.clone()).await?;
+        let index_id = "single-node-simple-2";
+        let test_sandbox = TestSandbox::create(index_id, index_config.clone()).await?;
 
         let mut docs = vec![];
         let partition_by_fast_field_values = vec![1, 2, 3, 4, 5];

--- a/quickwit-search/src/search_stream/leaf.rs
+++ b/quickwit-search/src/search_stream/leaf.rs
@@ -219,9 +219,10 @@ async fn leaf_search_stream_single_split(
             }
             _ => {
                 return Err(SearchError::InternalError(
-                    "Mixed types (u64, i64) for fast field and partition field are not supported.".to_owned(),
+                    "Mixed types (u64, i64) for fast field and partition field are not supported."
+                        .to_owned(),
                 ));
-            },
+            }
         };
         Result::<Vec<u8>>::Ok(buffer)
     });

--- a/quickwit-search/src/search_stream/leaf.rs
+++ b/quickwit-search/src/search_stream/leaf.rs
@@ -156,7 +156,7 @@ async fn leaf_search_stream_single_split(
         let mut buffer = Vec::new();
         match m_request_fields.fast_field_types() {
             (Type::I64, None) => {
-                let collected_values = collect_values::<u64>(
+                let collected_values = collect_values::<i64>(
                     &m_request_fields,
                     stream_request.start_timestamp,
                     stream_request.end_timestamp,

--- a/quickwit-search/src/search_stream/leaf.rs
+++ b/quickwit-search/src/search_stream/leaf.rs
@@ -163,7 +163,7 @@ async fn leaf_search_stream_single_split(
                     searcher,
                     query.as_ref(),
                 )?;
-                super::serialize::<u64>(&collected_values, &mut buffer, output_format).map_err(
+                super::serialize::<i64>(&collected_values, &mut buffer, output_format).map_err(
                     |_| {
                         SearchError::InternalError(
                             "Error when serializing i64 during export".to_owned(),

--- a/quickwit-search/src/search_stream/leaf.rs
+++ b/quickwit-search/src/search_stream/leaf.rs
@@ -140,7 +140,7 @@ async fn leaf_search_stream_single_split(
     warmup(
         &*searcher,
         query.as_ref(),
-        &request_fields.fast_fields_for_request(), // FIXME: pass the right vec.
+        &request_fields.fast_fields_for_request(),
     )
     .await?;
 

--- a/quickwit-search/src/search_stream/leaf.rs
+++ b/quickwit-search/src/search_stream/leaf.rs
@@ -550,7 +550,7 @@ mod tests {
         let mut partitions_values = vec![];
         while cursor < buffer.len() {
             let partition_slice: [u8; 8] = buffer[cursor..cursor + 8].try_into().unwrap();
-            let partition = u64::from_le_bytes(partition_slice.try_into().unwrap());
+            let partition = u64::from_le_bytes(partition_slice);
             cursor += 8;
 
             let payload_size_slice: [u8; 8] = buffer[cursor..cursor + 8].try_into().unwrap();

--- a/quickwit-search/src/search_stream/mod.rs
+++ b/quickwit-search/src/search_stream/mod.rs
@@ -156,7 +156,7 @@ mod tests {
             partition_value: 2u64,
             fast_field_values: vec![5u64],
         };
-        super::serialize_partitions::<u64, u64>(&vec![partition_1, partition_2], &mut buffer)
+        super::serialize_partitions::<u64, u64>(&[partition_1, partition_2], &mut buffer)
             .unwrap();
         let expected_buffer: Vec<u8> = vec![
             1u64.to_le_bytes(),

--- a/quickwit-search/src/search_stream/mod.rs
+++ b/quickwit-search/src/search_stream/mod.rs
@@ -156,8 +156,7 @@ mod tests {
             partition_value: 2u64,
             fast_field_values: vec![5u64],
         };
-        super::serialize_partitions::<u64, u64>(&[partition_1, partition_2], &mut buffer)
-            .unwrap();
+        super::serialize_partitions::<u64, u64>(&[partition_1, partition_2], &mut buffer).unwrap();
         let expected_buffer: Vec<u8> = vec![
             1u64.to_le_bytes(),
             16usize.to_le_bytes(),

--- a/quickwit-search/src/search_stream/mod.rs
+++ b/quickwit-search/src/search_stream/mod.rs
@@ -124,7 +124,9 @@ mod helpers {
 
 #[cfg(test)]
 mod tests {
-    use crate::search_stream::{serialize_click_house_row_binary, serialize_csv};
+    use crate::search_stream::{
+        collector::PartitionValues, serialize_click_house_row_binary, serialize_csv,
+    };
 
     #[test]
     fn test_serialize_row_binary() {
@@ -142,5 +144,33 @@ mod tests {
         let mut buffer = Vec::new();
         serialize_csv::<i64>(&[-10i64], &mut buffer).unwrap();
         assert_eq!(buffer, "-10\n".as_bytes());
+    }
+
+    #[test]
+    fn test_serialize_partitions() {
+        let mut buffer = Vec::new();
+        let partition_1 = PartitionValues {
+            partition_value: 1u64,
+            fast_field_values: vec![3u64, 4u64],
+        };
+        let partition_2 = PartitionValues {
+            partition_value: 2u64,
+            fast_field_values: vec![5u64],
+        };
+        super::serialize_partitions::<u64, u64>(&vec![partition_1, partition_2], &mut buffer)
+            .unwrap();
+        let expected_buffer: Vec<u8> = vec![
+            1u64.to_le_bytes(),
+            16usize.to_le_bytes(),
+            3u64.to_le_bytes(),
+            4u64.to_le_bytes(),
+            2u64.to_le_bytes(),
+            8usize.to_le_bytes(),
+            5u64.to_le_bytes(),
+        ]
+        .into_iter()
+        .flatten()
+        .collect();
+        assert_eq!(buffer, expected_buffer);
     }
 }

--- a/quickwit-search/src/search_stream/mod.rs
+++ b/quickwit-search/src/search_stream/mod.rs
@@ -124,9 +124,8 @@ mod helpers {
 
 #[cfg(test)]
 mod tests {
-    use crate::search_stream::{
-        collector::PartitionValues, serialize_click_house_row_binary, serialize_csv,
-    };
+    use crate::search_stream::collector::PartitionValues;
+    use crate::search_stream::{serialize_click_house_row_binary, serialize_csv};
 
     #[test]
     fn test_serialize_row_binary() {

--- a/quickwit-search/src/search_stream/mod.rs
+++ b/quickwit-search/src/search_stream/mod.rs
@@ -42,6 +42,7 @@ pub fn serialize<TFastValue: FastValue + Display>(
     match format {
         OutputFormat::Csv => serialize_csv(values, buffer),
         OutputFormat::ClickHouseRowBinary => serialize_click_house_row_binary(values, buffer),
+        OutputFormat::PartitionnedClickhouseRowBinary => panic!("Not covered yes")
     }
 }
 

--- a/quickwit-search/src/search_stream/root.rs
+++ b/quickwit-search/src/search_stream/root.rs
@@ -51,13 +51,14 @@ pub async fn root_search_stream(
 
     // Create a hash map of SplitMetadata with split id as a key.
     let split_metadata_map: HashMap<String, SplitMetadataAndFooterOffsets> = split_metadata_list
+        .clone()
         .into_iter()
         .map(|metadata| (metadata.split_metadata.split_id.clone(), metadata))
         .collect();
     let leaf_search_jobs: Vec<Job> =
         job_for_splits(&split_metadata_map.keys().collect(), &split_metadata_map);
     let assigned_leaf_search_jobs = client_pool
-        .assign_jobs(leaf_search_jobs, &HashSet::default())
+        .assign_jobs(leaf_search_jobs.clone(), &HashSet::default())
         .await?;
 
     debug!(assigned_leaf_search_jobs=?assigned_leaf_search_jobs, "Assigned leaf search jobs.");
@@ -112,8 +113,10 @@ mod tests {
 
     use quickwit_index_config::WikipediaIndexConfig;
     use quickwit_indexing::mock_split_meta;
-    use quickwit_metastore::checkpoint::Checkpoint;
-    use quickwit_metastore::{IndexMetadata, MockMetastore, SplitState};
+    use quickwit_metastore::{
+        checkpoint::Checkpoint, IndexMetadata, MockMetastore,
+        SplitState,
+    };
     use quickwit_proto::OutputFormat;
     use tokio_stream::wrappers::UnboundedReceiverStream;
 
@@ -130,6 +133,66 @@ mod tests {
             end_timestamp: None,
             fast_field: "timestamp".to_string(),
             output_format: OutputFormat::Csv as i32,
+            partition_by_field: None,
+            tags: vec![],
+        };
+        let mut metastore = MockMetastore::new();
+        metastore
+            .expect_index_metadata()
+            .returning(|_index_id: &str| {
+                Ok(IndexMetadata {
+                    index_id: "test-idx".to_string(),
+                    index_uri: "file:///path/to/index/test-idx".to_string(),
+                    index_config: Arc::new(WikipediaIndexConfig::new()),
+                    checkpoint: Checkpoint::default(),
+                })
+            });
+        metastore.expect_list_splits().returning(
+            |_index_id: &str,
+             _split_state: SplitState,
+             _time_range: Option<Range<i64>>,
+             _tags: &[String]| { Ok(vec![mock_split_meta("split1")]) },
+        );
+        let mut mock_search_service = MockSearchService::new();
+        let (result_sender, result_receiver) = tokio::sync::mpsc::unbounded_channel();
+        result_sender.send(Ok(quickwit_proto::LeafSearchStreamResult {
+            data: b"123".to_vec(),
+            split_id: "split_1".to_string(),
+        }))?;
+        result_sender.send(Ok(quickwit_proto::LeafSearchStreamResult {
+            data: b"456".to_vec(),
+            split_id: "split_1".to_string(),
+        }))?;
+        mock_search_service.expect_leaf_search_stream().return_once(
+            |_leaf_search_req: quickwit_proto::LeafSearchStreamRequest| {
+                Ok(UnboundedReceiverStream::new(result_receiver))
+            },
+        );
+        // The test will hang on indefinitely if we don't drop the receiver.
+        drop(result_sender);
+        let client_pool =
+            Arc::new(SearchClientPool::from_mocks(vec![Arc::new(mock_search_service)]).await?);
+
+        let cluster_client = ClusterClient::new(client_pool.clone());
+        let result: Vec<Bytes> =
+            root_search_stream(&request, &metastore, &cluster_client, &client_pool).await?;
+        assert_eq!(result.len(), 2);
+        assert_eq!(&result[0], &b"123"[..]);
+        assert_eq!(&result[1], &b"456"[..]);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_root_search_stream_single_split_partitionned() -> anyhow::Result<()> {
+        let request = quickwit_proto::SearchStreamRequest {
+            index_id: "test-idx".to_string(),
+            query: "test".to_string(),
+            search_fields: vec!["body".to_string()],
+            start_timestamp: None,
+            end_timestamp: None,
+            fast_field: "timestamp".to_string(),
+            output_format: OutputFormat::Csv as i32,
+            partition_by_field: Some("timestamp".to_string()),
             tags: vec![],
         };
         let mut metastore = MockMetastore::new();
@@ -187,6 +250,7 @@ mod tests {
             end_timestamp: None,
             fast_field: "timestamp".to_string(),
             output_format: OutputFormat::Csv as i32,
+            partition_by_field: None,
             tags: vec![],
         };
         let mut metastore = MockMetastore::new();

--- a/quickwit-search/src/search_stream/root.rs
+++ b/quickwit-search/src/search_stream/root.rs
@@ -113,10 +113,8 @@ mod tests {
 
     use quickwit_index_config::WikipediaIndexConfig;
     use quickwit_indexing::mock_split_meta;
-    use quickwit_metastore::{
-        checkpoint::Checkpoint, IndexMetadata, MockMetastore,
-        SplitState,
-    };
+    use quickwit_metastore::checkpoint::Checkpoint;
+    use quickwit_metastore::{IndexMetadata, MockMetastore, SplitState};
     use quickwit_proto::OutputFormat;
     use tokio_stream::wrappers::UnboundedReceiverStream;
 

--- a/quickwit-serve/src/lib.rs
+++ b/quickwit-serve/src/lib.rs
@@ -198,6 +198,7 @@ mod tests {
             end_timestamp: None,
             fast_field: "timestamp".to_string(),
             output_format: OutputFormat::Csv as i32,
+            partition_by_field: None,
             tags: vec![],
         };
         let mut metastore = MockMetastore::new();

--- a/quickwit-serve/src/rest.rs
+++ b/quickwit-serve/src/rest.rs
@@ -311,7 +311,9 @@ async fn recover_fn(rejection: Rejection) -> Result<impl Reply, Rejection> {
 }
 
 fn from_simple_list<'de, D>(deserializer: D) -> Result<Option<Vec<String>>, D::Error>
-where D: Deserializer<'de> {
+where
+    D: Deserializer<'de>,
+{
     let str_sequence = String::deserialize(deserializer)?;
     Ok(Some(
         str_sequence
@@ -597,6 +599,7 @@ mod tests {
                 end_timestamp: None,
                 fast_field: "external_id".to_string(),
                 output_format: OutputFormat::Csv,
+                partition_by_field: None,
                 tags: None
             }
         );
@@ -622,6 +625,7 @@ mod tests {
                 end_timestamp: None,
                 fast_field: "external_id".to_string(),
                 output_format: OutputFormat::ClickHouseRowBinary,
+                partition_by_field: None,
                 tags: Some(vec!["lang:english".to_string()])
             }
         );
@@ -640,8 +644,7 @@ mod tests {
         let parse_error = rejection.find::<serde_qs::Error>().unwrap();
         assert_eq!(
             parse_error.to_string(),
-            "failed with reason: unknown variant `click_house_row_binary`, expected `csv` or \
-             `clickHouseRowBinary`"
+            "failed with reason: unknown variant `click_house_row_binary`, expected one of `csv`, `clickHouseRowBinary`, `partitionnedClickhouseRowBinary`"
         );
     }
 }

--- a/quickwit-serve/src/rest.rs
+++ b/quickwit-serve/src/rest.rs
@@ -310,9 +310,7 @@ async fn recover_fn(rejection: Rejection) -> Result<impl Reply, Rejection> {
 }
 
 fn from_simple_list<'de, D>(deserializer: D) -> Result<Option<Vec<String>>, D::Error>
-where
-    D: Deserializer<'de>,
-{
+where D: Deserializer<'de> {
     let str_sequence = String::deserialize(deserializer)?;
     Ok(Some(
         str_sequence
@@ -643,7 +641,8 @@ mod tests {
         let parse_error = rejection.find::<serde_qs::Error>().unwrap();
         assert_eq!(
             parse_error.to_string(),
-            "failed with reason: unknown variant `click_house_row_binary`, expected one of `csv`, `clickHouseRowBinary`, `partitionnedClickhouseRowBinary`"
+            "failed with reason: unknown variant `click_house_row_binary`, expected one of `csv`, \
+             `clickHouseRowBinary`, `partitionnedClickhouseRowBinary`"
         );
     }
 }

--- a/quickwit-serve/src/rest.rs
+++ b/quickwit-serve/src/rest.rs
@@ -270,7 +270,6 @@ async fn search_stream<TSearchService: SearchService>(
     info!(index_id=%index_id,request=?request, "search_stream");
     let content_type = match request.output_format {
         OutputFormat::ClickHouseRowBinary => "application/octet-stream",
-        OutputFormat::PartitionnedClickhouseRowBinary => "application/octet-stream",
         OutputFormat::Csv => "text/csv",
     };
     let reply =

--- a/quickwit-serve/src/rest.rs
+++ b/quickwit-serve/src/rest.rs
@@ -217,6 +217,8 @@ pub struct SearchStreamRequestQueryString {
     /// The requested output format.
     #[serde(default)]
     pub output_format: OutputFormat,
+    #[serde(default)]
+    pub partition_by_field: Option<String>,
     /// The tag filter.
     #[serde(default)]
     #[serde(deserialize_with = "from_simple_list")]
@@ -237,6 +239,7 @@ async fn search_stream_endpoint<TSearchService: SearchService>(
         fast_field: search_request.fast_field,
         output_format: search_request.output_format as i32,
         tags: search_request.tags.unwrap_or_default(),
+        partition_by_field: search_request.partition_by_field,
     };
     let data = search_service.root_search_stream(request).await?;
     let stream = stream::iter(data).map(Result::<Bytes, std::io::Error>::Ok);
@@ -267,6 +270,7 @@ async fn search_stream<TSearchService: SearchService>(
     info!(index_id=%index_id,request=?request, "search_stream");
     let content_type = match request.output_format {
         OutputFormat::ClickHouseRowBinary => "application/octet-stream",
+        OutputFormat::PartitionnedClickhouseRowBinary => "application/octet-stream",
         OutputFormat::Csv => "text/csv",
     };
     let reply =

--- a/quickwit-serve/src/rest.rs
+++ b/quickwit-serve/src/rest.rs
@@ -641,8 +641,8 @@ mod tests {
         let parse_error = rejection.find::<serde_qs::Error>().unwrap();
         assert_eq!(
             parse_error.to_string(),
-            "failed with reason: unknown variant `click_house_row_binary`, expected one of `csv`, \
-             `clickHouseRowBinary`, `partitionnedClickhouseRowBinary`"
+            "failed with reason: unknown variant `click_house_row_binary`, expected `csv` or \
+             `clickHouseRowBinary`"
         );
     }
 }


### PR DESCRIPTION
### Description
add's an optional `partitionByFastField` option in the `search/stream` that will partition the values of the requested fast field. 

### How was this PR tested?
Internally for now 
### What's missing : 
* Some refactoring in the collector code because there is a lot of similar looking code 
* Some automated tests for the feature
