### PR TITLE
Define a default set of release-flags.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           toolchain: stable
       - name: Build binary
-        run: cargo build --release
+        run: cargo build --release --features release-feature-set
       - name: Rename artifact
         run: mv target/release/${{ matrix.artifact_name }} ${{ env.ASSET_FULL_NAME }}
       - name: Compress artifact
@@ -62,8 +62,8 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           use-cross: true
-          command: build 
-          args: --release --target aarch64-unknown-linux-gnu
+          command: build
+          args: --release --features release-feature-set --target aarch64-unknown-linux-gnu
       - name: Rename artifact
         run: mv target/aarch64-unknown-linux-gnu/release/quickwit ${{ env.ASSET_FULL_NAME }}
       - name: Compress artifact
@@ -94,7 +94,7 @@ jobs:
         with:
           use-cross: true
           command: build
-          args: --release --target x86_64-unknown-linux-musl
+          args: --release --features release-feature-set --target x86_64-unknown-linux-musl
       - name: Rename artifact
         run: mv target/x86_64-unknown-linux-musl/release/quickwit ${{ env.ASSET_FULL_NAME }}
       - name: Compress artifact
@@ -125,7 +125,7 @@ jobs:
         with:
           use-cross: true
           command: build
-          args: --release --target aarch64-unknown-linux-musl
+          args: --release --features release-feature-set --target aarch64-unknown-linux-musl
       - name: Rename artifact
         run: mv target/aarch64-unknown-linux-musl/release/quickwit ${{ env.ASSET_FULL_NAME }}
       - name: Compress artifact
@@ -156,7 +156,7 @@ jobs:
         with:
           use-cross: true
           command: build
-          args: --release --target armv7-unknown-linux-gnueabihf
+          args: --release --features release-feature-set --target armv7-unknown-linux-gnueabihf
       - name: Rename artifact
         run: mv target/armv7-unknown-linux-gnueabihf/release/quickwit ${{ env.ASSET_FULL_NAME }}
       - name: Compress artifact
@@ -187,7 +187,7 @@ jobs:
         with:
           use-cross: true
           command: build
-          args: --release --target armv7-unknown-linux-musleabihf
+          args: --release --features release-feature-set --target armv7-unknown-linux-musleabihf
       - name: Rename artifact
         run: mv target/armv7-unknown-linux-musleabihf/release/quickwit ${{ env.ASSET_FULL_NAME }}
       - name: Compress artifact
@@ -218,7 +218,7 @@ jobs:
         with:
           use-cross: true
           command: build
-          args: --release --target x86_64-unknown-linux-gnu
+          args: --release --features release-feature-set --target x86_64-unknown-linux-gnu
       - name: Rename artifact
         run: mv target/x86_64-unknown-linux-gnu/release/quickwit ${{ env.ASSET_FULL_NAME }}
       - name: Compress artifact

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ WORKDIR /quickwit
 
 RUN echo "Building workspace with feature(s) '$CARGO_FEATURES' and profile '$CARGO_PROFILE'" \
     && cargo build \
-        $(echo "--features $CARGO_FEATURES") \
+        --features $CARGO_FEATURES \
         $(test "$CARGO_PROFILE" = "release" && echo "--release") \
     && echo "Copying binaries to /quickwit/bin" \
     && mkdir -p /quickwit/bin \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM rust:bullseye AS builder
 
-ARG CARGO_FEATURES=all
+ARG CARGO_FEATURES=release-feature-set
 ARG CARGO_PROFILE=release
 
 # Labels
@@ -24,7 +24,7 @@ WORKDIR /quickwit
 
 RUN echo "Building workspace with feature(s) '$CARGO_FEATURES' and profile '$CARGO_PROFILE'" \
     && cargo build \
-        $(test "$CARGO_FEATURES" = "all" && echo "--all-features" || echo "--features $CARGO_FEATURES") \
+        $(echo "--features $CARGO_FEATURES") \
         $(test "$CARGO_PROFILE" = "release" && echo "--release") \
     && echo "Copying binaries to /quickwit/bin" \
     && mkdir -p /quickwit/bin \

--- a/quickwit-cli/Cargo.toml
+++ b/quickwit-cli/Cargo.toml
@@ -51,3 +51,4 @@ serial_test = "0.5.1"
 
 [features]
 ci-test = []
+release-feature-set = ["quickwit-metastore/postgres", "quickwit-indexing/kafka"]


### PR DESCRIPTION
This works by adding a `release-feature-set` feature in quickwit-cli.

- `--all-features` does not work with `cargo install`
- Release binaries github actions now rely on `release-feature-set`
- Docker container also relies on `release-feature-set`
