### PR TITLE
Bugfix packager state

### DIFF
--- a/quickwit-actors/src/actor_handle.rs
+++ b/quickwit-actors/src/actor_handle.rs
@@ -72,7 +72,7 @@ impl<A: Actor> Supervisable for ActorHandle<A> {
     }
 
     fn health(&self) -> Health {
-        let actor_state = self.actor_context.state();
+        let actor_state = self.state();
         if actor_state == ActorState::Exit {
             let actor_exit_status = self
                 .actor_exit_status
@@ -111,6 +111,10 @@ impl<A: Actor> ActorHandle<A> {
             join_handle,
             actor_exit_status,
         }
+    }
+
+    pub fn state(&self) -> ActorState {
+        self.actor_context.state()
     }
 
     /// Process all of the pending messages, and returns a snapshot of

--- a/quickwit-actors/src/spawn_builder.rs
+++ b/quickwit-actors/src/spawn_builder.rs
@@ -17,6 +17,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+use tracing::info;
+
 use crate::async_actor::spawn_async_actor;
 use crate::mailbox::Inbox;
 use crate::scheduler::SchedulerMessage;
@@ -90,6 +92,7 @@ impl<A: AsyncActor> SpawnBuilder<A> {
     /// Spawns an async actor.
     pub fn spawn_async(self) -> (Mailbox<A::Message>, ActorHandle<A>) {
         let (actor, ctx, inbox) = self.create_actor_context_and_inbox();
+        info!(actor = ctx.actor_instance_id(), "spawn-async");
         let mailbox = ctx.mailbox().clone();
         let actor_handle = spawn_async_actor(actor, ctx, inbox);
         (mailbox, actor_handle)
@@ -100,6 +103,7 @@ impl<A: SyncActor> SpawnBuilder<A> {
     /// Spawns an async actor.
     pub fn spawn_sync(self) -> (Mailbox<A::Message>, ActorHandle<A>) {
         let (actor, ctx, inbox) = self.create_actor_context_and_inbox();
+        info!(actor = ctx.actor_instance_id(), "spawn-sync");
         let mailbox = ctx.mailbox().clone();
         let actor_handle = spawn_sync_actor(actor, ctx, inbox);
         (mailbox, actor_handle)

--- a/quickwit-indexing/src/actors/pipeline_supervisor.rs
+++ b/quickwit-indexing/src/actors/pipeline_supervisor.rs
@@ -22,8 +22,8 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use quickwit_actors::{
-    create_mailbox, Actor, ActorContext, ActorExitStatus, ActorHandle, AsyncActor, Health,
-    KillSwitch, QueueCapacity, Supervisable,
+    create_mailbox, Actor, ActorContext, ActorExitStatus, ActorHandle, ActorState, AsyncActor,
+    Health, KillSwitch, QueueCapacity, Supervisable,
 };
 use quickwit_metastore::{Metastore, SplitState};
 use quickwit_storage::StorageUriResolver;
@@ -345,8 +345,9 @@ impl IndexingPipelineSupervisor {
                         // packager panics, the finalizer may never be
                         // called, so we defensively send the message if we
                         // detect that the packager is not running, while the merge planner is.
-                        if handlers.packager.health() != Health::Healthy
-                            && handlers.merge_planner.health() == Health::Healthy
+
+                        if handlers.packager.state() != ActorState::Running
+                            && handlers.merge_planner.state() == ActorState::Running
                         {
                             // Failing to send is fine here.
                             info!("Stopping the merge planner since the packager is dead.");


### PR DESCRIPTION
Bugfix: Stopping the merge planner cannot rely on healthcheck
The mechanic that decide whether the merge planner should be
stopped is broken.

Indeed, it relies on the idea that the packager healthcheck is faulty
while the merge_planner is healthy and running, but these calls
happen right after the overall healthcheck has been called.

The progress is therefore always reset at this point and the condition
never triggers.
