### PR TITLE
Draft indexing server and collect metrics for prometheus.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2259,9 +2259,11 @@ dependencies = [
  "fail",
  "flume",
  "futures",
+ "hyper",
  "itertools",
  "mockall 0.9.1",
  "once_cell",
+ "prometheus",
  "proptest",
  "quickwit-actors",
  "quickwit-common",
@@ -2280,6 +2282,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "ulid",
+ "warp",
 ]
 
 [[package]]

--- a/quickwit-cli/src/cli.yaml
+++ b/quickwit-cli/src/cli.yaml
@@ -198,3 +198,42 @@ subcommands:
                 value_name: PEER SEED
                 multiple: true
                 use_delimiter: true
+    - serve-indexing:
+        about: Starts a web server that runs indexing.
+        args:
+            - metastore-uri:
+                help: Location of the metastore
+                long: metastore-uri
+                value_name: METASTORE URI
+                required: true
+            - host:
+                help: Hostname the web server should bind to.
+                long: host
+                default_value: '0.0.0.0'
+                value_name: HOSTNAME
+            - port:
+                help: Port the web server should bind to.
+                long: port
+                default_value: '8090'
+                value_name: PORT
+            - source-config-uri:
+                help: Location of source config files
+                long: source-config-uri
+                value_name: SOURCE CONFIG URI
+                required: true
+            - index-id:
+                help: Index id
+                long: index-id
+                value_name: INDEX ID
+                required: true
+                multiple: true
+                use_delimiter: true
+            - temp-dir:
+                help: Creates intermediate files in this local directory. By default, the OS temp directory will be used.
+                long: temp-dir
+                value_name: TEMP DIR
+            - heap-size:
+                help: Amount of memory allocated to the process and split between the indexing threads
+                long: heap-size
+                value_name: HEAP SIZE
+                default_value: 2G

