### PR TITLE
Rename `FetchDocsResult` to `FetchDocsResponse`

### DIFF
--- a/quickwit-proto/proto/search_api.proto
+++ b/quickwit-proto/proto/search_api.proto
@@ -41,7 +41,7 @@ service SearchService {
 
   /// Fetches the documents contents from the document store.
   /// This methods takes `PartialHit`s and returns `Hit`s.
-  rpc FetchDocs(FetchDocsRequest) returns (FetchDocsResult);
+  rpc FetchDocs(FetchDocsRequest) returns (FetchDocsResponse);
 
   // Perform a leaf stream on a given set of splits.
   rpc LeafSearchStream(LeafSearchStreamRequest) returns (stream LeafSearchStreamResult);
@@ -197,7 +197,7 @@ message FetchDocsRequest {
   string index_uri = 4;
 }
 
-message FetchDocsResult {
+message FetchDocsResponse {
   // List of complete hits.
   repeated Hit hits = 1;
 }

--- a/quickwit-proto/src/quickwit.rs
+++ b/quickwit-proto/src/quickwit.rs
@@ -181,7 +181,7 @@ pub struct FetchDocsRequest {
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct FetchDocsResult {
+pub struct FetchDocsResponse {
     /// List of complete hits.
     #[prost(message, repeated, tag = "1")]
     pub hits: ::prost::alloc::vec::Vec<Hit>,
@@ -366,7 +366,7 @@ pub mod search_service_client {
         pub async fn fetch_docs(
             &mut self,
             request: impl tonic::IntoRequest<super::FetchDocsRequest>,
-        ) -> Result<tonic::Response<super::FetchDocsResult>, tonic::Status> {
+        ) -> Result<tonic::Response<super::FetchDocsResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(
                     tonic::Code::Unknown,
@@ -432,7 +432,7 @@ pub mod search_service_server {
         async fn fetch_docs(
             &self,
             request: tonic::Request<super::FetchDocsRequest>,
-        ) -> Result<tonic::Response<super::FetchDocsResult>, tonic::Status>;
+        ) -> Result<tonic::Response<super::FetchDocsResponse>, tonic::Status>;
         #[doc = "Server streaming response type for the LeafSearchStream method."]
         type LeafSearchStreamStream: futures_core::Stream<Item = Result<super::LeafSearchStreamResult, tonic::Status>>
             + Send
@@ -549,7 +549,7 @@ pub mod search_service_server {
                     #[allow(non_camel_case_types)]
                     struct FetchDocsSvc<T: SearchService>(pub Arc<T>);
                     impl<T: SearchService> tonic::server::UnaryService<super::FetchDocsRequest> for FetchDocsSvc<T> {
-                        type Response = super::FetchDocsResult;
+                        type Response = super::FetchDocsResponse;
                         type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,

--- a/quickwit-search/src/client.rs
+++ b/quickwit-search/src/client.rs
@@ -33,7 +33,7 @@ use tracing::*;
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 use crate::error::parse_grpc_error;
-use crate::{SearchError, SearchService};
+use crate::SearchService;
 
 struct MetadataMap<'a>(&'a mut tonic::metadata::MetadataMap);
 
@@ -107,7 +107,7 @@ impl SearchServiceClient {
     pub async fn root_search(
         &mut self,
         request: quickwit_proto::SearchRequest,
-    ) -> Result<quickwit_proto::SearchResponse, SearchError> {
+    ) -> crate::Result<quickwit_proto::SearchResponse> {
         match &mut self.client_impl {
             SearchServiceClientImpl::Grpc(grpc_client) => {
                 let tonic_request = Request::new(request);
@@ -125,7 +125,7 @@ impl SearchServiceClient {
     pub async fn leaf_search(
         &mut self,
         request: quickwit_proto::LeafSearchRequest,
-    ) -> Result<quickwit_proto::LeafSearchResponse, SearchError> {
+    ) -> crate::Result<quickwit_proto::LeafSearchResponse> {
         match &mut self.client_impl {
             SearchServiceClientImpl::Grpc(grpc_client) => {
                 let mut tonic_request = Request::new(request);
@@ -209,7 +209,7 @@ impl SearchServiceClient {
     pub async fn fetch_docs(
         &mut self,
         request: quickwit_proto::FetchDocsRequest,
-    ) -> Result<quickwit_proto::FetchDocsResult, SearchError> {
+    ) -> crate::Result<quickwit_proto::FetchDocsResponse> {
         match &mut self.client_impl {
             SearchServiceClientImpl::Grpc(grpc_client) => {
                 let mut tonic_request = Request::new(request);

--- a/quickwit-search/src/cluster_client.rs
+++ b/quickwit-search/src/cluster_client.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 
 use futures::StreamExt;
 use quickwit_proto::{
-    FetchDocsRequest, FetchDocsResult, LeafSearchRequest, LeafSearchResponse,
+    FetchDocsRequest, FetchDocsResponse, LeafSearchRequest, LeafSearchResponse,
     LeafSearchStreamRequest, LeafSearchStreamResult,
 };
 use tokio::sync::mpsc::error::SendError;
@@ -43,16 +43,16 @@ pub struct ClusterClient {
 }
 
 impl ClusterClient {
-    /// Instanciate ClusterClient.
+    /// Instantiates [`ClusterClient`].
     pub fn new(client_pool: Arc<SearchClientPool>) -> Self {
         Self { client_pool }
     }
 
-    /// Fetch docs with retry on another node client.
+    /// Fetches docs with retry on another node client.
     pub async fn fetch_docs(
         &self,
         placed_request: (FetchDocsRequest, SearchServiceClient),
-    ) -> Result<FetchDocsResult, SearchError> {
+    ) -> crate::Result<FetchDocsResponse> {
         let (request, mut client) = placed_request;
         let mut result = client.fetch_docs(request.clone()).await;
         let retry_policy = DefaultRetryPolicy {};
@@ -71,7 +71,7 @@ impl ClusterClient {
     pub async fn leaf_search(
         &self,
         placed_request: (LeafSearchRequest, SearchServiceClient),
-    ) -> Result<LeafSearchResponse, SearchError> {
+    ) -> crate::Result<LeafSearchResponse> {
         let (request, mut client) = placed_request;
         let mut result = client.leaf_search(request.clone()).await;
         let retry_policy = LeafSearchRetryPolicy {};
@@ -91,7 +91,7 @@ impl ClusterClient {
     pub async fn leaf_search_stream(
         &self,
         placed_request: (LeafSearchStreamRequest, SearchServiceClient),
-    ) -> UnboundedReceiverStream<Result<LeafSearchStreamResult, SearchError>> {
+    ) -> UnboundedReceiverStream<crate::Result<LeafSearchStreamResult>> {
         let (request, mut client) = placed_request;
         // We need a dedicated channel to send results with retry. First we send only the successful
         // responses and and ignore errors. If there are some errors, we make one retry and
@@ -134,9 +134,9 @@ impl ClusterClient {
 
 // Merge initial leaf search results with results obtained from a retry.
 fn merge_leaf_search_results(
-    initial_response_result: Result<LeafSearchResponse, SearchError>,
-    retry_response_result: Result<LeafSearchResponse, SearchError>,
-) -> Result<LeafSearchResponse, SearchError> {
+    initial_response_result: crate::Result<LeafSearchResponse>,
+    retry_response_result: crate::Result<LeafSearchResponse>,
+) -> crate::Result<LeafSearchResponse> {
     match (initial_response_result, retry_response_result) {
         (Ok(mut initial_response), Ok(mut retry_response)) => {
             initial_response
@@ -162,10 +162,10 @@ fn merge_leaf_search_results(
 // If `send_error` is false, errors are ignored and not forwarded. This is
 // useful if you want to make a retry before propagating errors.
 async fn forward_leaf_search_stream(
-    mut stream: UnboundedReceiverStream<Result<LeafSearchStreamResult, SearchError>>,
+    mut stream: UnboundedReceiverStream<crate::Result<LeafSearchStreamResult>>,
     sender: UnboundedSender<Result<LeafSearchStreamResult, SearchError>>,
     send_error: bool,
-) -> Result<SuccessfullSplitIds, SendError<Result<LeafSearchStreamResult, SearchError>>> {
+) -> Result<SuccessfullSplitIds, SendError<crate::Result<LeafSearchStreamResult>>> {
     let mut successful_split_ids: Vec<String> = Vec::new();
     while let Some(result) = stream.next().await {
         match result {
@@ -290,7 +290,7 @@ mod tests {
         mock_service
             .expect_fetch_docs()
             .return_once(|_: quickwit_proto::FetchDocsRequest| {
-                Ok(quickwit_proto::FetchDocsResult { hits: vec![] })
+                Ok(quickwit_proto::FetchDocsResponse { hits: vec![] })
             });
         let client_pool =
             Arc::new(SearchClientPool::from_mocks(vec![Arc::new(mock_service)]).await?);
@@ -322,7 +322,7 @@ mod tests {
         mock_service_2
             .expect_fetch_docs()
             .return_once(|_: quickwit_proto::FetchDocsRequest| {
-                Ok(quickwit_proto::FetchDocsResult { hits: vec![] })
+                Ok(quickwit_proto::FetchDocsResponse { hits: vec![] })
             });
         let client_pool = Arc::new(
             SearchClientPool::from_mocks(vec![Arc::new(mock_service_1), Arc::new(mock_service_2)])

--- a/quickwit-search/src/lib.rs
+++ b/quickwit-search/src/lib.rs
@@ -175,7 +175,7 @@ pub async fn single_node_search(
     )
     .await
     .context("Failed to perform leaf search.")?;
-    let fetch_docs_result = fetch_docs(
+    let fetch_docs_response = fetch_docs(
         leaf_search_response.partial_hits,
         index_storage,
         &split_metadata,
@@ -185,7 +185,7 @@ pub async fn single_node_search(
     let elapsed = start_instant.elapsed();
     Ok(SearchResponse {
         num_hits: leaf_search_response.num_hits,
-        hits: fetch_docs_result.hits,
+        hits: fetch_docs_response.hits,
         elapsed_time_micros: elapsed.as_micros() as u64,
         errors: vec![],
     })

--- a/quickwit-search/src/retry/mod.rs
+++ b/quickwit-search/src/retry/mod.rs
@@ -119,7 +119,7 @@ mod tests {
     use std::net::SocketAddr;
     use std::sync::Arc;
 
-    use quickwit_proto::{FetchDocsRequest, FetchDocsResult, SplitIdAndFooterOffsets};
+    use quickwit_proto::{FetchDocsRequest, FetchDocsResponse, SplitIdAndFooterOffsets};
 
     use crate::retry::{retry_client, DefaultRetryPolicy, RetryPolicy};
     use crate::{MockSearchService, SearchClientPool, SearchError};
@@ -141,7 +141,7 @@ mod tests {
     fn test_should_retry_on_error() -> anyhow::Result<()> {
         let retry_policy = DefaultRetryPolicy {};
         let request = mock_doc_request();
-        let result = Result::<(), SearchError>::Err(SearchError::InternalError("test".to_string()));
+        let result = crate::Result::<()>::Err(SearchError::InternalError("test".to_string()));
         let retry = retry_policy
             .retry_request(&request, result.as_ref())
             .is_some();
@@ -153,7 +153,7 @@ mod tests {
     fn test_should_not_retry_if_result_is_ok() -> anyhow::Result<()> {
         let retry_policy = DefaultRetryPolicy {};
         let request = mock_doc_request();
-        let result = Result::<FetchDocsResult, SearchError>::Ok(FetchDocsResult { hits: vec![] });
+        let result = crate::Result::<FetchDocsResponse>::Ok(FetchDocsResponse { hits: vec![] });
         let retry = retry_policy
             .retry_request(&request, result.as_ref())
             .is_some();

--- a/quickwit-search/src/root.rs
+++ b/quickwit-search/src/root.rs
@@ -24,7 +24,7 @@ use futures::{StreamExt, TryStreamExt};
 use itertools::Itertools;
 use quickwit_metastore::{Metastore, SplitMetadata, SplitMetadataAndFooterOffsets};
 use quickwit_proto::{
-    FetchDocsRequest, FetchDocsResult, LeafSearchRequest, LeafSearchResponse, PartialHit,
+    FetchDocsRequest, FetchDocsResponse, LeafSearchRequest, LeafSearchResponse, PartialHit,
     SearchRequest, SearchResponse,
 };
 use tantivy::collector::Collector;
@@ -118,7 +118,7 @@ pub async fn root_search(
     let assigned_doc_fetch_jobs = client_pool
         .assign_jobs(fetch_docs_req_jobs, &HashSet::new())
         .await?;
-    let fetch_docs_responses: Vec<FetchDocsResult> =
+    let fetch_docs_responses: Vec<FetchDocsResponse> =
         futures::stream::iter(assigned_doc_fetch_jobs.into_iter())
             .map(|(client, client_jobs)| {
                 let doc_request = jobs_to_fetch_docs_request(
@@ -325,7 +325,7 @@ mod tests {
         );
         mock_search_service.expect_fetch_docs().returning(
             |fetch_docs_req: quickwit_proto::FetchDocsRequest| {
-                Ok(quickwit_proto::FetchDocsResult {
+                Ok(quickwit_proto::FetchDocsResponse {
                     hits: get_doc_for_fetch_req(fetch_docs_req),
                 })
             },
@@ -387,7 +387,7 @@ mod tests {
         );
         mock_search_service1.expect_fetch_docs().returning(
             |fetch_docs_req: quickwit_proto::FetchDocsRequest| {
-                Ok(quickwit_proto::FetchDocsResult {
+                Ok(quickwit_proto::FetchDocsResponse {
                     hits: get_doc_for_fetch_req(fetch_docs_req),
                 })
             },
@@ -405,7 +405,7 @@ mod tests {
         );
         mock_search_service2.expect_fetch_docs().returning(
             |fetch_docs_req: quickwit_proto::FetchDocsRequest| {
-                Ok(quickwit_proto::FetchDocsResult {
+                Ok(quickwit_proto::FetchDocsResponse {
                     hits: get_doc_for_fetch_req(fetch_docs_req),
                 })
             },
@@ -477,7 +477,7 @@ mod tests {
 
         mock_search_service1.expect_fetch_docs().returning(
             |fetch_docs_req: quickwit_proto::FetchDocsRequest| {
-                Ok(quickwit_proto::FetchDocsResult {
+                Ok(quickwit_proto::FetchDocsResponse {
                     hits: get_doc_for_fetch_req(fetch_docs_req),
                 })
             },
@@ -517,7 +517,7 @@ mod tests {
             });
         mock_search_service2.expect_fetch_docs().returning(
             |fetch_docs_req: quickwit_proto::FetchDocsRequest| {
-                Ok(quickwit_proto::FetchDocsResult {
+                Ok(quickwit_proto::FetchDocsResponse {
                     hits: get_doc_for_fetch_req(fetch_docs_req),
                 })
             },
@@ -604,7 +604,7 @@ mod tests {
             });
         mock_search_service1.expect_fetch_docs().returning(
             |fetch_docs_req: quickwit_proto::FetchDocsRequest| {
-                Ok(quickwit_proto::FetchDocsResult {
+                Ok(quickwit_proto::FetchDocsResponse {
                     hits: get_doc_for_fetch_req(fetch_docs_req),
                 })
             },
@@ -643,7 +643,7 @@ mod tests {
             });
         mock_search_service2.expect_fetch_docs().returning(
             |fetch_docs_req: quickwit_proto::FetchDocsRequest| {
-                Ok(quickwit_proto::FetchDocsResult {
+                Ok(quickwit_proto::FetchDocsResponse {
                     hits: get_doc_for_fetch_req(fetch_docs_req),
                 })
             },
@@ -722,7 +722,7 @@ mod tests {
             });
         mock_search_service1.expect_fetch_docs().returning(
             |fetch_docs_req: quickwit_proto::FetchDocsRequest| {
-                Ok(quickwit_proto::FetchDocsResult {
+                Ok(quickwit_proto::FetchDocsResponse {
                     hits: get_doc_for_fetch_req(fetch_docs_req),
                 })
             },
@@ -842,7 +842,7 @@ mod tests {
         );
         mock_search_service1.expect_fetch_docs().returning(
             |fetch_docs_req: quickwit_proto::FetchDocsRequest| {
-                Ok(quickwit_proto::FetchDocsResult {
+                Ok(quickwit_proto::FetchDocsResponse {
                     hits: get_doc_for_fetch_req(fetch_docs_req),
                 })
             },
@@ -928,7 +928,7 @@ mod tests {
         );
         mock_search_service1.expect_fetch_docs().returning(
             |fetch_docs_req: quickwit_proto::FetchDocsRequest| {
-                Ok(quickwit_proto::FetchDocsResult {
+                Ok(quickwit_proto::FetchDocsResponse {
                     hits: get_doc_for_fetch_req(fetch_docs_req),
                 })
             },

--- a/quickwit-search/src/service.rs
+++ b/quickwit-search/src/service.rs
@@ -24,7 +24,7 @@ use bytes::Bytes;
 use quickwit_index_config::IndexConfig;
 use quickwit_metastore::Metastore;
 use quickwit_proto::{
-    FetchDocsRequest, FetchDocsResult, LeafSearchRequest, LeafSearchResponse,
+    FetchDocsRequest, FetchDocsResponse, LeafSearchRequest, LeafSearchResponse,
     LeafSearchStreamRequest, LeafSearchStreamResult, SearchRequest, SearchResponse,
     SearchStreamRequest,
 };
@@ -71,7 +71,7 @@ pub trait SearchService: 'static + Send + Sync {
 
     /// Fetches the documents contents from the document store.
     /// This methods takes `PartialHit`s and returns `Hit`s.
-    async fn fetch_docs(&self, request: FetchDocsRequest) -> crate::Result<FetchDocsResult>;
+    async fn fetch_docs(&self, request: FetchDocsRequest) -> crate::Result<FetchDocsResponse>;
 
     /// Performs a root search returning a receiver for streaming
     async fn root_search_stream(&self, request: SearchStreamRequest) -> crate::Result<Vec<Bytes>>;
@@ -153,19 +153,19 @@ impl SearchService for SearchServiceImpl {
     async fn fetch_docs(
         &self,
         fetch_docs_request: FetchDocsRequest,
-    ) -> crate::Result<FetchDocsResult> {
+    ) -> crate::Result<FetchDocsResponse> {
         let storage = self
             .storage_resolver
             .resolve(&fetch_docs_request.index_uri)?;
 
-        let fetch_docs_result = fetch_docs(
+        let fetch_docs_response = fetch_docs(
             fetch_docs_request.partial_hits,
             storage,
             &fetch_docs_request.split_metadata,
         )
         .await?;
 
-        Ok(fetch_docs_result)
+        Ok(fetch_docs_response)
     }
 
     async fn root_search_stream(

--- a/quickwit-serve/src/grpc_adapter/search_adapter.rs
+++ b/quickwit-serve/src/grpc_adapter/search_adapter.rs
@@ -107,17 +107,17 @@ impl grpc::SearchService for GrpcSearchAdapter {
     async fn fetch_docs(
         &self,
         request: tonic::Request<quickwit_proto::FetchDocsRequest>,
-    ) -> Result<tonic::Response<quickwit_proto::FetchDocsResult>, tonic::Status> {
+    ) -> Result<tonic::Response<quickwit_proto::FetchDocsResponse>, tonic::Status> {
         let parent_cx =
             global::get_text_map_propagator(|prop| prop.extract(&MetadataMap(request.metadata())));
         Span::current().set_parent(parent_cx);
         let fetch_docs_request = request.into_inner();
-        let fetch_docs_result = self
+        let fetch_docs_response = self
             .0
             .fetch_docs(fetch_docs_request)
             .await
             .map_err(Into::<tonic::Status>::into)?;
-        Ok(tonic::Response::new(fetch_docs_result))
+        Ok(tonic::Response::new(fetch_docs_response))
     }
 
     type LeafSearchStreamStream = std::pin::Pin<


### PR DESCRIPTION
### Description
Rename `FetchDocsResult` to `FetchDocsResponse`.

### How was this PR tested?
Compiled locally.
