### PR TITLE
Customize source actor name

### DIFF
--- a/quickwit-actors/src/actor.rs
+++ b/quickwit-actors/src/actor.rs
@@ -132,9 +132,9 @@ pub trait Actor: Send + Sync + 'static {
         QueueCapacity::Unbounded
     }
 
-    /// Extracts an observable state. Useful for unit test, and admin UI.
+    /// Extracts an observable state. Useful for unit tests, and admin UI.
     ///
-    /// This function should return fast.
+    /// This function should return quickly.
     fn observable_state(&self) -> Self::ObservableState;
 }
 

--- a/quickwit-indexing/src/source/file_source.rs
+++ b/quickwit-indexing/src/source/file_source.rs
@@ -108,6 +108,10 @@ impl Source for FileSource {
         Ok(())
     }
 
+    fn name(&self) -> String {
+        "file-source".to_string()
+    }
+
     fn observable_state(&self) -> serde_json::Value {
         serde_json::to_value(&self.counters).unwrap()
     }

--- a/quickwit-indexing/src/source/kafka_source.rs
+++ b/quickwit-indexing/src/source/kafka_source.rs
@@ -246,6 +246,10 @@ impl Source for KafkaSource {
         Ok(())
     }
 
+    fn name(&self) -> String {
+        "kafka-source".to_string()
+    }
+
     fn observable_state(&self) -> serde_json::Value {
         let assigned_partition_ids: Vec<&i32> =
             self.state.assigned_partition_ids.keys().sorted().collect();

--- a/quickwit-indexing/src/source/mod.rs
+++ b/quickwit-indexing/src/source/mod.rs
@@ -82,6 +82,9 @@ pub trait Source: Send + Sync + 'static {
         Ok(())
     }
 
+    /// A name identifying the type of source.
+    fn name(&self) -> String;
+
     /// Returns an observable_state for the actor.
     ///
     /// This object is simply a json object, and its content may vary depending on the
@@ -113,6 +116,10 @@ impl fmt::Debug for Loop {
 impl Actor for SourceActor {
     type Message = Loop;
     type ObservableState = serde_json::Value;
+
+    fn name(&self) -> String {
+        self.source.name()
+    }
 
     fn observable_state(&self) -> Self::ObservableState {
         self.source.observable_state()

--- a/quickwit-indexing/src/source/vec_source.rs
+++ b/quickwit-indexing/src/source/vec_source.rs
@@ -103,6 +103,10 @@ impl Source for VecSource {
         Ok(())
     }
 
+    fn name(&self) -> String {
+        "vec-source".to_string()
+    }
+
     fn observable_state(&self) -> serde_json::Value {
         serde_json::json!({
             "next_item_idx": self.next_item_idx,
@@ -112,7 +116,7 @@ impl Source for VecSource {
 
 #[cfg(test)]
 mod tests {
-    use quickwit_actors::{create_test_mailbox, Command, CommandOrMessage, Universe};
+    use quickwit_actors::{create_test_mailbox, Actor, Command, CommandOrMessage, Universe};
     use serde_json::json;
 
     use super::*;
@@ -137,6 +141,7 @@ mod tests {
             source: Box::new(vec_source),
             batch_sink: mailbox,
         };
+        assert_eq!(vec_source_actor.name(), "vec-source");
         let (_vec_source_mailbox, vec_source_handle) =
             universe.spawn_actor(vec_source_actor).spawn_async();
         let (actor_termination, last_observation) = vec_source_handle.join().await;


### PR DESCRIPTION
### Description
Allow customizable source names. Since sources are all wrapped in a `SourceActor`, logs do not display the source type:
```
Sep 28 19:25:07.322  INFO quickwit_actors::spawn_builder: spawn-async actor="holy-quickwit_indexing::source::SourceActor-708J"
```

There might be a better place/way to implement this. I'm also wondering whether we should change the `name(&self) -> String` signature to `name(&self) -> &str`. 

### How was this PR tested?
Added unit test
