### PR TITLE
Add QUICKWIT_JAEGER_ENABLED env variable to enable jaeger tracing.

### DIFF
--- a/quickwit-cli/src/lib.rs
+++ b/quickwit-cli/src/lib.rs
@@ -55,6 +55,9 @@ use tracing::debug;
 /// Throughput calculation window size.
 const THROUGHPUT_WINDOW_SIZE: usize = 5;
 
+/// This environment variable can be set to send telemetry events to a jaeger instance.
+pub const QUICKWIT_JAEGER_ENABLED_ENV_KEY: &str = "QUICKWIT_JAEGER_ENABLED";
+
 #[derive(Debug, Eq, PartialEq)]
 pub struct InspectSplitArgs {
     metastore_uri: String,


### PR DESCRIPTION
### Description
Fix #559 

Notes: I tried to use a common `registry` variable but I had some types incompatibility so I ended up with a `if` and `else`.

### How was this PR tested?
Locally only.