--- a/quickwit-common/src/metrics.rs
+++ b/quickwit-common/src/metrics.rs
@@ -17,13 +17,27 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use prometheus::{Encoder, IntCounter, IntGauge, Opts, TextEncoder};
+use prometheus::{Encoder, IntCounter, IntCounterVec, IntGauge, IntGaugeVec, Opts, TextEncoder};
 
 pub fn new_counter(name: &str, description: &str) -> IntCounter {
     let counter =
         IntCounter::with_opts(Opts::new(name, description)).expect("Failed to create counter");
     prometheus::register(Box::new(counter.clone())).expect("Failed to register counter");
     counter
+}
+
+pub fn new_counter_vec(name: &str, description: &str, label_names: &[&str]) -> IntCounterVec {
+    let counter_vec =
+        IntCounterVec::new(Opts::new(name, description), label_names).expect("Failed to create counter vec");
+    prometheus::register(Box::new(counter_vec.clone())).expect("Failed to register counter vec");
+    counter_vec
+}
+
+pub fn new_gauge_vec(name: &str, description: &str, label_names: &[&str]) -> IntGaugeVec {
+    let gauge_vec =
+        IntGaugeVec::new(Opts::new(name, description), label_names).expect("Failed to create counter vec");
+    prometheus::register(Box::new(gauge_vec.clone())).expect("Failed to register counter vec");
+    gauge_vec
 }
 
 pub fn new_gauge(name: &str, description: &str) -> IntGauge {

--- a/quickwit-indexing/Cargo.toml
+++ b/quickwit-indexing/Cargo.toml
@@ -35,6 +35,9 @@ tokio = { version = "1", features = ["sync"] }
 tracing = "0.1"
 ulid = "0.4"
 tokio-stream = "0.1.6"
+warp = '0.3'
+hyper = { version = "0.14", features = ["stream", "server", "http1", "http2", "tcp", "client"] }
+prometheus = "0.13"
 
 [features]
 kafka = ["rdkafka"]

--- a/quickwit-indexing/src/args.rs
+++ b/quickwit-indexing/src/args.rs
@@ -1,0 +1,46 @@
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use std::net::SocketAddr;
+use std::path::PathBuf;
+
+use byte_unit::Byte;
+
+#[derive(Debug, PartialEq)]
+pub struct ServeIndexingArgs {
+    /// Socket address of the REST server.
+    pub rest_socket_addr: SocketAddr,
+        
+    /// Metastore URI.
+    pub metastore_uri: String,
+    
+    /// Index IDs for which indexers will be spawns
+    // TODO: remove this args once we can get index IDs from the
+    // metastore or from the source config storage.  
+    pub index_ids: Vec<String>,
+
+    /// Indexes sources config URI.
+    pub source_config_uri: String,
+
+    /// Indexer heap size.
+    pub heap_size: Byte,
+
+    /// Scratch dir.
+    pub temp_dir: Option<PathBuf>,
+}

--- a/quickwit-indexing/src/counters.rs
+++ b/quickwit-indexing/src/counters.rs
@@ -1,0 +1,50 @@
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use once_cell::sync::Lazy;
+use prometheus::{IntCounterVec, IntGaugeVec};
+use quickwit_common::metrics::{new_counter_vec, new_gauge_vec};
+
+pub struct Counters {
+    pub num_docs: IntGaugeVec,
+    pub num_invalid_docs: IntGaugeVec,
+    pub num_local_splits: IntGaugeVec,
+    pub num_published_splits: IntGaugeVec,
+    pub num_uploaded_splits: IntGaugeVec,
+    pub num_staged_splits: IntGaugeVec,
+    pub total_bytes_processed: IntGaugeVec,
+    pub total_size_splits: IntGaugeVec,
+}
+
+impl Default for Counters {
+    fn default() -> Self {
+        Counters {
+            num_docs: new_gauge_vec("indexing:num_docs", "Number of docs indexed", &["index_id"]),
+            num_invalid_docs: new_gauge_vec("indexing:num_invalid_docs", "Number of invalid docs", &["index_id"]),
+            num_local_splits: new_gauge_vec("indexing:num_local_splits", "Number of local splits", &["index_id"]),
+            num_published_splits: new_gauge_vec("indexing:num_published_splits", "Number of published splits", &["index_id"]),
+            num_uploaded_splits: new_gauge_vec("indexing:num_uploaded_splits", "Number of uploaded splits", &["index_id"]),
+            num_staged_splits: new_gauge_vec("indexing:num_staged_splits", "Number of staged splits", &["index_id"]),
+            total_bytes_processed: new_gauge_vec("indexing:total_bytes_processed", "Total bytes processed", &["index_id"]),
+            total_size_splits: new_gauge_vec("indexing:total_size_splits", "Total size of splits", &["index_id"]),
+        }
+    }
+}
+
+pub static COUNTERS: Lazy<Counters> = Lazy::new(Counters::default);

--- a/quickwit-indexing/src/lib.rs
+++ b/quickwit-indexing/src/lib.rs
@@ -186,6 +186,7 @@ async fn observe_supervisors(index_ids: &[&String], supervisor_handlers: Vec<Act
         if observations.iter().all(|observation| {
             observation.obs_type == ObservationType::PostMortem
         }) {
+            // TODO: funny things. I got post mortem even though one actor continues to publish splits.
             warn!("all supervisors are down, stopping observations.");
             break;
         }

--- a/quickwit-indexing/src/lib.rs
+++ b/quickwit-indexing/src/lib.rs
@@ -17,15 +17,21 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+use std::path::Path;
 use std::sync::Arc;
-
-use anyhow::bail;
-use quickwit_actors::Universe;
-use quickwit_metastore::Metastore;
-use quickwit_storage::StorageUriResolver;
+use std::time::Duration;
+use futures::future::join_all;
+use anyhow::{Context, bail};
+use counters::COUNTERS;
+use itertools::Itertools;
+use quickwit_actors::{ActorExitStatus, ActorHandle, ObservationType, Universe};
+use quickwit_metastore::{Metastore, MetastoreUriResolver};
+use quickwit_storage::{Storage, StorageUriResolver, quickwit_storage_uri_resolver};
+use tracing::{debug, info, warn};
 
 use crate::actors::{IndexerParams, IndexingPipelineParams, IndexingPipelineSupervisor};
-use crate::models::IndexingStatistics;
+use crate::models::{CommitPolicy, IndexingStatistics, ScratchDirectory};
+use crate::rest::start_rest_service;
 use crate::source::SourceConfig;
 
 pub mod actors;
@@ -34,10 +40,13 @@ mod merge_policy;
 pub mod models;
 pub(crate) mod semaphore;
 pub mod source;
+pub mod counters;
+pub mod rest;
+pub mod args;
 mod test_utils;
 
 pub use test_utils::{mock_split_meta, TestSandbox};
-
+pub use crate::args::ServeIndexingArgs;
 pub use self::garbage_collection::{
     delete_splits_with_files, run_garbage_collect, FileEntry, SplitDeletionStats,
 };
@@ -70,4 +79,126 @@ pub async fn index_data(
 
 pub(crate) fn new_split_id() -> String {
     ulid::Ulid::new().to_string()
+}
+
+/// Fetch source configs from storage for each index id.
+/// The source path must have the form `{index_id}.json`.
+// TODO: accept other format.
+async fn load_sources(source_storage: Arc<dyn Storage>, index_ids: &[String]) -> anyhow::Result<Vec<(&String, SourceConfig)>> {
+    let mut source_configs = vec![];
+    for index_id in index_ids {
+        let source_config_filename = format!("{}.json", index_id);
+        let source_config_path = Path::new(&source_config_filename);
+        if !source_storage.exists(source_config_path).await? {
+            info!(index_id=?index_id, "No source file found for index.");
+            continue;
+        }
+        let source_config_bytes = source_storage.get_all(source_config_path).await?;
+        let source_config: SourceConfig = serde_json::from_slice(&source_config_bytes)
+            .with_context(|| {
+                format!(
+                    "Failed to parse source config file `{}`.",
+                    source_config_path.display()
+                )
+            })?;
+        debug!(index_id=?index_id, "Source config built.");
+        source_configs.push((index_id, source_config));
+    }
+    Ok(source_configs)
+}
+
+/// Start Quickwit indexing server.
+pub async fn serve_indexing_cli(args: ServeIndexingArgs) -> anyhow::Result<()> {
+    debug!(args=?args.rest_socket_addr, "serve-indexing-cli");
+
+    let storage_uri_resolver = quickwit_storage_uri_resolver();
+    let metastore_resolver = MetastoreUriResolver::default();
+    let metastore = metastore_resolver.resolve(&args.metastore_uri).await?;
+    let source_storage = storage_uri_resolver.resolve(&args.source_config_uri)?;
+    
+    // Load sources from storage.
+    let sources = load_sources(source_storage, &args.index_ids).await?;
+    if sources.is_empty() {
+        info!("No source for indexes. Exiting...");
+        return Ok(());
+    }
+
+    let scratch_directory = if let Some(scratch_root_path) = args.temp_dir.as_ref() {
+        ScratchDirectory::new_in_path(scratch_root_path.clone())
+    } else {
+        ScratchDirectory::try_new_temp()
+            .with_context(|| "Failed to create a tempdir for the indexer")?
+    };
+
+    // Create indexing pilelines.
+    let universe = Universe::new();
+    let mut supervisor_handlers = vec![];
+    let mut supervisor_index_ids = vec![];
+    for (index_id, source_config) in sources.into_iter() {
+        debug!(index_id=?index_id, "instantiate-indexing-pipeline");
+        let indexer_params = IndexerParams {
+            scratch_directory: scratch_directory.temp_child()?,
+            heap_size: args.heap_size,
+            commit_policy: CommitPolicy::default(), //< TODO make the commit policy configurable
+        };
+        let indexing_pipeline_params = IndexingPipelineParams {
+            index_id: index_id.clone(),
+            source_config,
+            indexer_params,
+            metastore: metastore.clone(),
+            storage_uri_resolver: storage_uri_resolver.clone(),
+        };
+        let indexing_supervisor = IndexingPipelineSupervisor::new(indexing_pipeline_params);
+        let (_supervisor_mailbox, supervisor_handler) = universe.spawn_actor(indexing_supervisor).spawn_async();
+        supervisor_handlers.push(supervisor_handler);
+        supervisor_index_ids.push(index_id);
+    }
+
+    let rest_server = start_rest_service(args.rest_socket_addr);
+    let observe_result = observe_supervisors(&supervisor_index_ids, supervisor_handlers);
+    tokio::try_join!(rest_server, observe_result)?;
+    Ok(())
+}
+
+/// Loop on supervisor handler observe and update prometheus metrics with observation.
+// TODO: remove statistics and use counters directly into actors?
+async fn observe_supervisors(index_ids: &[&String], supervisor_handlers: Vec<ActorHandle<IndexingPipelineSupervisor>>) -> anyhow::Result<()> {
+    let mut report_interval = tokio::time::interval(Duration::from_secs(1));
+    loop {
+        report_interval.tick().await;
+        let futures = supervisor_handlers
+            .iter()
+            .map(|handler| handler.observe());
+        let observations = join_all(futures).await;
+
+        for (index_id, observation) in index_ids.iter().zip(observations.iter()) {
+            if observation.obs_type != ObservationType::PostMortem {
+                COUNTERS.num_docs.with_label_values(&[index_id]).set(observation.num_docs as i64);
+                COUNTERS.num_invalid_docs.with_label_values(&[index_id]).set(observation.num_invalid_docs as i64);
+                COUNTERS.num_local_splits.with_label_values(&[index_id]).set(observation.num_local_splits as i64);
+                COUNTERS.num_published_splits.with_label_values(&[index_id]).set(observation.num_published_splits as i64);
+                COUNTERS.num_staged_splits.with_label_values(&[index_id]).set(observation.num_staged_splits as i64);
+                COUNTERS.num_uploaded_splits.with_label_values(&[index_id]).set(observation.num_uploaded_splits as i64);
+                COUNTERS.total_bytes_processed.with_label_values(&[index_id]).set(observation.total_bytes_processed as i64);
+                COUNTERS.total_size_splits.with_label_values(&[index_id]).set(observation.total_size_splits as i64);
+            }   
+        }
+        if observations.iter().all(|observation| {
+            observation.obs_type == ObservationType::PostMortem
+        }) {
+            warn!("all supervisors are down, stopping observations.");
+            break;
+        }
+    }
+    let join_handles = supervisor_handlers.into_iter()
+        .map(|handler| handler.join());
+    let exit_statuses_futures = join_all(join_handles).await;
+    let exit_statuses = exit_statuses_futures
+        .iter()
+        .map(|(status, _)| status)
+        .collect_vec();
+    if exit_statuses.iter().all(|exit_status| {matches!(exit_status, ActorExitStatus::Success)}) {
+        return Ok(());
+    }
+    Ok(())
 }

--- a/quickwit-indexing/src/rest.rs
+++ b/quickwit-indexing/src/rest.rs
@@ -1,0 +1,36 @@
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use std::net::SocketAddr;
+
+use quickwit_common::metrics;
+use tracing::info;
+use warp::Filter;
+
+/// Start REST service given a HTTP address and a search service.
+pub async fn start_rest_service(
+    rest_addr: SocketAddr,
+) -> anyhow::Result<()> {
+    info!(rest_addr=?rest_addr, "Starting REST service.");
+    let metrics_service = warp::path("metrics")
+        .and(warp::get())
+        .map(metrics::metrics_handler);
+    warp::serve(metrics_service).run(rest_addr).await;
+    Ok(())
+}


### PR DESCRIPTION
### Description
My first goal was to have Prometheus indexing metrics and I ended up drafting an indexing server.

The indexing server starts like this:
`cargo r serve-indexing --metastore-uri 's3://my-bucket/quickwit' --source-config-uri 's3://my-bucket/quickwit-sources' --index-id hdfs_logs,wikipedia`

When starting, we first look for source files of names `{index_id}.json` located at the `source-config-uri` and if found, we create the source config and instantiate the pipeline.

Concerning metrics, I used the `IndexingStatistics` and prometheus gauges but I think it would be more appropriate to have counters and directly increment them in actors.

 
To be discussed @fulmicoton @guilload 