### PR TITLE
Better logging

### DIFF
--- a/quickwit-indexing/src/actors/indexer.rs
+++ b/quickwit-indexing/src/actors/indexer.rs
@@ -105,6 +105,7 @@ impl IndexerState {
         let index_builder = IndexBuilder::new().settings(index_settings).schema(schema);
         let indexed_split =
             IndexedSplit::new_in_dir(self.index_id.clone(), &self.indexer_params, index_builder)?;
+        info!(split_id=%indexed_split.split_id, "new-split");
         Ok(indexed_split)
     }
 

--- a/quickwit-indexing/src/actors/packager.rs
+++ b/quickwit-indexing/src/actors/packager.rs
@@ -253,6 +253,7 @@ fn create_packaged_split(
         size_in_bytes: split.docs_size_in_bytes,
         tags,
         footer_offsets: footer_start..footer_end,
+        split_date_of_birth: split.split_date_of_birth,
     };
     Ok(packaged_split)
 }
@@ -347,7 +348,7 @@ mod tests {
             time_range: timerange_opt,
             num_docs,
             docs_size_in_bytes: num_docs * 15, //< bogus number
-            start_time: Instant::now(),
+            split_date_of_birth: Instant::now(),
             index,
             index_writer,
             split_scratch_directory,

--- a/quickwit-indexing/src/actors/publisher.rs
+++ b/quickwit-indexing/src/actors/publisher.rs
@@ -60,6 +60,7 @@ impl Publisher {
             PublishOperation::PublishNewSplit {
                 new_split,
                 checkpoint_delta,
+                ..
             } => {
                 self.metastore
                     .publish_splits(
@@ -145,6 +146,8 @@ impl AsyncActor for Publisher {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Instant;
+
     use quickwit_actors::{create_test_mailbox, Universe};
     use quickwit_metastore::checkpoint::CheckpointDelta;
     use quickwit_metastore::{MockMetastore, SplitMetadata};
@@ -198,6 +201,7 @@ mod tests {
                         ..Default::default()
                     },
                     checkpoint_delta: CheckpointDelta::from(3..7),
+                    split_date_of_birth: Instant::now(),
                 }
             })
             .is_ok());
@@ -210,6 +214,7 @@ mod tests {
                         ..Default::default()
                     },
                     checkpoint_delta: CheckpointDelta::from(1..3),
+                    split_date_of_birth: Instant::now(),
                 },
             })
             .is_ok());

--- a/quickwit-indexing/src/actors/uploader.rs
+++ b/quickwit-indexing/src/actors/uploader.rs
@@ -142,6 +142,7 @@ fn make_publish_operation(
         PublishOperation::PublishNewSplit {
             new_split: split_metadata,
             checkpoint_delta,
+            split_date_of_birth: packaged_split.split_date_of_birth,
         }
     } else {
         PublishOperation::ReplaceSplits {
@@ -290,6 +291,7 @@ mod tests {
                     num_docs: 10,
                     tags: Default::default(),
                     replaced_split_ids: Vec::new(),
+                    split_date_of_birth: Instant::now(),
                 },
             )
             .await?;
@@ -305,6 +307,7 @@ mod tests {
         if let PublishOperation::PublishNewSplit {
             new_split,
             checkpoint_delta,
+            ..
         } = publisher_message.operation
         {
             assert_eq!(&new_split.split_id, "test-split");
@@ -367,6 +370,7 @@ mod tests {
                         "replaced-split-1".to_string(),
                         "replaced-split-2".to_string(),
                     ],
+                    split_date_of_birth: Instant::now(),
                 },
             )
             .await?;

--- a/quickwit-indexing/src/models/indexed_split.rs
+++ b/quickwit-indexing/src/models/indexed_split.rs
@@ -50,7 +50,7 @@ pub struct IndexedSplit {
     /// This is mostly useful to understand part of the time to search.
     /// However, note that the document may have been waiting for a long time in the source
     /// before actually reaching the indexer.
-    pub start_time: Instant,
+    pub split_date_of_birth: Instant,
 
     pub checkpoint_delta: CheckpointDelta,
 
@@ -92,7 +92,7 @@ impl IndexedSplit {
             time_range: None,
             docs_size_in_bytes: 0,
             num_docs: 0,
-            start_time: Instant::now(),
+            split_date_of_birth: Instant::now(),
             index,
             index_writer,
             split_scratch_directory,

--- a/quickwit-indexing/src/models/merge_scratch.rs
+++ b/quickwit-indexing/src/models/merge_scratch.rs
@@ -27,9 +27,3 @@ pub struct MergeScratch {
     pub merge_scratch_directory: ScratchDirectory,
     pub downloaded_splits_directory: ScratchDirectory,
 }
-
-impl MergeScratch {
-    pub fn into_merge_scratch_directory(self) -> ScratchDirectory {
-        self.merge_scratch_directory
-    }
-}

--- a/quickwit-indexing/src/models/packaged_split.rs
+++ b/quickwit-indexing/src/models/packaged_split.rs
@@ -19,6 +19,7 @@
 
 use std::collections::HashSet;
 use std::ops::{Range, RangeInclusive};
+use std::time::Instant;
 
 use quickwit_metastore::checkpoint::CheckpointDelta;
 
@@ -36,4 +37,5 @@ pub struct PackagedSplit {
     pub split_scratch_directory: ScratchDirectory,
     pub num_docs: u64,
     pub tags: HashSet<String>,
+    pub split_date_of_birth: Instant,
 }

--- a/quickwit-indexing/src/models/publisher_message.rs
+++ b/quickwit-indexing/src/models/publisher_message.rs
@@ -18,6 +18,7 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::fmt;
+use std::time::Instant;
 
 use quickwit_metastore::checkpoint::CheckpointDelta;
 use quickwit_metastore::SplitMetadata;
@@ -28,6 +29,7 @@ pub enum PublishOperation {
     PublishNewSplit {
         new_split: SplitMetadata,
         checkpoint_delta: CheckpointDelta,
+        split_date_of_birth: Instant, // for logging
     },
     /// Publish a merge, replacing several splits (typically 10)
     /// by a single larger split.
@@ -43,10 +45,12 @@ impl fmt::Debug for PublishOperation {
             Self::PublishNewSplit {
                 new_split: new_split_id,
                 checkpoint_delta,
+                split_date_of_birth: start_time,
             } => f
                 .debug_struct("PublishNewSplit")
                 .field("new_split_id", &new_split_id.split_id)
                 .field("checkpoint_delta", checkpoint_delta)
+                .field("tts_in_secs", &start_time.elapsed().as_secs_f32())
                 .finish(),
             Self::ReplaceSplits {
                 new_splits,


### PR DESCRIPTION
- We should decide and log the split id as early as the first doc is added in the indexer actor.
- log the time to search.
- Add separator to merge operation split ids
- remove redundant log lines
- Log a message when merge executor starts.
- set split id for merge in merge planner
- GC needs to log files it deletes

Closes #600
