### PR TITLE
Pass any client config parameters through source parameters

### DIFF
--- a/quickwit-indexing/src/source/mod.rs
+++ b/quickwit-indexing/src/source/mod.rs
@@ -174,9 +174,12 @@ pub fn quickwit_supported_sources() -> &'static SourceLoader {
 ///     "source_id": "my-kafka-source",
 ///     "source_type": "kafka",
 ///     "params": {
-///         "bootstrap_servers": "localhost:9092",
-///         "group_id": "my-kafka-source-consumer-group",
-///         "topic": "my-kafka-source-topic"
+///         "topic": "my-kafka-source-topic",
+///         "client_log_level": "warn",
+///         "client_params": {
+///             "bootstrap.servers": "localhost:9092",
+///             "group.id": "my-kafka-source-consumer-group"
+///         }
 ///     }
 /// }
 /// ```


### PR DESCRIPTION
### Description
The current implementation prevents from setting Kafka parameters other than `bootstrap.servers`, `group.id`, and `enable.partition.eof`. This PR allows passing any parameter via `client_params`.

### How was this PR tested?
Unit tests
