### PR TITLE
Retry transient error when fetching watermarks in Kafka source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,6 +136,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
+name = "backoff"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fe17f59a06fe8b87a6fc8bf53bb70b3aba76d7685f432487a68cd5552853625"
+dependencies = [
+ "futures-core",
+ "getrandom 0.2.3",
+ "instant",
+ "pin-project",
+ "rand 0.8.4",
+ "tokio",
+]
+
+[[package]]
 name = "base-x"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2152,6 +2166,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "backoff",
  "byte-unit",
  "fail",
  "flume",

--- a/quickwit-indexing/Cargo.toml
+++ b/quickwit-indexing/Cargo.toml
@@ -12,6 +12,7 @@ documentation = "https://quickwit.io/docs/"
 [dependencies]
 anyhow = "1"
 async-trait = "0.1"
+backoff = { version = "0.3", features = ["tokio"] }
 byte-unit = "4"
 fail = "0.4"
 flume = "0.10"


### PR DESCRIPTION
### Description
Sometimes a partition actually exists but `fetch_watermarks` throws `UnknownPartition` in CI env. I can't pinpoint what the problem exactly is. However, I've read a few things [here](https://github.com/confluentinc/confluent-kafka-python/commit/e2e0d9639b94064adba26d0f8a6c9417ac01a79c#diff-bffdbc99865016864a28a771105a44f1c75cce3b0cc6b16cca5808b9e2918919R424) and [there](https://issues.apache.org/jira/browse/KAFKA-6829) that seem to indicate that the issue comes from `librdkafka`. Retrying seems like the way to go.

### How was this PR tested?
Just unit testing, which is insufficient. Unfortunately, I'm unable to reproduce the error locally. I'm hoping that the spurious error will disappear after this PR is merged.
