### PR TITLE
Publish Docker image to Docker Hub on push to main branch

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+**/*.md
+**/*.txt
+**/.*
+**/Dockerfile
+**/target
+docs
+examples
+Makefile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,5 @@
+name: CI
+
 on:
   pull_request:
   push:
@@ -8,7 +10,6 @@ on:
       - "Cargo.toml"
       - "quickwit-*/**"
 
-name: CI
 
 env:
   RUSTFLAGS: -Dwarnings

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,8 +1,9 @@
-name: coverage
+name: Code coverage
 
 on:
   push:
     branches: [main, run-coverage-workflow]
+
 jobs:
   test:
     name: coverage

--- a/.github/workflows/publish_main_docker_image.yaml
+++ b/.github/workflows/publish_main_docker_image.yaml
@@ -1,0 +1,32 @@
+name: Publish Docker image to Docker Hub (main)
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+      
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: quickwit/quickwit
+      
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/publish_release_docker_image.yaml
+++ b/.github/workflows/publish_release_docker_image.yaml
@@ -1,4 +1,4 @@
-name: dockerhub
+name: Publish Docker image to Docker Hub (release)
 
 on:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: release
+name: Build release packages
 
 on:
   push:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1657,6 +1657,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
+name = "openssl-sys"
+version = "0.9.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69df2d8dfc6ce3aaf44b40dec6f487d5a886516cf6879c49e98e0710f310a058"
+dependencies = [
+ "autocfg 1.0.1",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "opentelemetry"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2619,6 +2632,7 @@ dependencies = [
  "libc",
  "libz-sys",
  "num_enum",
+ "openssl-sys",
  "pkg-config",
 ]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,43 @@
+FROM rust:bullseye AS builder
+
+ARG CARGO_FEATURES=all
+ARG CARGO_PROFILE=release
+
+# Labels
+LABEL maintainer="hello@quickwit.io"
+LABEL org.opencontainers.image.vendor="Quickwit, Inc."
+
+RUN apt-get -y update \
+    && apt-get -y install ca-certificates \
+                          cmake \
+                          libpq-dev \
+                          libpq5  \
+                          libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Required by tonic
+RUN rustup component add rustfmt
+
+COPY . /quickwit
+
+WORKDIR /quickwit
+
+RUN echo "Building workspace with feature(s) '$CARGO_FEATURES' and profile '$CARGO_PROFILE'" \
+    && cargo build \
+        $(test "$CARGO_FEATURES" = "all" && echo "--all-features" || echo "--features $CARGO_FEATURES") \
+        $(test "$CARGO_PROFILE" = "release" && echo "--release") \
+    && echo "Copying binaries to /quickwit/bin" \
+    && mkdir -p /quickwit/bin \
+    && find target/$CARGO_PROFILE -maxdepth 1 -perm /a+x -type f -exec mv {} /quickwit/bin \;
+
+
+FROM debian:bullseye-slim AS quickwit
+
+RUN apt-get -y update \
+    && apt-get -y install ca-certificates \
+                          libpq5  \
+                          libssl1.1 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /quickwit/bin/quickwit /usr/local/bin/quickwit
+ENTRYPOINT ["quickwit"]

--- a/quickwit-indexing/Cargo.toml
+++ b/quickwit-indexing/Cargo.toml
@@ -24,7 +24,7 @@ quickwit-directories = {path = "../quickwit-directories"}
 quickwit-index-config = {path = "../quickwit-index-config", features=["testsuite"]}
 quickwit-metastore = {path = "../quickwit-metastore" }
 quickwit-storage = { version = "0.1.0", path = "../quickwit-storage" }
-rdkafka = { version = "0.26", features = ["cmake-build"], optional = true }
+rdkafka = { version = "0.26", features = ["cmake-build", "ssl"], optional = true }
 serde = "1"
 serde_json = "1"
 tantivy = { git= "https://github.com/quickwit-inc/tantivy", rev="a622e2f"}


### PR DESCRIPTION
### Description
Publish Docker image to Docker Hub at `quickwit/quickwit:main` on push to main branch. 

### How was this PR tested?
- [x] Built Docker image locally.
- [x] Ensured image is correctly published