### PR TITLE
stream split bundle on the fly

### DIFF
--- a/quickwit-cli/src/lib.rs
+++ b/quickwit-cli/src/lib.rs
@@ -211,7 +211,11 @@ pub async fn extract_split_cli(args: ExtractSplitArgs) -> anyhow::Result<()> {
     let split_file = PathBuf::from(format!("{}.split", args.split_id));
     let (_, bundle_footer) = read_split_footer(index_storage.clone(), &split_file).await?;
 
-    let bundle_storage = BundleStorage::new(index_storage, split_file, &bundle_footer)?;
+    let (_hotcache_bytes, bundle_storage) = BundleStorage::open_from_split_data_with_owned_bytes(
+        index_storage,
+        split_file,
+        bundle_footer,
+    )?;
 
     std::fs::create_dir_all(args.target_folder.to_owned())?;
 

--- a/quickwit-common/src/lib.rs
+++ b/quickwit-common/src/lib.rs
@@ -22,6 +22,7 @@ pub mod metrics;
 
 use std::fmt::Debug;
 use std::ops::Range;
+use std::path::Path;
 use std::str::FromStr;
 
 pub use coolid::new_coolid;
@@ -29,6 +30,10 @@ use tracing::{error, info};
 
 /// Filenames used for hotcache files.
 pub const HOTCACHE_FILENAME: &str = "hotcache";
+
+pub fn get_hotcache_path() -> &'static Path {
+    Path::new(HOTCACHE_FILENAME)
+}
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum QuickwitEnv {

--- a/quickwit-common/src/lib.rs
+++ b/quickwit-common/src/lib.rs
@@ -22,18 +22,10 @@ pub mod metrics;
 
 use std::fmt::Debug;
 use std::ops::Range;
-use std::path::Path;
 use std::str::FromStr;
 
 pub use coolid::new_coolid;
 use tracing::{error, info};
-
-/// Filenames used for hotcache files.
-pub const HOTCACHE_FILENAME: &str = "hotcache";
-
-pub fn get_hotcache_path() -> &'static Path {
-    Path::new(HOTCACHE_FILENAME)
-}
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum QuickwitEnv {

--- a/quickwit-directories/src/bundle_directory.rs
+++ b/quickwit-directories/src/bundle_directory.rs
@@ -90,11 +90,10 @@ pub fn get_hotcache_from_split(data: OwnedBytes) -> io::Result<OwnedBytes> {
 
 impl BundleDirectory {
     /// Get files and their sizes in a split.
-    pub fn get_stats_split(data: OwnedBytes) -> io::Result<Vec<(PathBuf, usize)>> {
+    pub fn get_stats_split(data: OwnedBytes) -> io::Result<Vec<(PathBuf, u64)>> {
         let split_file = FileSlice::new(Box::new(data));
         let (body_and_bundle_metadata, hot_cache) = split_footer(split_file)?;
-        let file_offsets =
-            BundleStorageFileOffsets::open_from_file_slice(body_and_bundle_metadata)?;
+        let file_offsets = BundleStorageFileOffsets::open(body_and_bundle_metadata)?;
 
         let mut files_and_size: Vec<(_, _)> = file_offsets
             .files
@@ -102,7 +101,10 @@ impl BundleDirectory {
             .map(|(file, range)| (file, range.end - range.start))
             .collect();
 
-        files_and_size.push((PathBuf::from("hotcache".to_string()), hot_cache.len()));
+        files_and_size.push((
+            PathBuf::from("hotcache".to_string()),
+            hot_cache.len() as u64,
+        ));
 
         files_and_size.sort();
         Ok(files_and_size)
@@ -117,7 +119,7 @@ impl BundleDirectory {
 
     /// Opens a BundleDirectory, given a file containing the bundle data.
     pub fn open_bundle(file: FileSlice) -> io::Result<BundleDirectory> {
-        let file_offsets = BundleStorageFileOffsets::open_from_file_slice(file.clone())?;
+        let file_offsets = BundleStorageFileOffsets::open(file.clone())?;
         Ok(BundleDirectory { file, file_offsets })
     }
 }
@@ -133,7 +135,9 @@ impl Directory for BundleDirectory {
             .file_offsets
             .get(path)
             .ok_or_else(|| OpenReadError::FileDoesNotExist(path.to_path_buf()))?;
-        Ok(self.file.slice(byte_range))
+        Ok(self
+            .file
+            .slice(byte_range.start as usize..byte_range.end as usize))
     }
 
     fn atomic_read(&self, path: &Path) -> Result<Vec<u8>, OpenReadError> {
@@ -173,26 +177,18 @@ impl Directory for BundleDirectory {
 
 #[cfg(test)]
 mod tests {
-    use std::fs::{self, File};
+    use std::fs::File;
     use std::io::Write;
 
-    use quickwit_storage::BundleStorageBuilder;
-    use tantivy::common::CountingWriter;
+    use quickwit_storage::{get_split_payload_streamer, PutPayload};
 
     use super::*;
 
-    #[test]
-    fn test_bundle_directory_stats() -> anyhow::Result<()> {
+    #[tokio::test]
+    async fn test_bundle_directory_stats() -> anyhow::Result<()> {
         let temp_dir = tempfile::tempdir()?;
         let test_filepath1 = temp_dir.path().join("f1");
         let test_filepath2 = temp_dir.path().join("f2");
-        let test_bundle_path = temp_dir.path().join("le_bundle");
-
-        // Simulating split file which is created in packager.rs, which contains the bundle and
-        // appends the footer. The bundle directory can read the format created by
-        // packager.rs
-        let mut split_file = CountingWriter::wrap(File::create(test_bundle_path.to_owned())?);
-        let mut bundle_builder = BundleStorageBuilder::new(&mut split_file)?;
 
         let mut file1 = File::create(&test_filepath1)?;
         file1.write_all(&[123, 76])?;
@@ -200,42 +196,30 @@ mod tests {
         let mut file2 = File::create(&test_filepath2)?;
         file2.write_all(&[99, 55, 44])?;
 
-        bundle_builder.add_file(&test_filepath1)?;
-        bundle_builder.add_file(&test_filepath2)?;
-        bundle_builder.finalize()?;
+        let split_streamer = get_split_payload_streamer(
+            &[test_filepath1.clone(), test_filepath2.clone()],
+            &[
+                1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
+            ],
+        )?;
 
-        // append hotcache and hotcache len
-        let hotcache_offset_start = split_file.written_bytes();
-        split_file.write_all(&[
-            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
-        ])?;
-
-        let hotcache_offset_end = split_file.written_bytes();
-        let hotcache_num_bytes = hotcache_offset_end - hotcache_offset_start;
-
-        split_file.write_all(&hotcache_num_bytes.to_le_bytes())?;
-
-        let buffer = fs::read(test_bundle_path)?;
+        let buffer = split_streamer.read_all().await?;
 
         // check stats
-        let stats = BundleDirectory::get_stats_split(OwnedBytes::new(buffer))?;
+        let stats = BundleDirectory::get_stats_split(buffer)?;
 
-        assert_eq!(stats[0], (PathBuf::from("f1".to_string()), 2_usize));
-        assert_eq!(stats[1], (PathBuf::from("f2".to_string()), 3_usize));
-        assert_eq!(stats[2], (PathBuf::from("hotcache".to_string()), 18_usize));
+        assert_eq!(stats[0], (PathBuf::from("f1".to_string()), 2_u64));
+        assert_eq!(stats[1], (PathBuf::from("f2".to_string()), 3_u64));
+        assert_eq!(stats[2], (PathBuf::from("hotcache".to_string()), 18_u64));
 
         Ok(())
     }
 
-    #[test]
-    fn test_bundle_directory() -> anyhow::Result<()> {
+    #[tokio::test]
+    async fn test_bundle_directory() -> anyhow::Result<()> {
         let temp_dir = tempfile::tempdir()?;
         let test_filepath1 = temp_dir.path().join("f1");
         let test_filepath2 = temp_dir.path().join("f2");
-        let test_bundle_path = temp_dir.path().join("le_bundle");
-
-        let mut bundle_file = File::create(test_bundle_path.to_owned())?;
-        let mut bundle_builder = BundleStorageBuilder::new(&mut bundle_file)?;
 
         let mut file1 = File::create(&test_filepath1)?;
         file1.write_all(&[123, 76])?;
@@ -243,18 +227,52 @@ mod tests {
         let mut file2 = File::create(&test_filepath2)?;
         file2.write_all(&[99, 55, 44])?;
 
-        bundle_builder.add_file(&test_filepath1)?;
-        bundle_builder.add_file(&test_filepath2)?;
-        bundle_builder.finalize()?;
+        let split_streamer = get_split_payload_streamer(
+            &[test_filepath1.clone(), test_filepath2.clone()],
+            &[
+                1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
+            ],
+        )?;
 
-        let buffer = fs::read(test_bundle_path)?;
-        let bundle_file_slice = FileSlice::from(buffer);
+        let buffer = split_streamer.read_all().await?;
 
-        let bundle_dir = BundleDirectory::open_bundle(bundle_file_slice)?;
+        let bundle_file_slice = FileSlice::from(buffer.to_vec());
+
+        let bundle_dir = BundleDirectory::open_split(bundle_file_slice)?;
 
         assert!(bundle_dir.exists(Path::new("f1")).unwrap());
         assert!(bundle_dir.exists(Path::new("f2")).unwrap());
         assert!(!bundle_dir.exists(Path::new("f3")).unwrap());
+
+        let f1_data = bundle_dir.atomic_read(Path::new("f1"))?;
+        assert_eq!(&*f1_data, &[123u8, 76u8]);
+
+        let f2_data = bundle_dir.atomic_read(Path::new("f2"))?;
+        assert_eq!(&f2_data[..], &[99, 55, 44]);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_stream_split_to_bundle_and_open() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let test_filepath1 = temp_dir.path().join("f1");
+        let test_filepath2 = temp_dir.path().join("f2");
+
+        let mut file1 = File::create(&test_filepath1)?;
+        file1.write_all(&[123, 76])?;
+
+        let mut file2 = File::create(&test_filepath2)?;
+        file2.write_all(&[99, 55, 44])?;
+
+        let split_streamer = get_split_payload_streamer(
+            &[test_filepath1.clone(), test_filepath2.clone()],
+            &[1, 2, 3],
+        )?;
+
+        let data = split_streamer.read_all().await?;
+
+        let bundle_dir = BundleDirectory::open_split(FileSlice::from(data.to_vec()))?;
 
         let f1_data = bundle_dir.atomic_read(Path::new("f1"))?;
         assert_eq!(&*f1_data, &[123u8, 76u8]);

--- a/quickwit-directories/src/bundle_directory.rs
+++ b/quickwit-directories/src/bundle_directory.rs
@@ -180,7 +180,7 @@ mod tests {
     use std::fs::File;
     use std::io::Write;
 
-    use quickwit_storage::{get_split_payload_streamer, PutPayload};
+    use quickwit_storage::{PutPayload, SplitPayloadBuilder};
 
     use super::*;
 
@@ -196,7 +196,7 @@ mod tests {
         let mut file2 = File::create(&test_filepath2)?;
         file2.write_all(&[99, 55, 44])?;
 
-        let split_streamer = get_split_payload_streamer(
+        let split_streamer = SplitPayloadBuilder::get_split_payload(
             &[test_filepath1.clone(), test_filepath2.clone()],
             &[
                 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
@@ -227,7 +227,7 @@ mod tests {
         let mut file2 = File::create(&test_filepath2)?;
         file2.write_all(&[99, 55, 44])?;
 
-        let split_streamer = get_split_payload_streamer(
+        let split_streamer = SplitPayloadBuilder::get_split_payload(
             &[test_filepath1.clone(), test_filepath2.clone()],
             &[
                 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
@@ -265,7 +265,7 @@ mod tests {
         let mut file2 = File::create(&test_filepath2)?;
         file2.write_all(&[99, 55, 44])?;
 
-        let split_streamer = get_split_payload_streamer(
+        let split_streamer = SplitPayloadBuilder::get_split_payload(
             &[test_filepath1.clone(), test_filepath2.clone()],
             &[1, 2, 3],
         )?;

--- a/quickwit-indexing/src/actors/merge_executor.rs
+++ b/quickwit-indexing/src/actors/merge_executor.rs
@@ -806,7 +806,7 @@ mod tests {
     use super::*;
     use crate::merge_policy::MergeOperation;
     use crate::models::ScratchDirectory;
-    use crate::{new_split_id, BundledSplitFile, TestSandbox};
+    use crate::{get_tantivy_directory_from_split_bundle, new_split_id, TestSandbox};
 
     #[tokio::test]
     async fn test_merge_executor() -> anyhow::Result<()> {
@@ -848,11 +848,8 @@ mod tests {
             storage
                 .copy_to_file(Path::new(&split_filename), &dest_filepath)
                 .await?;
-            tantivy_dirs.push(
-                BundledSplitFile::new(dest_filepath.to_owned())
-                    .get_tantivy_directory()
-                    .unwrap(),
-            );
+
+            tantivy_dirs.push(get_tantivy_directory_from_split_bundle(&dest_filepath).unwrap())
         }
         let merge_scratch = MergeScratch {
             merge_operation: MergeOperation::Merge {

--- a/quickwit-indexing/src/actors/merge_split_downloader.rs
+++ b/quickwit-indexing/src/actors/merge_split_downloader.rs
@@ -135,7 +135,7 @@ mod tests {
 
     use quickwit_actors::{create_test_mailbox, Universe};
     use quickwit_common::split_file;
-    use quickwit_storage::{get_split_payload_streamer, PutPayload, RamStorageBuilder};
+    use quickwit_storage::{PutPayload, RamStorageBuilder, SplitPayloadBuilder};
 
     use super::*;
     use crate::new_split_id;
@@ -157,7 +157,7 @@ mod tests {
         let storage = {
             let mut storage_builder = RamStorageBuilder::default();
             for split in &splits_to_merge {
-                let buffer = get_split_payload_streamer(&[], &[1, 2, 3])?
+                let buffer = SplitPayloadBuilder::get_split_payload(&[], &[1, 2, 3])?
                     .read_all()
                     .await?;
                 storage_builder = storage_builder.put(&split_file(&split.split_id), &buffer);

--- a/quickwit-indexing/src/actors/merge_split_downloader.rs
+++ b/quickwit-indexing/src/actors/merge_split_downloader.rs
@@ -135,7 +135,7 @@ mod tests {
 
     use quickwit_actors::{create_test_mailbox, Universe};
     use quickwit_common::split_file;
-    use quickwit_storage::{BundleStorageBuilder, RamStorageBuilder};
+    use quickwit_storage::{get_split_payload_streamer, PutPayload, RamStorageBuilder};
 
     use super::*;
     use crate::new_split_id;
@@ -157,13 +157,9 @@ mod tests {
         let storage = {
             let mut storage_builder = RamStorageBuilder::default();
             for split in &splits_to_merge {
-                let mut buffer: Vec<u8> = Vec::new();
-                let create_bundle = BundleStorageBuilder::new(&mut buffer)?;
-                create_bundle.finalize()?;
-                // hotcache
-                buffer.extend(&[1, 2, 3]);
-                buffer.extend(3_usize.to_le_bytes());
-
+                let buffer = get_split_payload_streamer(&[], &[1, 2, 3])?
+                    .read_all()
+                    .await?;
                 storage_builder = storage_builder.put(&split_file(&split.split_id), &buffer);
             }
             let ram_storage = storage_builder.build();

--- a/quickwit-indexing/src/actors/packager.rs
+++ b/quickwit-indexing/src/actors/packager.rs
@@ -18,10 +18,7 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::collections::HashSet;
-use std::fs::File;
 use std::io;
-use std::io::Write;
-use std::ops::Range;
 use std::path::{Path, PathBuf};
 
 use anyhow::Context;
@@ -29,8 +26,6 @@ use fail::fail_point;
 use itertools::Itertools;
 use quickwit_actors::{Actor, ActorContext, Mailbox, QueueCapacity, SyncActor};
 use quickwit_directories::write_hotcache;
-use quickwit_storage::{BundleStorageBuilder, BUNDLE_FILENAME};
-use tantivy::common::CountingWriter;
 use tantivy::schema::Field;
 use tantivy::{ReloadPolicy, SegmentId, SegmentMeta};
 use tracing::*;
@@ -157,28 +152,8 @@ fn list_split_files(
             }
         }
     }
+    index_files.sort();
     index_files
-}
-
-/// Create the file bundle.
-///
-/// Returns the range of the file offsets metadata (required to open the bundle.)
-fn create_file_bundle(
-    segment_metas: &[SegmentMeta],
-    scratch_dir: &ScratchDirectory,
-    split_file: &mut impl io::Write,
-    ctx: &ActorContext<IndexedSplitBatch>,
-) -> anyhow::Result<Range<u64>> {
-    let _protected_zone_guard = ctx.protect_zone();
-    // List the split files that will be packaged into the bundle.
-    let mut bundle_storage_builder = BundleStorageBuilder::new(split_file)?;
-
-    for split_file in list_split_files(segment_metas, scratch_dir) {
-        bundle_storage_builder.add_file(&split_file)?;
-    }
-
-    let bundle_storage_offsets = bundle_storage_builder.finalize()?;
-    Ok(bundle_storage_offsets)
 }
 
 /// If necessary, merge all segments and returns a PackagedSplit.
@@ -206,9 +181,9 @@ fn merge_segments_if_required(
     Ok(segment_metas_after_merge)
 }
 
-fn build_hotcache<W: io::Write>(split_path: &Path, split_file: &mut W) -> anyhow::Result<()> {
+fn build_hotcache<W: io::Write>(split_path: &Path, out: &mut W) -> anyhow::Result<()> {
     let mmap_directory = tantivy::directory::MmapDirectory::open(split_path)?;
-    write_hotcache(mmap_directory, split_file)?;
+    write_hotcache(mmap_directory, out)?;
     Ok(())
 }
 
@@ -220,19 +195,7 @@ fn create_packaged_split(
 ) -> anyhow::Result<PackagedSplit> {
     info!("create-packaged-split");
 
-    let split_filepath = split.split_scratch_directory.path().join(BUNDLE_FILENAME); // TODO rename <split_id>.split
-    let mut split_file = CountingWriter::wrap(File::create(split_filepath)?);
-
-    debug!("create-file-bundle");
-    let Range {
-        start: footer_start,
-        end: _,
-    } = create_file_bundle(
-        segment_metas,
-        &split.split_scratch_directory,
-        &mut split_file,
-        ctx,
-    )?;
+    let split_files = list_split_files(segment_metas, &split.split_scratch_directory);
 
     let num_docs = segment_metas
         .iter()
@@ -256,17 +219,9 @@ fn create_packaged_split(
     ctx.record_progress();
 
     debug!("build-hotcache");
-    let hotcache_offset_start = split_file.written_bytes();
-    build_hotcache(split.split_scratch_directory.path(), &mut split_file)?;
-    let hotcache_offset_end = split_file.written_bytes();
-    let hotcache_num_bytes = hotcache_offset_end - hotcache_offset_start;
+    let mut hotcache_bytes = vec![];
+    build_hotcache(split.split_scratch_directory.path(), &mut hotcache_bytes)?;
     ctx.record_progress();
-
-    debug!("split-write-all");
-    split_file.write_all(&hotcache_num_bytes.to_le_bytes())?;
-    split_file.flush()?;
-
-    let footer_end = split_file.written_bytes();
 
     let packaged_split = PackagedSplit {
         split_id: split.split_id.to_string(),
@@ -279,8 +234,9 @@ fn create_packaged_split(
         time_range: split.time_range,
         size_in_bytes: split.docs_size_in_bytes,
         tags,
-        footer_offsets: footer_start..footer_end,
         split_date_of_birth: split.split_date_of_birth,
+        split_files,
+        hotcache_bytes,
     };
     Ok(packaged_split)
 }

--- a/quickwit-indexing/src/actors/uploader.rs
+++ b/quickwit-indexing/src/actors/uploader.rs
@@ -20,6 +20,7 @@
 use std::collections::HashSet;
 use std::iter::FromIterator;
 use std::mem;
+use std::ops::Range;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
@@ -29,7 +30,7 @@ use fail::fail_point;
 use itertools::Itertools;
 use quickwit_actors::{Actor, ActorContext, ActorExitStatus, AsyncActor, Mailbox, QueueCapacity};
 use quickwit_metastore::{Metastore, SplitMetadata, SplitMetadataAndFooterOffsets, SplitState};
-use quickwit_storage::BUNDLE_FILENAME;
+use quickwit_storage::get_split_payload_streamer;
 use tantivy::chrono::Utc;
 use tokio::sync::oneshot::Receiver;
 use tokio::sync::Semaphore;
@@ -96,7 +97,10 @@ impl Actor for Uploader {
     }
 }
 
-fn create_split_metadata(split: &PackagedSplit) -> SplitMetadataAndFooterOffsets {
+fn create_split_metadata(
+    split: &PackagedSplit,
+    footer_offsets: Range<u64>,
+) -> SplitMetadataAndFooterOffsets {
     SplitMetadataAndFooterOffsets {
         split_metadata: SplitMetadata {
             split_id: split.split_id.clone(),
@@ -108,7 +112,7 @@ fn create_split_metadata(split: &PackagedSplit) -> SplitMetadataAndFooterOffsets
             tags: split.tags.clone(),
             demux_num_ops: split.demux_num_ops,
         },
-        footer_offsets: split.footer_offsets.clone(),
+        footer_offsets,
     }
 }
 
@@ -146,7 +150,13 @@ async fn stage_and_upload_split(
     metastore: &dyn Metastore,
     counters: UploaderCounters,
 ) -> anyhow::Result<SplitMetadata> {
-    let split_metadata_and_footer_offsets = create_split_metadata(packaged_split);
+    let split_streamer =
+        get_split_payload_streamer(&packaged_split.split_files, &packaged_split.hotcache_bytes)?;
+
+    let split_metadata_and_footer_offsets = create_split_metadata(
+        packaged_split,
+        split_streamer.footer_range.start as u64..split_streamer.footer_range.end as u64,
+    );
     let index_id = packaged_split.index_id.clone();
     let split_metadata = split_metadata_and_footer_offsets.split_metadata.clone();
     info!("staging-split");
@@ -154,14 +164,14 @@ async fn stage_and_upload_split(
         .stage_split(&index_id, split_metadata_and_footer_offsets)
         .await?;
     counters.num_staged_splits.fetch_add(1, Ordering::SeqCst);
-    let bundle_path = packaged_split
-        .split_scratch_directory
-        .path()
-        .join(BUNDLE_FILENAME);
 
     info!("storing-split");
     split_store
-        .store_split(&split_metadata, &bundle_path)
+        .store_split(
+            &split_metadata,
+            packaged_split.split_scratch_directory.path(),
+            Box::new(split_streamer),
+        )
         .await?;
     counters.num_uploaded_splits.fetch_add(1, Ordering::SeqCst);
     Ok(split_metadata)
@@ -263,7 +273,7 @@ mod tests {
     use crate::models::ScratchDirectory;
 
     #[tokio::test]
-    async fn test_uploader() -> anyhow::Result<()> {
+    async fn test_uploader_1() -> anyhow::Result<()> {
         quickwit_common::setup_logging_for_tests();
         let universe = Universe::new();
         let (mailbox, inbox) = create_test_mailbox();
@@ -289,10 +299,6 @@ mod tests {
         );
         let (uploader_mailbox, uploader_handle) = universe.spawn_actor(uploader).spawn_async();
         let split_scratch_directory = ScratchDirectory::for_test()?;
-        std::fs::write(
-            split_scratch_directory.path().join(BUNDLE_FILENAME),
-            &b"bubu"[..],
-        )?;
         universe
             .send_message(
                 &uploader_mailbox,
@@ -302,13 +308,14 @@ mod tests {
                     checkpoint_deltas: vec![CheckpointDelta::from(3..15)],
                     time_range: Some(1_628_203_589i64..=1_628_203_640i64),
                     size_in_bytes: 1_000,
-                    footer_offsets: 1000..2000,
                     split_scratch_directory,
                     num_docs: 10,
                     demux_num_ops: 0,
                     tags: Default::default(),
                     replaced_split_ids: Vec::new(),
                     split_date_of_birth: Instant::now(),
+                    hotcache_bytes: vec![],
+                    split_files: vec![],
                 }]),
             )
             .await?;
@@ -367,21 +374,12 @@ mod tests {
         let (uploader_mailbox, uploader_handle) = universe.spawn_actor(uploader).spawn_async();
         let split_scratch_directory_1 = ScratchDirectory::for_test()?;
         let split_scratch_directory_2 = ScratchDirectory::for_test()?;
-        std::fs::write(
-            split_scratch_directory_1.path().join(BUNDLE_FILENAME),
-            &b"bubu"[..],
-        )?;
-        std::fs::write(
-            split_scratch_directory_2.path().join(BUNDLE_FILENAME),
-            &b"bubu"[..],
-        )?;
         let packaged_split_1 = PackagedSplit {
             split_id: "test-split-1".to_string(),
             index_id: "test-index".to_string(),
             checkpoint_deltas: vec![CheckpointDelta::from(3..15), CheckpointDelta::from(16..18)],
             time_range: Some(1_628_203_589i64..=1_628_203_640i64),
             size_in_bytes: 1_000,
-            footer_offsets: 1000..2000,
             split_scratch_directory: split_scratch_directory_1,
             num_docs: 10,
             demux_num_ops: 1,
@@ -391,6 +389,8 @@ mod tests {
                 "replaced-split-2".to_string(),
             ],
             split_date_of_birth: Instant::now(),
+            split_files: vec![],
+            hotcache_bytes: vec![],
         };
         let package_split_2 = PackagedSplit {
             split_id: "test-split-2".to_string(),
@@ -398,7 +398,6 @@ mod tests {
             checkpoint_deltas: vec![CheckpointDelta::from(3..15), CheckpointDelta::from(16..18)],
             time_range: Some(1_628_203_589i64..=1_628_203_640i64),
             size_in_bytes: 1_000,
-            footer_offsets: 1000..2000,
             split_scratch_directory: split_scratch_directory_2,
             num_docs: 10,
             demux_num_ops: 1,
@@ -408,6 +407,8 @@ mod tests {
                 "replaced-split-2".to_string(),
             ],
             split_date_of_birth: Instant::now(),
+            split_files: vec![],
+            hotcache_bytes: vec![],
         };
         universe
             .send_message(

--- a/quickwit-indexing/src/actors/uploader.rs
+++ b/quickwit-indexing/src/actors/uploader.rs
@@ -30,7 +30,7 @@ use fail::fail_point;
 use itertools::Itertools;
 use quickwit_actors::{Actor, ActorContext, ActorExitStatus, AsyncActor, Mailbox, QueueCapacity};
 use quickwit_metastore::{Metastore, SplitMetadata, SplitMetadataAndFooterOffsets, SplitState};
-use quickwit_storage::get_split_payload_streamer;
+use quickwit_storage::SplitPayloadBuilder;
 use tantivy::chrono::Utc;
 use tokio::sync::oneshot::Receiver;
 use tokio::sync::Semaphore;
@@ -150,8 +150,10 @@ async fn stage_and_upload_split(
     metastore: &dyn Metastore,
     counters: UploaderCounters,
 ) -> anyhow::Result<SplitMetadata> {
-    let split_streamer =
-        get_split_payload_streamer(&packaged_split.split_files, &packaged_split.hotcache_bytes)?;
+    let split_streamer = SplitPayloadBuilder::get_split_payload(
+        &packaged_split.split_files,
+        &packaged_split.hotcache_bytes,
+    )?;
 
     let split_metadata_and_footer_offsets = create_split_metadata(
         packaged_split,

--- a/quickwit-indexing/src/lib.rs
+++ b/quickwit-indexing/src/lib.rs
@@ -27,7 +27,10 @@ use quickwit_storage::StorageUriResolver;
 use crate::actors::{IndexerParams, IndexingPipelineParams, IndexingPipelineSupervisor};
 use crate::models::IndexingStatistics;
 use crate::source::SourceConfig;
-pub use crate::split_store::{BundledSplitFile, IndexingSplitStore, IndexingSplitStoreParams};
+pub use crate::split_store::{
+    get_tantivy_directory_from_split_bundle, IndexingSplitStore, IndexingSplitStoreParams,
+    SplitFolder,
+};
 
 pub mod actors;
 mod controlled_directory;

--- a/quickwit-indexing/src/merge_policy.rs
+++ b/quickwit-indexing/src/merge_policy.rs
@@ -197,7 +197,7 @@ impl<'a> fmt::Debug for SplitShortDebug<'a> {
 }
 
 fn splits_short_debug(splits: &[SplitMetadata]) -> Vec<SplitShortDebug> {
-    splits.iter().map(|split| SplitShortDebug(split)).collect()
+    splits.iter().map(SplitShortDebug).collect()
 }
 
 impl MergePolicy for StableMultitenantWithTimestampMergePolicy {

--- a/quickwit-indexing/src/models/packaged_split.rs
+++ b/quickwit-indexing/src/models/packaged_split.rs
@@ -18,7 +18,7 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::collections::HashSet;
-use std::ops::{Range, RangeInclusive};
+use std::ops::RangeInclusive;
 use std::time::Instant;
 
 use quickwit_metastore::checkpoint::CheckpointDelta;
@@ -33,12 +33,13 @@ pub struct PackagedSplit {
     pub checkpoint_deltas: Vec<CheckpointDelta>,
     pub time_range: Option<RangeInclusive<i64>>,
     pub size_in_bytes: u64,
-    pub footer_offsets: Range<u64>,
     pub split_scratch_directory: ScratchDirectory,
     pub num_docs: u64,
     pub demux_num_ops: usize,
     pub tags: HashSet<String>,
     pub split_date_of_birth: Instant,
+    pub split_files: Vec<std::path::PathBuf>,
+    pub hotcache_bytes: Vec<u8>,
 }
 
 #[derive(Debug)]

--- a/quickwit-indexing/src/models/packaged_split.rs
+++ b/quickwit-indexing/src/models/packaged_split.rs
@@ -18,6 +18,7 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::collections::HashSet;
+use std::fmt;
 use std::ops::RangeInclusive;
 use std::time::Instant;
 
@@ -25,7 +26,6 @@ use quickwit_metastore::checkpoint::CheckpointDelta;
 
 use crate::models::ScratchDirectory;
 
-#[derive(Debug)]
 pub struct PackagedSplit {
     pub split_id: String,
     pub replaced_split_ids: Vec<String>,
@@ -40,6 +40,25 @@ pub struct PackagedSplit {
     pub split_date_of_birth: Instant,
     pub split_files: Vec<std::path::PathBuf>,
     pub hotcache_bytes: Vec<u8>,
+}
+
+impl fmt::Debug for PackagedSplit {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PackagedSplit")
+            .field("split_id", &self.split_id)
+            .field("replaced_split_ids", &self.replaced_split_ids)
+            .field("index_id", &self.index_id)
+            .field("checkpoint_deltas", &self.checkpoint_deltas)
+            .field("time_range", &self.time_range)
+            .field("size_in_bytes", &self.size_in_bytes)
+            .field("split_scratch_directory", &self.split_scratch_directory)
+            .field("num_docs", &self.num_docs)
+            .field("demux_num_ops", &self.demux_num_ops)
+            .field("tags", &self.tags)
+            .field("split_date_of_birth", &self.split_date_of_birth)
+            .field("split_files", &self.split_files)
+            .finish()
+    }
 }
 
 #[derive(Debug)]

--- a/quickwit-indexing/src/split_store/indexing_split_store.rs
+++ b/quickwit-indexing/src/split_store/indexing_split_store.rs
@@ -261,7 +261,7 @@ mod test_split_store {
 
     use quickwit_metastore::{SplitMetadata, SplitMetadataAndFooterOffsets, SplitState};
     use quickwit_storage::{
-        get_split_payload_streamer, PutPayload, RamStorage, Storage, StorageError, StorageErrorKind,
+        PutPayload, RamStorage, SplitPayloadBuilder, Storage, StorageError, StorageErrorKind,
     };
     use tempfile::tempdir;
     use tokio::fs;
@@ -402,7 +402,7 @@ mod test_split_store {
                 .store_split(
                     &split_metadata1,
                     &split_path,
-                    Box::new(get_split_payload_streamer(&[], &[5, 5, 5])?),
+                    Box::new(SplitPayloadBuilder::get_split_payload(&[], &[5, 5, 5])?),
                 )
                 .await?;
             assert!(!split_path.exists());
@@ -445,7 +445,7 @@ mod test_split_store {
                 .store_split(
                     &split_metadata1,
                     &split_path,
-                    Box::new(get_split_payload_streamer(&[], &[5, 5, 5])?),
+                    Box::new(SplitPayloadBuilder::get_split_payload(&[], &[5, 5, 5])?),
                 )
                 .await?;
             assert!(!split_path.exists());
@@ -467,7 +467,7 @@ mod test_split_store {
                 .store_split(
                     &split_metadata2,
                     &split_path,
-                    Box::new(get_split_payload_streamer(&[], &[5, 5, 5])?),
+                    Box::new(SplitPayloadBuilder::get_split_payload(&[], &[5, 5, 5])?),
                 )
                 .await?;
             assert!(!split_path.exists());
@@ -515,7 +515,7 @@ mod test_split_store {
                 .store_split(
                     &split_metadata1,
                     &split_path,
-                    Box::new(get_split_payload_streamer(&[], &[5, 5, 5])?),
+                    Box::new(SplitPayloadBuilder::get_split_payload(&[], &[5, 5, 5])?),
                 )
                 .await?;
             assert!(!split_path.exists());
@@ -537,7 +537,7 @@ mod test_split_store {
                 .store_split(
                     &split_metadata2,
                     &split_path,
-                    Box::new(get_split_payload_streamer(&[], &[5, 5, 5])?),
+                    Box::new(SplitPayloadBuilder::get_split_payload(&[], &[5, 5, 5])?),
                 )
                 .await?;
             assert!(!split_path.exists());
@@ -570,7 +570,7 @@ mod test_split_store {
             merge_policy.clone(),
         )?;
 
-        let split_streamer = get_split_payload_streamer(&[], &[5, 5, 5])?;
+        let split_streamer = SplitPayloadBuilder::get_split_payload(&[], &[5, 5, 5])?;
         {
             let split_path = temp_dir.path().join("split2");
             fs::create_dir_all(&split_path).await?;
@@ -682,7 +682,7 @@ mod test_split_store {
                 .store_split(
                     &split_metadata1,
                     &split_path,
-                    Box::new(get_split_payload_streamer(
+                    Box::new(SplitPayloadBuilder::get_split_payload(
                         &[file_in_split.to_owned()],
                         &[1, 2, 3],
                     )?),

--- a/quickwit-indexing/src/split_store/indexing_split_store.rs
+++ b/quickwit-indexing/src/split_store/indexing_split_store.rs
@@ -32,7 +32,10 @@ use tracing::info;
 
 use super::LocalSplitStore;
 use crate::split_store::SPLIT_CACHE_DIR_NAME;
-use crate::{BundledSplitFile, MergePolicy, StableMultitenantWithTimestampMergePolicy};
+use crate::{
+    get_tantivy_directory_from_split_bundle, MergePolicy, SplitFolder,
+    StableMultitenantWithTimestampMergePolicy,
+};
 
 /// `IndexingSplitStoreParams` encapsulates the various contraints of the cache.
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -121,21 +124,21 @@ impl IndexingSplitStore {
     /// In order to limit the write IO, the file might be moved (and not copied into
     /// the store).
     /// In other words, after calling this function the file will not be available
-    /// at `split_path` anymore.
-    pub async fn store_split(
-        &self,
-        split: &SplitMetadata,
-        split_path: &Path,
+    /// at `split_folder` anymore.
+    pub async fn store_split<'a>(
+        &'a self,
+        split: &'a SplitMetadata,
+        split_folder: &'a Path,
+        put_payload: Box<dyn PutPayload>,
     ) -> anyhow::Result<()> {
         info!("store-split-remote-start");
 
         let start = Instant::now();
-        let split_num_bytes = tokio::fs::metadata(split_path).await?.len() as usize;
+        let split_num_bytes = put_payload.len();
 
         let key = PathBuf::from(quickwit_common::split_file(&split.split_id));
-        let payload = PutPayload::from(split_path.to_path_buf());
         self.remote_storage
-            .put(&key, Box::new(payload))
+            .put(&key, put_payload)
             .await
             .with_context(|| {
                 format!(
@@ -161,9 +164,9 @@ impl IndexingSplitStore {
             info!("store-in-cache");
             if let Some(split_store) = self.local_split_store.as_ref() {
                 let mut split_store_lock = split_store.lock().await;
-                let tantivy_dir = BundledSplitFile::new(split_path.to_path_buf());
+                let tantivy_dir = SplitFolder::new(split_folder.to_path_buf());
                 if split_store_lock
-                    .move_into_cache(&split.split_id, tantivy_dir, split_num_bytes)
+                    .move_into_cache(&split.split_id, tantivy_dir, split_num_bytes as usize)
                     .await?
                 {
                     return Ok(());
@@ -171,7 +174,7 @@ impl IndexingSplitStore {
             }
         }
 
-        tokio::fs::remove_file(split_path).await?;
+        tokio::fs::remove_dir_all(split_folder).await?;
 
         Ok(())
     }
@@ -199,11 +202,11 @@ impl IndexingSplitStore {
         let path = PathBuf::from(quickwit_common::split_file(split_id));
         if let Some(local_split_store) = self.local_split_store.as_ref() {
             let mut local_split_store_lock = local_split_store.lock().await;
-            if let Some(split_file) = local_split_store_lock
+            if let Some(split_folder) = local_split_store_lock
                 .get_cached_split(split_id, output_dir_path)
                 .await?
             {
-                return split_file.get_tantivy_directory();
+                return split_folder.get_tantivy_directory();
             }
         }
         let start_time = Instant::now();
@@ -213,7 +216,7 @@ impl IndexingSplitStore {
             .copy_to_file(&path, &dest_filepath)
             .await?;
         info!(split_id=split_id,elapsed=?start_time.elapsed(), "fetch-split-from_remote-storage-success");
-        BundledSplitFile::new(dest_filepath.to_owned()).get_tantivy_directory()
+        get_tantivy_directory_from_split_bundle(&dest_filepath)
     }
 
     /// Removes the danglings splits.
@@ -252,29 +255,30 @@ impl IndexingSplitStore {
 }
 
 #[cfg(test)]
-mod tests {
+mod test_split_store {
     use std::path::Path;
     use std::sync::Arc;
 
     use quickwit_metastore::{SplitMetadata, SplitMetadataAndFooterOffsets, SplitState};
     use quickwit_storage::{
-        BundleStorageBuilder, RamStorage, Storage, StorageError, StorageErrorKind,
+        get_split_payload_streamer, PutPayload, RamStorage, Storage, StorageError, StorageErrorKind,
     };
     use tempfile::tempdir;
     use tokio::fs;
 
     use super::{IndexingSplitStore, IndexingSplitStoreParams};
     use crate::split_store::SPLIT_CACHE_DIR_NAME;
-    use crate::StableMultitenantWithTimestampMergePolicy;
+    use crate::{MergePolicy, StableMultitenantWithTimestampMergePolicy};
 
     #[tokio::test]
     async fn test_create_should_error_with_wrong_num_files() -> anyhow::Result<()> {
         let local_dir = tempdir()?;
         let root_path = local_dir.path().join(SPLIT_CACHE_DIR_NAME);
         fs::create_dir_all(root_path.to_path_buf()).await?;
-        fs::write(root_path.join("a.split"), b"a").await?;
-        fs::write(root_path.join("b.split"), b"b").await?;
-        fs::write(root_path.join("c.split"), b"c").await?;
+
+        fs::create_dir_all(&root_path.join("a.split")).await?;
+        fs::create_dir_all(&root_path.join("b.split")).await?;
+        fs::create_dir_all(&root_path.join("c.split")).await?;
 
         let cache_params = IndexingSplitStoreParams {
             max_num_splits: 2,
@@ -303,8 +307,9 @@ mod tests {
         let local_dir = tempdir()?;
         let root_path = local_dir.path().join(SPLIT_CACHE_DIR_NAME);
         fs::create_dir_all(root_path.to_path_buf()).await?;
-        fs::write(root_path.join("a.split"), b"abcdefgh").await?;
-        fs::write(root_path.join("b.split"), b"abcdefgh").await?;
+
+        fs::create_dir_all(&root_path.join("a.split")).await?;
+        fs::create_dir_all(&root_path.join("b.split")).await?;
 
         let cache_params = IndexingSplitStoreParams {
             max_num_splits: 4,
@@ -372,13 +377,14 @@ mod tests {
             merge_policy.clone(),
         )?;
         {
-            let bundle_path = temp_dir.path().join("bundle");
-            fs::write(&bundle_path, b"split1 content").await?;
+            let split_path = temp_dir.path().join("split1");
+            fs::create_dir_all(&split_path).await?;
             let split_metadata1 = create_test_split_metadata("split1");
+
             split_store
-                .store_split(&split_metadata1, &bundle_path)
+                .store_split(&split_metadata1, &split_path, Box::new(vec![1, 2, 3, 4]))
                 .await?;
-            assert!(!bundle_path.exists());
+            assert!(!split_path.exists());
             assert!(split_cache_dir
                 .path()
                 .join(SPLIT_CACHE_DIR_NAME)
@@ -386,16 +392,20 @@ mod tests {
                 .exists());
             let local_store_stats = split_store.inspect_local_store().await;
             assert_eq!(local_store_stats.len(), 1);
-            assert_eq!(local_store_stats.get("split1").cloned(), Some(14));
+            assert_eq!(local_store_stats.get("split1").cloned(), Some(4));
         }
         {
-            let bundle_path = temp_dir.path().join("bundle");
-            fs::write(&bundle_path, b"split2 larger content").await?;
+            let split_path = temp_dir.path().join("split2");
+            fs::create_dir_all(&split_path).await?;
             let split_metadata1 = create_test_split_metadata("split2");
             split_store
-                .store_split(&split_metadata1, &bundle_path)
+                .store_split(
+                    &split_metadata1,
+                    &split_path,
+                    Box::new(get_split_payload_streamer(&[], &[5, 5, 5])?),
+                )
                 .await?;
-            assert!(!bundle_path.exists());
+            assert!(!split_path.exists());
             assert!(split_cache_dir
                 .path()
                 .join(SPLIT_CACHE_DIR_NAME)
@@ -403,8 +413,8 @@ mod tests {
                 .exists());
             let local_store_stats = split_store.inspect_local_store().await;
             assert_eq!(local_store_stats.len(), 2);
-            assert_eq!(local_store_stats.get("split1").cloned(), Some(14));
-            assert_eq!(local_store_stats.get("split2").cloned(), Some(21));
+            assert_eq!(local_store_stats.get("split1").cloned(), Some(4));
+            assert_eq!(local_store_stats.get("split2").cloned(), Some(31));
         }
 
         Ok(())
@@ -413,7 +423,6 @@ mod tests {
     #[tokio::test]
     async fn test_put_should_not_store_in_cache_when_max_num_files_reached() -> anyhow::Result<()> {
         let temp_dir = tempfile::tempdir()?;
-        let bundle_path = temp_dir.path().join("bundle");
 
         let split_cache_dir = tempdir()?;
         let merge_policy = Arc::new(StableMultitenantWithTimestampMergePolicy::default());
@@ -428,20 +437,18 @@ mod tests {
             merge_policy.clone(),
         )?;
 
-        let mut bundle_data: Vec<u8> = Vec::new();
-        let create_bundle = BundleStorageBuilder::new(&mut bundle_data)?;
-        create_bundle.finalize()?;
-        // hotcache
-        bundle_data.extend(&[1, 2, 3]);
-        bundle_data.extend(3_usize.to_le_bytes());
-
         {
-            fs::write(&bundle_path, &bundle_data).await?;
+            let split_path = temp_dir.path().join("split1");
+            fs::create_dir_all(&split_path).await?;
             let split_metadata1 = create_test_split_metadata("split1");
             split_store
-                .store_split(&split_metadata1, &bundle_path)
+                .store_split(
+                    &split_metadata1,
+                    &split_path,
+                    Box::new(get_split_payload_streamer(&[], &[5, 5, 5])?),
+                )
                 .await?;
-            assert!(!bundle_path.exists());
+            assert!(!split_path.exists());
             assert!(split_cache_dir
                 .path()
                 .join(SPLIT_CACHE_DIR_NAME)
@@ -452,12 +459,18 @@ mod tests {
             assert_eq!(local_store_stats.get("split1").cloned(), Some(31));
         }
         {
-            fs::write(&bundle_path, &bundle_data).await?;
+            let split_path = temp_dir.path().join("split2");
+            fs::create_dir_all(&split_path).await?;
             let split_metadata2 = create_test_split_metadata("split2");
+
             split_store
-                .store_split(&split_metadata2, &bundle_path)
+                .store_split(
+                    &split_metadata2,
+                    &split_path,
+                    Box::new(get_split_payload_streamer(&[], &[5, 5, 5])?),
+                )
                 .await?;
-            assert!(!bundle_path.exists());
+            assert!(!split_path.exists());
             assert!(!split_cache_dir
                 .path()
                 .join(SPLIT_CACHE_DIR_NAME)
@@ -469,7 +482,9 @@ mod tests {
         }
         {
             let output = tempfile::tempdir()?;
+            // get from cache
             let _split1 = split_store.fetch_split("split1", output.path()).await?;
+            // get from remote storage
             let _split2 = split_store.fetch_split("split2", output.path()).await?;
         }
         Ok(())
@@ -478,7 +493,6 @@ mod tests {
     #[tokio::test]
     async fn test_put_should_not_store_in_cache_when_max_num_bytes_reached() -> anyhow::Result<()> {
         let temp_dir = tempfile::tempdir()?;
-        let bundle_path = temp_dir.path().join("bundle");
 
         let split_cache_dir = tempdir()?;
         let merge_policy = Arc::new(StableMultitenantWithTimestampMergePolicy::default());
@@ -488,18 +502,23 @@ mod tests {
             split_cache_dir.path(),
             IndexingSplitStoreParams {
                 max_num_splits: 10,
-                max_num_bytes: 20,
+                max_num_bytes: 40,
             },
             merge_policy.clone(),
         )?;
 
         {
-            fs::write(&bundle_path, b"split1 content").await?;
+            let split_path = temp_dir.path().join("split1");
+            fs::create_dir_all(&split_path).await?;
             let split_metadata1 = create_test_split_metadata("split1");
             split_store
-                .store_split(&split_metadata1, &bundle_path)
+                .store_split(
+                    &split_metadata1,
+                    &split_path,
+                    Box::new(get_split_payload_streamer(&[], &[5, 5, 5])?),
+                )
                 .await?;
-            assert!(!bundle_path.exists());
+            assert!(!split_path.exists());
             assert!(split_cache_dir
                 .path()
                 .join(SPLIT_CACHE_DIR_NAME)
@@ -507,16 +526,21 @@ mod tests {
                 .exists());
             let local_store_stats = split_store.inspect_local_store().await;
             assert_eq!(local_store_stats.len(), 1);
-            assert_eq!(local_store_stats.get("split1").cloned(), Some(14));
+            assert_eq!(local_store_stats.get("split1").cloned(), Some(31));
         }
 
         {
-            fs::write(&bundle_path, b"split2 content").await?;
+            let split_path = temp_dir.path().join("split2");
+            fs::create_dir_all(&split_path).await?;
             let split_metadata2 = create_test_split_metadata("split2");
             split_store
-                .store_split(&split_metadata2, &bundle_path)
+                .store_split(
+                    &split_metadata2,
+                    &split_path,
+                    Box::new(get_split_payload_streamer(&[], &[5, 5, 5])?),
+                )
                 .await?;
-            assert!(!bundle_path.exists());
+            assert!(!split_path.exists());
             assert!(!split_cache_dir
                 .path()
                 .join(SPLIT_CACHE_DIR_NAME)
@@ -524,7 +548,7 @@ mod tests {
                 .exists());
             let local_store_stats = split_store.inspect_local_store().await;
             assert_eq!(local_store_stats.len(), 1);
-            assert_eq!(local_store_stats.get("split1").cloned(), Some(14));
+            assert_eq!(local_store_stats.get("split2").cloned(), None);
         }
         Ok(())
     }
@@ -532,7 +556,6 @@ mod tests {
     #[tokio::test]
     async fn test_delete_should_remove_from_both_storage() -> anyhow::Result<()> {
         let temp_dir = tempfile::tempdir()?;
-        let bundle_path = temp_dir.path().join("bundle");
 
         let split_cache_dir = tempdir()?;
         let merge_policy = Arc::new(StableMultitenantWithTimestampMergePolicy::default());
@@ -542,18 +565,24 @@ mod tests {
             split_cache_dir.path(),
             IndexingSplitStoreParams {
                 max_num_splits: 10,
-                max_num_bytes: 20,
+                max_num_bytes: 40,
             },
             merge_policy.clone(),
         )?;
 
+        let split_streamer = get_split_payload_streamer(&[], &[5, 5, 5])?;
         {
-            fs::write(&bundle_path, b"split1 content").await?;
+            let split_path = temp_dir.path().join("split2");
+            fs::create_dir_all(&split_path).await?;
             let split_metadata1 = create_test_split_metadata("split1");
             split_store
-                .store_split(&split_metadata1, &bundle_path)
+                .store_split(
+                    &split_metadata1,
+                    &split_path,
+                    Box::new(split_streamer.clone()),
+                )
                 .await?;
-            assert!(!bundle_path.exists());
+            assert!(!split_path.exists());
             assert!(split_cache_dir
                 .path()
                 .join(SPLIT_CACHE_DIR_NAME)
@@ -561,11 +590,11 @@ mod tests {
                 .exists());
             let local_store_stats = split_store.inspect_local_store().await;
             assert_eq!(local_store_stats.len(), 1);
-            assert_eq!(local_store_stats.get("split1").cloned(), Some(14));
+            assert_eq!(local_store_stats.get("split1").cloned(), Some(31));
         }
 
         let split1_bytes = remote_storage.get_all(Path::new("split1.split")).await?;
-        assert_eq!(&split1_bytes, &b"split1 content"[..]);
+        assert_eq!(split1_bytes, &split_streamer.read_all().await?);
 
         split_store.delete("split1").await?;
 
@@ -583,12 +612,16 @@ mod tests {
         let local_dir = tempdir()?;
         let root_path = local_dir.path().join(SPLIT_CACHE_DIR_NAME);
         fs::create_dir_all(root_path.to_path_buf()).await?;
-        fs::write(root_path.join("a.split"), b"a").await?;
-        fs::write(root_path.join("b.split"), b"b").await?;
+
+        fs::create_dir_all(&root_path.join("a.split")).await?;
+        fs::create_dir_all(&root_path.join("b.split")).await?;
+
+        fs::write(root_path.join("a.split").join("myfile"), b"abcdefgh").await?;
+        fs::write(root_path.join("b.split").join("myfile"), b"abcdefgh").await?;
 
         let cache_params = IndexingSplitStoreParams {
             max_num_splits: 100,
-            max_num_bytes: 100,
+            max_num_bytes: 200,
         };
         let remote_storage = Arc::new(RamStorage::default());
         let merge_policy = Arc::new(StableMultitenantWithTimestampMergePolicy::default());
@@ -611,6 +644,61 @@ mod tests {
             .await?;
         assert!(!root_path.join("a.split").as_path().exists());
         assert!(root_path.join("b.split").as_path().exists());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_mature_splits() -> anyhow::Result<()> {
+        #[derive(Debug)]
+        struct SplitsAreMature {}
+        impl MergePolicy for SplitsAreMature {
+            fn operations(
+                &self,
+                _: &mut Vec<SplitMetadata>,
+            ) -> Vec<crate::merge_policy::MergeOperation> {
+                unimplemented!()
+            }
+            fn is_mature(&self, _: &SplitMetadata) -> bool {
+                true
+            }
+        }
+        let temp_dir = tempfile::tempdir()?;
+        let split_cache_dir = tempdir()?;
+        let remote_storage = Arc::new(RamStorage::default());
+        let split_store = IndexingSplitStore::create_with_local_store(
+            remote_storage,
+            split_cache_dir.path(),
+            IndexingSplitStoreParams::default(),
+            Arc::new(SplitsAreMature {}),
+        )?;
+        {
+            let split_path = temp_dir.path().join("split1");
+            fs::create_dir_all(&split_path).await?;
+            let file_in_split = split_path.join("myfile");
+            fs::write(file_in_split.to_owned(), b"abcdefgh").await?;
+            let split_metadata1 = create_test_split_metadata("split1");
+
+            split_store
+                .store_split(
+                    &split_metadata1,
+                    &split_path,
+                    Box::new(get_split_payload_streamer(
+                        &[file_in_split.to_owned()],
+                        &[1, 2, 3],
+                    )?),
+                )
+                .await?;
+            assert!(!split_path.exists());
+            assert!(!split_cache_dir
+                .path()
+                .join(SPLIT_CACHE_DIR_NAME)
+                .join("split1.split")
+                .exists());
+            let local_store_stats = split_store.inspect_local_store().await;
+            assert_eq!(local_store_stats.len(), 0);
+            assert_eq!(local_store_stats.get("split1").cloned(), None);
+        }
+
         Ok(())
     }
 }

--- a/quickwit-indexing/src/split_store/local_split_store.rs
+++ b/quickwit-indexing/src/split_store/local_split_store.rs
@@ -24,7 +24,7 @@ use std::{fs, io};
 
 use quickwit_common::split_file;
 use quickwit_directories::BundleDirectory;
-use quickwit_storage::{get_split_payload_streamer, PutPayload, StorageErrorKind, StorageResult};
+use quickwit_storage::{PutPayload, SplitPayloadBuilder, StorageErrorKind, StorageResult};
 use tantivy::directory::MmapDirectory;
 use tantivy::Directory;
 use tracing::{error, warn};
@@ -130,7 +130,7 @@ impl LocalSplitStore {
                     .map(|el| el.map(|el| el.path()))
                     .collect::<Result<_, _>>()?;
                 // TODO: Do we need the hotcache?
-                let split_streamer = get_split_payload_streamer(&paths, &[])?;
+                let split_streamer = SplitPayloadBuilder::get_split_payload(&paths, &[])?;
 
                 let split_num_bytes = split_streamer.len() as usize;
                 total_size_in_bytes += split_num_bytes;
@@ -346,7 +346,7 @@ mod tests {
         let mut file2 = File::create(&test_filepath2)?;
         file2.write_all(&[99, 55, 44])?;
 
-        let split_streamer = get_split_payload_streamer(
+        let split_streamer = SplitPayloadBuilder::get_split_payload(
             &[test_filepath1.clone(), test_filepath2.clone()],
             &[1, 2, 3],
         )?;

--- a/quickwit-indexing/src/split_store/local_split_store.rs
+++ b/quickwit-indexing/src/split_store/local_split_store.rs
@@ -24,33 +24,43 @@ use std::{fs, io};
 
 use quickwit_common::split_file;
 use quickwit_directories::BundleDirectory;
-use quickwit_storage::{StorageErrorKind, StorageResult};
+use quickwit_storage::{get_split_payload_streamer, PutPayload, StorageErrorKind, StorageResult};
 use tantivy::directory::MmapDirectory;
 use tantivy::Directory;
 use tracing::{error, warn};
 
 use super::IndexingSplitStoreParams;
 
-#[derive(Clone, Debug)]
-pub struct BundledSplitFile {
-    pub path: PathBuf,
+pub fn get_tantivy_directory_from_split_bundle(
+    split_file: &Path,
+) -> StorageResult<Box<dyn Directory>> {
+    let mmap_directory = MmapDirectory::open(split_file.parent().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::NotFound,
+            format!("Couldn't find parent for {:?}", &split_file),
+        )
+    })?)?;
+    let split_fileslice = mmap_directory.open_read(Path::new(&split_file))?;
+    Ok(Box::new(BundleDirectory::open_split(split_fileslice)?))
 }
-impl BundledSplitFile {
+
+#[derive(Clone, Debug)]
+pub struct SplitFolder {
+    path: PathBuf,
+}
+impl SplitFolder {
     pub fn new(path: PathBuf) -> Self {
-        BundledSplitFile { path }
+        SplitFolder { path }
+    }
+    fn path(&self) -> &Path {
+        &self.path
     }
 }
 
-impl BundledSplitFile {
+impl SplitFolder {
     pub fn get_tantivy_directory(&self) -> StorageResult<Box<dyn Directory>> {
-        let mmap_directory = MmapDirectory::open(self.path.parent().ok_or_else(|| {
-            io::Error::new(
-                io::ErrorKind::NotFound,
-                format!("Couldn't find parent for {:?}", &self.path),
-            )
-        })?)?;
-        let split_fileslice = mmap_directory.open_read(Path::new(&self.path))?;
-        Ok(Box::new(BundleDirectory::open_split(split_fileslice)?))
+        let mmap_directory = MmapDirectory::open(&self.path)?;
+        Ok(Box::new(mmap_directory))
     }
 
     /// Moves the underlying data to a new location.
@@ -63,7 +73,7 @@ impl BundledSplitFile {
     }
 
     async fn delete(&self) -> io::Result<()> {
-        missing_file_is_ok(tokio::fs::remove_file(&self.path).await)?;
+        missing_file_is_ok(tokio::fs::remove_dir_all(&self.path).await)?;
         Ok(())
     }
 }
@@ -76,9 +86,8 @@ fn missing_file_is_ok(io_result: io::Result<()>) -> io::Result<()> {
     }
 }
 
-// TODO add folder support
-fn split_id_from_filename(dir_entry: &DirEntry) -> Option<String> {
-    if !dir_entry.path().is_file() {
+fn split_id_from_split_folder(dir_entry: &DirEntry) -> Option<String> {
+    if !dir_entry.path().is_dir() {
         return None;
     }
     let split_filename = dir_entry.file_name().into_string().ok()?;
@@ -98,7 +107,7 @@ pub struct LocalSplitStore {
     params: IndexingSplitStoreParams,
     /// Splits owned by the local split store, which reside in the split_store_folder.
     /// SplitId -> (Split Num Bytes, BundledSplitFile)
-    split_files: HashMap<String, (usize, BundledSplitFile)>,
+    split_files: HashMap<String, (usize, SplitFolder)>,
     /// The root folder where all data is moved into.
     split_store_folder: PathBuf,
 }
@@ -111,14 +120,19 @@ impl LocalSplitStore {
         local_storage_root: PathBuf,
         params: IndexingSplitStoreParams,
     ) -> StorageResult<LocalSplitStore> {
-        let mut split_files: HashMap<String, (usize, BundledSplitFile)> = HashMap::new();
+        let mut split_files: HashMap<String, (usize, SplitFolder)> = HashMap::new();
         let mut total_size_in_bytes: usize = 0;
         for dir_entry_result in fs::read_dir(&local_storage_root)? {
             let dir_entry = dir_entry_result?;
-            if let Some(split_id) = split_id_from_filename(&dir_entry) {
-                // TODO support folder containing tantivy index
-                let split_file = BundledSplitFile::new(dir_entry.path());
-                let split_num_bytes = dir_entry.metadata()?.len() as usize;
+            if let Some(split_id) = split_id_from_split_folder(&dir_entry) {
+                let split_file = SplitFolder::new(dir_entry.path());
+                let paths: Vec<_> = fs::read_dir(dir_entry.path())?
+                    .map(|el| el.map(|el| el.path()))
+                    .collect::<Result<_, _>>()?;
+                // TODO: Do we need the hotcache?
+                let split_streamer = get_split_payload_streamer(&paths, &[])?;
+
+                let split_num_bytes = split_streamer.len() as usize;
                 total_size_in_bytes += split_num_bytes;
                 split_files.insert(split_id, (split_num_bytes, split_file));
             }
@@ -179,20 +193,22 @@ impl LocalSplitStore {
     }
 
     /// Moves a split into the store.
-    /// from here is an external path, and to is an internal path.
     pub async fn move_into(
         &self,
-        split: &mut BundledSplitFile,
-        to_full_path: &Path,
+        split: &mut SplitFolder,
+        new_folder: &Path,
         split_id: &str,
     ) -> StorageResult<()> {
-        split.move_to(to_full_path, split_id).await?;
+        split.move_to(new_folder, split_id).await?;
         Ok(())
     }
 
-    /// Moves a split within the store to an external path.
-    /// from here is an internal path, and to is an external path.
-    pub async fn move_out(&mut self, split_id: &str, to: &Path) -> StorageResult<BundledSplitFile> {
+    /// Moves a split within the store to an external folder.
+    pub async fn move_out(
+        &mut self,
+        split_id: &str,
+        to_folder: &Path,
+    ) -> StorageResult<SplitFolder> {
         let mut split_file = self
             .split_files
             .remove(split_id)
@@ -201,15 +217,16 @@ impl LocalSplitStore {
                     .with_error(anyhow::anyhow!("Missing split_id `{}`", split_id))
             })?
             .1;
-        split_file.move_to(to, split_id).await?;
+        split_file.move_to(to_folder, split_id).await?;
         Ok(split_file)
     }
 
+    /// Retuns a cached split.
     pub async fn get_cached_split(
         &mut self,
         split_id: &str,
         output_dir_path: &Path,
-    ) -> StorageResult<Option<BundledSplitFile>> {
+    ) -> StorageResult<Option<SplitFolder>> {
         if !self.split_files.contains_key(split_id) {
             return Ok(None);
         }
@@ -241,9 +258,9 @@ impl LocalSplitStore {
         }
     }
 
-    /// Tries to move a `split` file into the cache.
+    /// Tries to move a `split_folder` file into the cache.
     ///
-    /// Move is not an image here. We are litterally moving files.
+    /// Move is not an image here. We are litterally moving the directory.
     ///
     /// If the cache capacity does not allow it, this function
     /// just logs a warning and returns Ok(false).
@@ -252,9 +269,10 @@ impl LocalSplitStore {
     pub async fn move_into_cache<'a>(
         &'a mut self,
         split_id: &'a str,
-        mut split_file: BundledSplitFile,
+        mut split_folder: SplitFolder,
         split_num_bytes: usize,
     ) -> io::Result<bool> {
+        assert!(split_folder.path().is_dir());
         let size_in_cache = self.size_in_store();
 
         // Avoid storing in the cache when the maximum number of cached files is reached.
@@ -269,39 +287,80 @@ impl LocalSplitStore {
             return Ok(false);
         }
 
-        self.move_into(&mut split_file, &self.split_store_folder, split_id)
+        self.move_into(&mut split_folder, &self.split_store_folder, split_id)
             .await?;
 
         self.split_files
-            .insert(split_id.to_string(), (split_num_bytes, split_file));
+            .insert(split_id.to_string(), (split_num_bytes, split_folder));
         Ok(true)
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::fs::File;
+    use std::io::Write;
+
+    use quickwit_storage::PutPayload;
+    use tantivy::directory::FileSlice;
+
     use super::*;
 
     #[tokio::test]
     async fn test_local_split_store_load_existing_splits() -> anyhow::Result<()> {
         let temp_dir = tempfile::tempdir()?;
-        tokio::fs::write(&temp_dir.path().join("split1.split"), b"split-content").await?;
-        tokio::fs::write(&temp_dir.path().join("split2.split"), b"split-content2").await?;
+        tokio::fs::write(&temp_dir.path().join("not-a-split.split"), b"split-content").await?;
+        tokio::fs::write(
+            &temp_dir.path().join("also-not-a-split.split"),
+            b"split-content2",
+        )
+        .await?;
         tokio::fs::write(&temp_dir.path().join("different-file"), b"split-content").await?;
-        tokio::fs::create_dir(&temp_dir.path().join("not-a-split.split")).await?;
+        tokio::fs::create_dir(&temp_dir.path().join("split1.split")).await?;
+        tokio::fs::create_dir(&temp_dir.path().join("split2.split")).await?;
         let params = IndexingSplitStoreParams::default();
         let split_store = LocalSplitStore::open(temp_dir.path().to_path_buf(), params)?;
         let cache_content = split_store.inspect();
         assert_eq!(cache_content.len(), 2);
-        assert_eq!(cache_content.get("split1").cloned(), Some(13));
-        assert_eq!(cache_content.get("split2").cloned(), Some(14));
+        assert_eq!(cache_content.get("split1").cloned(), Some(28));
+        assert_eq!(cache_content.get("split2").cloned(), Some(28));
         assert_eq!(
             split_store.size_in_store(),
             SizeInCache {
                 num_splits: 2,
-                size_in_bytes: 27
+                size_in_bytes: 28 * 2
             }
         );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_stream_split_to_bundle_and_open() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let test_filepath1 = temp_dir.path().join("f1");
+        let test_filepath2 = temp_dir.path().join("f2");
+
+        let mut file1 = File::create(&test_filepath1)?;
+        file1.write_all(&[123, 76])?;
+
+        let mut file2 = File::create(&test_filepath2)?;
+        file2.write_all(&[99, 55, 44])?;
+
+        let split_streamer = get_split_payload_streamer(
+            &[test_filepath1.clone(), test_filepath2.clone()],
+            &[1, 2, 3],
+        )?;
+
+        let data = split_streamer.read_all().await?;
+
+        let bundle_dir = BundleDirectory::open_split(FileSlice::from(data.to_vec()))?;
+
+        let f1_data = bundle_dir.atomic_read(Path::new("f1"))?;
+        assert_eq!(&*f1_data, &[123u8, 76u8]);
+
+        let f2_data = bundle_dir.atomic_read(Path::new("f2"))?;
+        assert_eq!(&f2_data[..], &[99, 55, 44]);
+
         Ok(())
     }
 }

--- a/quickwit-indexing/src/split_store/mod.rs
+++ b/quickwit-indexing/src/split_store/mod.rs
@@ -21,8 +21,8 @@ mod indexing_split_store;
 mod local_split_store;
 
 pub use indexing_split_store::{IndexingSplitStore, IndexingSplitStoreParams};
-pub use local_split_store::BundledSplitFile;
 use local_split_store::LocalSplitStore;
+pub use local_split_store::{get_tantivy_directory_from_split_bundle, SplitFolder};
 
 /// An intermediate folder created at `<cache dir>/SPLIT_CACHE_DIR_NAME`
 /// to hold the local split files.

--- a/quickwit-metastore/src/metastore/single_file_metastore.rs
+++ b/quickwit-metastore/src/metastore/single_file_metastore.rs
@@ -25,7 +25,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use chrono::Utc;
 use quickwit_storage::{
-    quickwit_storage_uri_resolver, PutPayload, Storage, StorageErrorKind, StorageResolverError,
+    quickwit_storage_uri_resolver, Storage, StorageErrorKind, StorageResolverError,
     StorageUriResolver,
 };
 use tokio::sync::Mutex;
@@ -156,7 +156,7 @@ impl InnerSingleFileMetastore {
 
         // Put data back into storage.
         self.storage
-            .put(&metadata_path, Box::new(PutPayload::from(content)))
+            .put(&metadata_path, Box::new(content))
             .await
             .map_err(|storage_err| match storage_err.kind() {
                 StorageErrorKind::Unauthorized => MetastoreError::Forbidden {
@@ -692,7 +692,7 @@ mod tests {
 
     use chrono::Utc;
     use quickwit_index_config::WikipediaIndexConfig;
-    use quickwit_storage::{MockStorage, PutPayload, StorageErrorKind};
+    use quickwit_storage::{MockStorage, StorageErrorKind};
     use rand::Rng;
     use tokio::time::Duration;
 
@@ -881,7 +881,7 @@ mod tests {
             .lock()
             .await
             .storage
-            .put(&metadata_path, Box::new(PutPayload::from(content)))
+            .put(&metadata_path, Box::new(content))
             .await
             .unwrap();
 

--- a/quickwit-search/src/leaf.rs
+++ b/quickwit-search/src/leaf.rs
@@ -18,7 +18,6 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::collections::{BTreeMap, HashSet};
-use std::convert::TryInto;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -36,6 +35,7 @@ use quickwit_storage::{
     wrap_storage_with_long_term_cache, BundleStorage, MemorySizedCache, OwnedBytes, Storage,
 };
 use tantivy::collector::Collector;
+use tantivy::directory::FileSlice;
 use tantivy::query::Query;
 use tantivy::{Index, ReloadPolicy, Searcher, Term};
 use tokio::task::spawn_blocking;
@@ -100,20 +100,19 @@ pub(crate) async fn open_index(
     split_and_footer_offsets: &SplitIdAndFooterOffsets,
 ) -> anyhow::Result<Index> {
     let split_file = PathBuf::from(format!("{}.split", split_and_footer_offsets.split_id));
-    let mut footer_data =
+    let footer_data =
         get_split_footer_from_cache_or_fetch(index_storage.clone(), split_and_footer_offsets)
             .await?;
-    let hotcache_len_bytes = footer_data.split_off(footer_data.len() - 8);
-    let hotcache_num_bytes =
-        u64::from_le_bytes((&*hotcache_len_bytes).try_into().unwrap()) as usize;
 
-    let hotcache_bytes = footer_data.split_off(footer_data.len() - hotcache_num_bytes);
-
-    let bundle_storage = BundleStorage::new(index_storage, split_file, &footer_data)?;
+    let (hotcache_bytes, bundle_storage) = BundleStorage::open_from_split_data(
+        index_storage,
+        split_file,
+        FileSlice::new(Box::new(footer_data)),
+    )?;
     let bundle_storage_with_cache = wrap_storage_with_long_term_cache(Arc::new(bundle_storage));
     let directory = StorageDirectory::new(bundle_storage_with_cache);
     let caching_directory = CachingDirectory::new_with_unlimited_capacity(Arc::new(directory));
-    let hot_directory = HotDirectory::open(caching_directory, hotcache_bytes)?;
+    let hot_directory = HotDirectory::open(caching_directory, hotcache_bytes.read_bytes()?)?;
     let index = Index::open(hot_directory)?;
     Ok(index)
 }

--- a/quickwit-storage/src/bundle_storage.rs
+++ b/quickwit-storage/src/bundle_storage.rs
@@ -265,7 +265,7 @@ mod tests {
     use std::fs;
 
     use super::*;
-    use crate::{get_split_payload_streamer, PutPayload, RamStorageBuilder};
+    use crate::{PutPayload, RamStorageBuilder, SplitPayloadBuilder};
 
     #[tokio::test]
     async fn bundle_storage_file_offsets() -> anyhow::Result<()> {
@@ -279,7 +279,7 @@ mod tests {
         let mut file2 = File::create(&test_filepath2)?;
         file2.write_all(&[99, 55, 44])?;
 
-        let buffer = get_split_payload_streamer(
+        let buffer = SplitPayloadBuilder::get_split_payload(
             &[test_filepath1.clone(), test_filepath2.clone()],
             &[5, 5, 5],
         )?
@@ -320,7 +320,7 @@ mod tests {
         let mut file2 = File::create(&test_filepath2)?;
         file2.write_all(&[99, 55, 44])?;
 
-        let buffer = get_split_payload_streamer(
+        let buffer = SplitPayloadBuilder::get_split_payload(
             &[test_filepath1.clone(), test_filepath2.clone()],
             &[1, 3, 3, 7],
         )?
@@ -359,7 +359,9 @@ mod tests {
 
     #[tokio::test]
     async fn bundlestorage_test_empty() -> anyhow::Result<()> {
-        let buffer = get_split_payload_streamer(&[], &[])?.read_all().await?;
+        let buffer = SplitPayloadBuilder::get_split_payload(&[], &[])?
+            .read_all()
+            .await?;
 
         let (_hotcache, metadata) =
             BundleStorageFileOffsets::open_from_split_data(FileSlice::from(buffer.to_vec()))?;

--- a/quickwit-storage/src/bundle_storage.rs
+++ b/quickwit-storage/src/bundle_storage.rs
@@ -22,7 +22,7 @@ use std::convert::TryInto;
 use std::fmt;
 use std::fmt::Debug;
 use std::fs::File;
-use std::io::{self, ErrorKind, Read, Write};
+use std::io::{self, Write};
 use std::ops::Range;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -30,16 +30,12 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use quickwit_common::chunk_range;
 use serde::{Deserialize, Serialize};
-use tantivy::common::CountingWriter;
 use tantivy::directory::FileSlice;
 use tantivy::HasLen;
 use thiserror::Error;
 use tracing::error;
 
 use crate::{OwnedBytes, Storage, StorageError, StorageResult};
-
-/// Filename used for the bundle.
-pub const BUNDLE_FILENAME: &str = "bundle";
 
 /// BundleStorage bundles together multiple files into a single file.
 /// with some metadata
@@ -50,21 +46,43 @@ pub struct BundleStorage {
 }
 
 impl BundleStorage {
-    /// Creates a new BundleStorage.
+    /// Opens a BundleStorage.
     ///
     /// The provided data must include the footer_bytes at the end of the slice, but it can have
     /// more up front.
-    pub fn new(
+    ///
+    /// Returns (Hotcache, Self)
+    pub fn open_from_split_data_with_owned_bytes(
         storage: Arc<dyn Storage>,
         bundle_filepath: PathBuf,
-        meta_data: &[u8],
-    ) -> Result<Self, CorruptedData> {
-        let metadata = BundleStorageFileOffsets::open(meta_data)?;
-        Ok(BundleStorage {
+        split_data: OwnedBytes,
+    ) -> io::Result<(FileSlice, Self)> {
+        Self::open_from_split_data(
             storage,
             bundle_filepath,
-            metadata,
-        })
+            FileSlice::new(Box::new(split_data)),
+        )
+    }
+    /// Opens a BundleStorage.
+    ///
+    /// The provided data must include the footer_bytes at the end of the slice, but it can have
+    /// more up front.
+    ///
+    /// Returns (Hotcache, Self)
+    pub fn open_from_split_data(
+        storage: Arc<dyn Storage>,
+        bundle_filepath: PathBuf,
+        split_data: FileSlice,
+    ) -> io::Result<(FileSlice, Self)> {
+        let (hotcache, metadata) = BundleStorageFileOffsets::open_from_split_data(split_data)?;
+        Ok((
+            hotcache,
+            BundleStorage {
+                storage,
+                bundle_filepath,
+                metadata,
+            },
+        ))
     }
 
     /// Returns Iterator over files contained in the bundle.
@@ -82,37 +100,51 @@ pub struct CorruptedData {
 }
 
 const SPLIT_HOTBYTES_FOOTER_LENGTH_NUM_BYTES: usize = std::mem::size_of::<u64>();
+const BUNDLE_METADATA_LENGTH_NUM_BYTES: usize = std::mem::size_of::<u64>();
 
 /// Returns the file offsets in the file bundle.
 #[derive(Debug, Default, Serialize, Deserialize, Clone)]
 pub struct BundleStorageFileOffsets {
     /// The files and their offsets in the body
-    pub files: HashMap<PathBuf, Range<usize>>,
+    pub files: HashMap<PathBuf, Range<u64>>,
 }
 
 impl BundleStorageFileOffsets {
-    fn open(data: &[u8]) -> Result<Self, CorruptedData> {
-        let (body_and_footer, footer_num_bytes_data) =
-            data.split_at(data.len() - SPLIT_HOTBYTES_FOOTER_LENGTH_NUM_BYTES);
-        let footer_num_bytes: u64 = u64::from_le_bytes(footer_num_bytes_data.try_into().unwrap());
-        let footer_slice = &body_and_footer[body_and_footer.len() - footer_num_bytes as usize..];
-        let bundle_storage_file_offsets = serde_json::from_slice(footer_slice)?;
-        Ok(bundle_storage_file_offsets)
+    /// File need to include split data (with hotcache at the end).
+    /// See docs/internals/split-format.md
+    /// [Files, FileMetadata, FileMetadata Len, HotCache, HotCache Len]
+    /// Returns (Hotcache, Self)
+    fn open_from_split_data(file: FileSlice) -> io::Result<(FileSlice, Self)> {
+        let (bundle_and_hotcache_bytes, hotcache_num_bytes_data) =
+            file.split_from_end(SPLIT_HOTBYTES_FOOTER_LENGTH_NUM_BYTES);
+
+        let hotcache_num_bytes: u64 = u64::from_le_bytes(
+            hotcache_num_bytes_data
+                .read_bytes()?
+                .as_ref()
+                .try_into()
+                .unwrap(),
+        );
+        let (bundle, hotcache) =
+            bundle_and_hotcache_bytes.split_from_end(hotcache_num_bytes as usize);
+        Ok((hotcache, Self::open(bundle)?))
     }
 
-    /// Read metadata from a file.
-    pub fn open_from_file_slice(file: FileSlice) -> io::Result<Self> {
-        let (body_and_footer, footer_num_bytes_data) =
-            file.split_from_end(SPLIT_HOTBYTES_FOOTER_LENGTH_NUM_BYTES);
+    /// FileSlice needs to end with the bundle (without hotcache from the split at the end).
+    /// See docs/internals/split-format.md
+    /// [Files, FileMetadata, FileMetadata Len]
+    pub fn open(file: FileSlice) -> io::Result<Self> {
+        let (tantivy_files_data, num_bytes_file_metadata) =
+            file.split_from_end(BUNDLE_METADATA_LENGTH_NUM_BYTES);
         let footer_num_bytes: u64 = u64::from_le_bytes(
-            footer_num_bytes_data
+            num_bytes_file_metadata
                 .read_bytes()?
                 .as_slice()
                 .try_into()
                 .unwrap(),
         );
 
-        let bundle_storage_file_offsets_data = body_and_footer
+        let bundle_storage_file_offsets_data = tantivy_files_data
             .slice_from_end(footer_num_bytes as usize)
             .read_bytes()?;
         let bundle_storage_file_offsets =
@@ -122,7 +154,7 @@ impl BundleStorageFileOffsets {
     }
 
     /// Returns file offsets for given path.
-    pub fn get(&self, path: &Path) -> Option<Range<usize>> {
+    pub fn get(&self, path: &Path) -> Option<Range<u64>> {
         self.files.get(path).cloned()
     }
 
@@ -137,7 +169,7 @@ impl Storage for BundleStorage {
     async fn put(
         &self,
         path: &Path,
-        _payload: Box<dyn crate::PutPayloadProvider>,
+        _payload: Box<dyn crate::PutPayload>,
     ) -> crate::StorageResult<()> {
         Err(unsupported_operation(path))
     }
@@ -198,7 +230,7 @@ impl Storage for BundleStorage {
             crate::StorageErrorKind::DoesNotExist
                 .with_error(anyhow::anyhow!("Missing file `{}`", path.display()))
         })?;
-        Ok(file_range.len() as u64)
+        Ok(file_range.end - file_range.start as u64)
     }
 
     fn uri(&self) -> String {
@@ -228,90 +260,18 @@ fn unsupported_operation(path: &Path) -> StorageError {
     io::Error::new(io::ErrorKind::Other, format!("{}: {:?}", msg, path)).into()
 }
 
-/// BundleStorage bundles together multiple files into a single file
-/// with some metadata
-pub struct BundleStorageBuilder<W> {
-    metadata: BundleStorageFileOffsets,
-    counting_writer: CountingWriter<W>,
-}
-
-impl<W: io::Write> BundleStorageBuilder<W> {
-    /// Creates a new BundleStorageBuilder, to which files can be added.
-    pub fn new(wrt: W) -> io::Result<Self> {
-        let counting_writer = CountingWriter::wrap(wrt);
-        Ok(BundleStorageBuilder {
-            counting_writer,
-            metadata: Default::default(),
-        })
-    }
-
-    /// Appends a file to the bundle file.
-    ///
-    /// The hotcache needs to be the last file that is added, in order to be able to read
-    /// the hotcache and the metadata in one continous read.
-    pub fn add_file_from_read<R: Read>(
-        &mut self,
-        mut read: R,
-        file_name: PathBuf,
-    ) -> io::Result<()> {
-        let start_offset = self.counting_writer.written_bytes() as usize;
-        io::copy(&mut read, &mut self.counting_writer)?;
-        let end_offset = self.counting_writer.written_bytes() as usize;
-        self.metadata
-            .files
-            .insert(file_name, start_offset..end_offset);
-        Ok(())
-    }
-
-    /// Appends a file to the bundle file.
-    ///
-    /// The hotcache needs to be the last file that is added, in order to be able to read
-    /// the hotcache and the metadata in one continous read.
-    pub fn add_file(&mut self, path: &Path) -> io::Result<()> {
-        let file = File::open(path)?;
-        let file_name = PathBuf::from(path.file_name().ok_or_else(|| {
-            io::Error::new(
-                ErrorKind::InvalidInput,
-                format!("could not extract file_name from path {:?}", path),
-            )
-        })?);
-        self.add_file_from_read(file, file_name)?;
-        Ok(())
-    }
-
-    /// Writes the bundle file offsets metadata at the end of the bundle file,
-    /// and returns the byte-range of this metadata information.
-    pub fn finalize(mut self) -> io::Result<Range<u64>> {
-        // The footer offset, where the footer begins.
-        // The footer includes the footer metadata as json encoded and the size of the footer in
-        // bytes.
-        let file_offsets_metadata_start = self.counting_writer.written_bytes();
-        let metadata_json = serde_json::to_string(&self.metadata)?;
-        self.counting_writer.write_all(metadata_json.as_bytes())?;
-        let metadata_json_len = metadata_json.len() as u64;
-        self.counting_writer
-            .write_all(&metadata_json_len.to_le_bytes())?;
-        let file_offsets_metadata_end = self.counting_writer.written_bytes();
-        Ok(file_offsets_metadata_start..file_offsets_metadata_end)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use std::fs;
 
     use super::*;
-    use crate::RamStorageBuilder;
+    use crate::{get_split_payload_streamer, PutPayload, RamStorageBuilder};
 
     #[tokio::test]
     async fn bundle_storage_file_offsets() -> anyhow::Result<()> {
         let temp_dir = tempfile::tempdir()?;
         let test_filepath1 = temp_dir.path().join("f1");
         let test_filepath2 = temp_dir.path().join("f2");
-        let test_bundle_path = temp_dir.path().join("le_bundle");
-
-        let mut bundle_file = File::create(test_bundle_path.to_owned())?;
-        let mut bundle_builder = BundleStorageBuilder::new(&mut bundle_file)?;
 
         let mut file1 = File::create(&test_filepath1)?;
         file1.write_all(&[123, 76])?;
@@ -319,14 +279,18 @@ mod tests {
         let mut file2 = File::create(&test_filepath2)?;
         file2.write_all(&[99, 55, 44])?;
 
-        bundle_builder.add_file(&test_filepath1)?;
-        bundle_builder.add_file(&test_filepath2)?;
-        bundle_builder.finalize()?;
+        let buffer = get_split_payload_streamer(
+            &[test_filepath1.clone(), test_filepath2.clone()],
+            &[5, 5, 5],
+        )?
+        .read_all()
+        .await?;
 
         let bundle_filepath = Path::new("bundle");
-        let buffer = fs::read(test_bundle_path)?;
-        let bundle_file_slice = FileSlice::from(buffer.to_owned());
-        let metadata = BundleStorageFileOffsets::open_from_file_slice(bundle_file_slice)?;
+        let bundle_file_slice = FileSlice::new(Box::new(buffer.clone()));
+        let (hotcache, metadata) =
+            BundleStorageFileOffsets::open_from_split_data(bundle_file_slice)?;
+        assert_eq!(hotcache.read_bytes().unwrap().as_ref(), &[5, 5, 5]);
         let ram_storage = RamStorageBuilder::default()
             .put(&bundle_filepath.to_string_lossy(), &buffer)
             .build();
@@ -346,9 +310,6 @@ mod tests {
     }
     #[tokio::test]
     async fn bundle_storage_test() -> anyhow::Result<()> {
-        let mut buffer = Vec::new();
-        let mut bundle_builder = BundleStorageBuilder::new(&mut buffer)?;
-
         let temp_dir = tempfile::tempdir()?;
         let test_filepath1 = temp_dir.path().join("f1");
         let test_filepath2 = temp_dir.path().join("f2");
@@ -359,11 +320,17 @@ mod tests {
         let mut file2 = File::create(&test_filepath2)?;
         file2.write_all(&[99, 55, 44])?;
 
-        bundle_builder.add_file(&test_filepath1)?;
-        bundle_builder.add_file(&test_filepath2)?;
-        bundle_builder.finalize()?;
+        let buffer = get_split_payload_streamer(
+            &[test_filepath1.clone(), test_filepath2.clone()],
+            &[1, 3, 3, 7],
+        )?
+        .read_all()
+        .await?;
 
-        let metadata = BundleStorageFileOffsets::open(&buffer)?;
+        let (hotcache, metadata) =
+            BundleStorageFileOffsets::open_from_split_data(FileSlice::from(buffer.to_vec()))?;
+        assert_eq!(hotcache.read_bytes().unwrap().as_ref(), &[1, 3, 3, 7]);
+
         let bundle_filepath = Path::new("bundle");
         let ram_storage = RamStorageBuilder::default()
             .put(&bundle_filepath.to_string_lossy(), &buffer)
@@ -392,12 +359,10 @@ mod tests {
 
     #[tokio::test]
     async fn bundlestorage_test_empty() -> anyhow::Result<()> {
-        let mut buffer: Vec<u8> = Vec::new();
+        let buffer = get_split_payload_streamer(&[], &[])?.read_all().await?;
 
-        let create_bundle = BundleStorageBuilder::new(&mut buffer)?;
-        create_bundle.finalize()?;
-
-        let metadata = BundleStorageFileOffsets::open(&buffer)?;
+        let (_hotcache, metadata) =
+            BundleStorageFileOffsets::open_from_split_data(FileSlice::from(buffer.to_vec()))?;
 
         let bundle_filepath = PathBuf::from("bundle");
         let ram_storage = RamStorageBuilder::default()

--- a/quickwit-storage/src/cache/storage_with_cache.rs
+++ b/quickwit-storage/src/cache/storage_with_cache.rs
@@ -36,7 +36,7 @@ impl Storage for StorageWithCache {
     async fn put(
         &self,
         path: &Path,
-        _payload: Box<dyn crate::PutPayloadProvider>,
+        _payload: Box<dyn crate::PutPayload>,
     ) -> crate::StorageResult<()> {
         unimplemented!("StorageWithCache is readonly. Failed to put {:?}", path)
     }

--- a/quickwit-storage/src/lib.rs
+++ b/quickwit-storage/src/lib.rs
@@ -56,7 +56,7 @@ pub use self::object_storage::{
 };
 pub use self::prefix_storage::add_prefix_to_storage;
 pub use self::ram_storage::{RamStorage, RamStorageBuilder};
-pub use self::split::{get_split_payload_streamer, SplitPayload, SplitPayloadBuilder};
+pub use self::split::{SplitPayload, SplitPayloadBuilder};
 #[cfg(any(test, feature = "testsuite"))]
 pub use self::storage::MockStorage;
 #[cfg(any(test, feature = "testsuite"))]

--- a/quickwit-storage/src/lib.rs
+++ b/quickwit-storage/src/lib.rs
@@ -31,22 +31,23 @@
 //! - The `BundleStorage` bundles together multiple files into a single file.
 mod cache;
 mod storage;
-pub use self::storage::{PutPayload, PutPayloadProvider, Storage};
+pub use self::payload::PutPayload;
+pub use self::storage::Storage;
 
 mod bundle_storage;
 mod error;
 mod local_file_storage;
 mod object_storage;
+mod payload;
 mod prefix_storage;
 mod ram_storage;
 mod retry;
+mod split;
 mod storage_resolver;
 
 pub use tantivy::directory::OwnedBytes;
 
-pub use self::bundle_storage::{
-    BundleStorage, BundleStorageBuilder, BundleStorageFileOffsets, BUNDLE_FILENAME,
-};
+pub use self::bundle_storage::{BundleStorage, BundleStorageFileOffsets};
 #[cfg(any(test, feature = "testsuite"))]
 pub use self::cache::MockCache;
 pub use self::local_file_storage::{LocalFileStorage, LocalFileStorageFactory};
@@ -55,6 +56,7 @@ pub use self::object_storage::{
 };
 pub use self::prefix_storage::add_prefix_to_storage;
 pub use self::ram_storage::{RamStorage, RamStorageBuilder};
+pub use self::split::{get_split_payload_streamer, SplitPayload, SplitPayloadBuilder};
 #[cfg(any(test, feature = "testsuite"))]
 pub use self::storage::MockStorage;
 #[cfg(any(test, feature = "testsuite"))]
@@ -74,7 +76,7 @@ pub(crate) mod tests {
 
     use anyhow::Context;
 
-    use crate::{PutPayload, Storage, StorageErrorKind};
+    use crate::{Storage, StorageErrorKind};
 
     async fn test_get_inexistent_file(storage: &mut dyn Storage) -> anyhow::Result<()> {
         let err = storage
@@ -90,7 +92,7 @@ pub(crate) mod tests {
         storage
             .put(
                 test_path,
-                Box::new(PutPayload::from(&b"abcdefghiklmnopqrstuvxyz"[..])),
+                Box::new(b"abcdefghiklmnopqrstuvxyz"[..].to_vec()),
             )
             .await?;
         let payload = storage.get_slice(test_path, 3..6).await?;
@@ -101,7 +103,7 @@ pub(crate) mod tests {
     async fn test_write_get_all(storage: &mut dyn Storage) -> anyhow::Result<()> {
         let test_path = Path::new("write_and_read_all");
         storage
-            .put(test_path, Box::new(PutPayload::from(&b"abcdef"[..])))
+            .put(test_path, Box::new(b"abcdef"[..].to_vec()))
             .await?;
         let payload = storage.get_all(test_path).await?;
         assert_eq!(&payload[..], &b"abcdef"[..]);
@@ -112,7 +114,7 @@ pub(crate) mod tests {
         let test_path = Path::new("write_and_cp");
         let payload_bytes = b"abcdefghijklmnopqrstuvwxyz".as_ref();
         storage
-            .put(test_path, Box::new(PutPayload::from(payload_bytes)))
+            .put(test_path, Box::new(payload_bytes.to_vec()))
             .await?;
         let tempdir = tempfile::tempdir()?;
         let dest_path = tempdir.path().to_path_buf();
@@ -127,7 +129,7 @@ pub(crate) mod tests {
         let test_path = Path::new("write_and_delete");
         let payload_bytes = b"abcdefghijklmnopqrstuvwxyz".as_ref();
         storage
-            .put(test_path, Box::new(PutPayload::from(payload_bytes)))
+            .put(test_path, Box::new(payload_bytes.to_vec()))
             .await?;
         storage.delete(test_path).await?;
         let slice_err = storage
@@ -142,7 +144,7 @@ pub(crate) mod tests {
         let test_path = Path::new("write_for_filesize");
         let payload_bytes = b"abcdefghijklmnopqrstuvwxyz".as_ref();
         storage
-            .put(test_path, Box::new(PutPayload::from(payload_bytes)))
+            .put(test_path, Box::new(payload_bytes.to_vec()))
             .await?;
         assert_eq!(storage.file_num_bytes(test_path).await?, 26u64);
         storage.delete(test_path).await?;
@@ -152,9 +154,7 @@ pub(crate) mod tests {
     async fn test_exists(storage: &mut dyn Storage) -> anyhow::Result<()> {
         let test_path = Path::new("exists");
         assert!(matches!(storage.exists(test_path).await, Ok(false)));
-        storage
-            .put(test_path, Box::new(PutPayload::from(b"".as_ref())))
-            .await?;
+        storage.put(test_path, Box::new(vec![])).await?;
         assert!(matches!(storage.exists(test_path).await, Ok(true)));
         assert!(matches!(storage.delete(test_path).await, Ok(())));
         Ok(())
@@ -173,7 +173,7 @@ pub(crate) mod tests {
         let test_path = Path::new("foo/bar/write_and_delete_with_separator");
         let payload_bytes = b"abcdefghijklmnopqrstuvwxyz".as_ref();
         storage
-            .put(test_path, Box::new(PutPayload::from(payload_bytes)))
+            .put(test_path, Box::new(payload_bytes.to_vec()))
             .await?;
         assert!(matches!(
             storage.exists(Path::new("foo/bar")).await,

--- a/quickwit-storage/src/local_file_storage.rs
+++ b/quickwit-storage/src/local_file_storage.rs
@@ -166,7 +166,7 @@ impl Storage for LocalFileStorage {
     async fn put(
         &self,
         path: &Path,
-        payload: Box<dyn crate::PutPayloadProvider>,
+        payload: Box<dyn crate::PutPayload>,
     ) -> crate::StorageResult<()> {
         let full_path = self.root.join(path);
         if let Some(parent_dir) = full_path.parent() {

--- a/quickwit-storage/src/object_storage/s3_compatible_storage.rs
+++ b/quickwit-storage/src/object_storage/s3_compatible_storage.rs
@@ -194,7 +194,7 @@ impl S3CompatibleObjectStorage {
     async fn put_single_part_single_try<'a>(
         &'a self,
         key: &'a str,
-        payload: Box<dyn crate::PutPayloadProvider>,
+        payload: Box<dyn crate::PutPayload>,
         len: u64,
     ) -> Result<(), RusotoErrorWrapper<PutObjectError>> {
         let body = payload.byte_stream().await?;
@@ -212,7 +212,7 @@ impl S3CompatibleObjectStorage {
     async fn put_single_part<'a>(
         &'a self,
         key: &'a str,
-        payload: Box<dyn crate::PutPayloadProvider>,
+        payload: Box<dyn crate::PutPayload>,
         len: u64,
     ) -> StorageResult<()> {
         retry(|| self.put_single_part_single_try(key, payload.clone(), len)).await?;
@@ -244,7 +244,7 @@ impl S3CompatibleObjectStorage {
 
     async fn create_multipart_requests(
         &self,
-        payload: Box<dyn crate::PutPayloadProvider>,
+        payload: Box<dyn crate::PutPayload>,
         len: u64,
         part_len: u64,
     ) -> io::Result<Vec<Part>> {
@@ -277,7 +277,7 @@ impl S3CompatibleObjectStorage {
         upload_id: MultipartUploadId,
         key: &'a str,
         part: Part,
-        payload: Box<dyn crate::PutPayloadProvider>,
+        payload: Box<dyn crate::PutPayload>,
     ) -> Result<CompletedPart, Retry<StorageError>> {
         let byte_stream = payload
             .range_byte_stream(part.range.clone())
@@ -316,7 +316,7 @@ impl S3CompatibleObjectStorage {
     async fn put_multi_part<'a>(
         &'a self,
         key: &'a str,
-        payload: Box<dyn crate::PutPayloadProvider>,
+        payload: Box<dyn crate::PutPayload>,
         part_len: u64,
         total_len: u64,
     ) -> StorageResult<()> {
@@ -457,10 +457,10 @@ impl Storage for S3CompatibleObjectStorage {
     async fn put(
         &self,
         path: &Path,
-        payload: Box<dyn crate::PutPayloadProvider>,
+        payload: Box<dyn crate::PutPayload>,
     ) -> crate::StorageResult<()> {
         let key = self.key(path);
-        let total_len = payload.len().await?;
+        let total_len = payload.len();
         let part_num_bytes = self.multipart_policy.part_num_bytes(total_len);
         if part_num_bytes >= total_len {
             self.put_single_part(&key, payload, total_len).await?;

--- a/quickwit-storage/src/payload.rs
+++ b/quickwit-storage/src/payload.rs
@@ -1,0 +1,85 @@
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use std::io;
+use std::ops::Range;
+
+use async_trait::async_trait;
+use rusoto_core::ByteStream;
+use tantivy::directory::OwnedBytes;
+
+#[async_trait]
+/// PutPayload is used to upload data and support multipart.
+pub trait PutPayload: PutPayloadClone + Send + Sync {
+    /// Return the total length of the payload.
+    fn len(&self) -> u64;
+
+    /// Retrieve bytestream for specified range.
+    async fn range_byte_stream(&self, range: Range<u64>) -> io::Result<ByteStream>;
+
+    /// Retrieve complete bytestream.
+    async fn byte_stream(&self) -> io::Result<ByteStream> {
+        let total_len = self.len();
+        let range = 0..total_len;
+        self.range_byte_stream(range).await
+    }
+
+    /// Load the whole Payload into memory.
+    async fn read_all(&self) -> io::Result<OwnedBytes> {
+        let total_len = self.len();
+        let range = 0..total_len;
+        let mut reader = self.range_byte_stream(range).await?.into_async_read();
+
+        let mut data: Vec<u8> = Vec::with_capacity(total_len as usize);
+        tokio::io::copy(&mut reader, &mut data).await?;
+
+        Ok(OwnedBytes::new(data))
+    }
+}
+
+pub trait PutPayloadClone {
+    fn box_clone(&self) -> Box<dyn PutPayload>;
+}
+
+impl<T> PutPayloadClone for T
+where T: 'static + PutPayload + Clone
+{
+    fn box_clone(&self) -> Box<dyn PutPayload> {
+        Box::new(self.clone())
+    }
+}
+
+impl Clone for Box<dyn PutPayload> {
+    fn clone(&self) -> Box<dyn PutPayload> {
+        self.box_clone()
+    }
+}
+
+#[async_trait]
+impl PutPayload for Vec<u8> {
+    fn len(&self) -> u64 {
+        self.len() as u64
+    }
+
+    async fn range_byte_stream(&self, range: Range<u64>) -> io::Result<ByteStream> {
+        Ok(ByteStream::from(
+            (&self[range.start as usize..range.end as usize]).to_vec(),
+        ))
+    }
+}

--- a/quickwit-storage/src/prefix_storage.rs
+++ b/quickwit-storage/src/prefix_storage.rs
@@ -37,7 +37,7 @@ impl Storage for PrefixStorage {
     async fn put(
         &self,
         path: &Path,
-        payload: Box<dyn crate::PutPayloadProvider>,
+        payload: Box<dyn crate::PutPayload>,
     ) -> crate::StorageResult<()> {
         self.storage.put(&self.prefix.join(path), payload).await
     }

--- a/quickwit-storage/src/ram_storage.rs
+++ b/quickwit-storage/src/ram_storage.rs
@@ -71,7 +71,7 @@ impl Storage for RamStorage {
     async fn put(
         &self,
         path: &Path,
-        payload: Box<dyn crate::PutPayloadProvider>,
+        payload: Box<dyn crate::PutPayload>,
     ) -> crate::StorageResult<()> {
         let payload_bytes = payload.read_all().await?;
         self.put_data(path, payload_bytes).await;

--- a/quickwit-storage/src/split.rs
+++ b/quickwit-storage/src/split.rs
@@ -1,0 +1,469 @@
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use std::collections::HashMap;
+use std::fmt::Debug;
+use std::io::{self, ErrorKind, SeekFrom};
+use std::ops::Range;
+use std::path::{Path, PathBuf};
+
+use async_trait::async_trait;
+use futures::{stream, StreamExt};
+use rusoto_core::ByteStream;
+use tokio::io::{AsyncReadExt, AsyncSeekExt};
+use tokio_util::io::ReaderStream;
+
+use crate::{BundleStorageFileOffsets, PutPayload};
+
+/// Payload of a split which builds the split bundle and hotcache on the fly and streams it to the
+/// storage.
+#[derive(Clone)]
+pub struct SplitPayload {
+    payloads: Vec<Box<dyn PutPayload>>,
+    /// bytes range of the footer (hotcache + bundle metadata)
+    pub footer_range: Range<u64>,
+}
+
+async fn range_byte_stream_from_payloads(
+    payloads: &[Box<dyn PutPayload>],
+    range: Range<u64>,
+) -> io::Result<ByteStream> {
+    let mut bytestreams: Vec<_> = Vec::new();
+
+    let payloads_and_ranges =
+        chunk_payload_ranges(payloads, range.start as usize..range.end as usize);
+
+    for (payload, range) in payloads_and_ranges {
+        bytestreams.push(
+            payload
+                .range_byte_stream(range.start as u64..range.end as u64)
+                .await?,
+        );
+    }
+
+    let concat_stream = ByteStream::new(stream::iter(bytestreams).flatten());
+    Ok(concat_stream)
+}
+
+#[async_trait]
+impl PutPayload for SplitPayload {
+    fn len(&self) -> u64 {
+        self.payloads.iter().map(|payload| payload.len()).sum()
+    }
+
+    async fn range_byte_stream(&self, range: Range<u64>) -> io::Result<ByteStream> {
+        range_byte_stream_from_payloads(&self.payloads, range).await
+
+        // let requested_payload_ranges = chunk_range(&absolute_payload_ranges, range.start as usize
+        // .. range.end as usize); for payload_range in requested_payload_ranges {
+        // let payload_pos =
+        // absolute_payload_ranges.iter().position(|range|range.contains(&payload_range.start)).
+        // expect("broken");
+
+        // let start=absolute_payload_ranges[payload_pos].start as u64;
+        // let relative_range = payload_range.start as u64 - start .. payload_range.end as u64 -
+        // start;
+
+        // bytestreams.push(self.payloads[payload_pos].range_byte_stream(relative_range).await?);
+
+        //}
+
+        // let mut bytestreams: Vec<_> = Vec::new();
+        // for payload in &self.payloads {
+        // let payload_len = payload.len();
+        // if range.start >= payload.len() {
+        //// The current payload does not intersect with the range
+        // range = (range.start - payload_len)..(range.end - payload_len);
+        // continue;
+        //} else if range.end > payload_len {
+        //// This payload intersects with the range, and it is NOT the last one.
+        // bytestreams.push(payload.range_byte_stream(range.start..payload_len).await?);
+        // range = range.start - payload_len..range.end - payload_len;
+        //} else {
+        //// This is the last chunk
+        // bytestreams.push(payload.range_byte_stream(range.start..range.end).await?);
+        // break;
+        //}
+    }
+}
+
+/// compute split offsets used by the SplitStreamer
+pub fn get_split_payload_streamer(
+    split_files: &[PathBuf],
+    hotcache: &[u8],
+) -> io::Result<SplitPayload> {
+    let mut split_offset_computer = SplitPayloadBuilder::new();
+    for file in split_files {
+        split_offset_computer.add_file(file)?;
+    }
+    let offsets = split_offset_computer.finalize(hotcache)?;
+    Ok(offsets)
+}
+
+#[derive(Clone)]
+struct FilePayload {
+    len: u64,
+    path: PathBuf,
+}
+
+#[async_trait]
+impl PutPayload for FilePayload {
+    fn len(&self) -> u64 {
+        self.len
+    }
+
+    async fn range_byte_stream(&self, range: Range<u64>) -> io::Result<ByteStream> {
+        assert!(!range.is_empty());
+        assert!(range.end <= self.len);
+        let mut file = tokio::fs::File::open(&self.path).await?;
+        if range.start > 0 {
+            file.seek(SeekFrom::Start(range.start)).await?;
+        }
+        if range.end == self.len {
+            return Ok(ByteStream::new(ReaderStream::new(file)));
+        }
+        Ok(ByteStream::new(ReaderStream::new(
+            file.take(range.end - range.start),
+        )))
+    }
+}
+
+/// SplitOffsetComputer is used to bundle together multiple files into a single split file.
+#[derive(Default, Debug)]
+pub struct SplitPayloadBuilder {
+    metadata: BundleStorageFileOffsets,
+    current_offset: usize,
+}
+
+impl SplitPayloadBuilder {
+    /// Creates a new SplitOffsetComputer, to which files and the hotcache can be added.
+    pub fn new() -> Self {
+        SplitPayloadBuilder {
+            current_offset: 0,
+            metadata: Default::default(),
+        }
+    }
+
+    /// Adds the file to the bundle file.
+    ///
+    /// The hotcache needs to be the last file that is added, in order to be able to read
+    /// the hotcache and the metadata in one continous read.
+    pub fn add_file(&mut self, path: &Path) -> io::Result<()> {
+        let file = std::fs::metadata(path)?;
+        let file_range = self.current_offset as u64..self.current_offset as u64 + file.len() as u64;
+        self.current_offset += file.len() as usize;
+        self.metadata.files.insert(path.to_owned(), file_range);
+        Ok(())
+    }
+
+    /// Writes the bundle file offsets metadata at the end of the bundle file,
+    /// and returns the byte-range of this metadata information.
+    pub fn finalize(self, hotcache: &[u8]) -> io::Result<SplitPayload> {
+        // Build the footer.
+        let mut footer_bytes = vec![];
+        // Fix paths to be relative
+        let metadata_with_fixed_paths = self
+            .metadata
+            .files
+            .iter()
+            .map(|(path, range)| {
+                let file_name = PathBuf::from(path.file_name().ok_or_else(|| {
+                    io::Error::new(
+                        ErrorKind::InvalidInput,
+                        format!("could not extract file_name from path {:?}", path),
+                    )
+                })?);
+                Ok((file_name, range.start..range.end))
+            })
+            .collect::<Result<HashMap<_, _>, io::Error>>()?;
+
+        let metadata_json = serde_json::to_string(&BundleStorageFileOffsets {
+            files: metadata_with_fixed_paths,
+        })?;
+
+        footer_bytes.extend(metadata_json.as_bytes());
+        let metadata_json_len = metadata_json.len() as u64;
+        footer_bytes.extend(&metadata_json_len.to_le_bytes());
+        footer_bytes.extend(hotcache);
+        footer_bytes.extend(&hotcache.len().to_le_bytes());
+
+        let mut payloads: Vec<Box<dyn PutPayload>> = Vec::new();
+
+        let mut sorted_files = self.metadata.files.iter().collect::<Vec<_>>();
+        sorted_files.sort_by_key(|(_file, range)| range.start);
+
+        for (path, byte_range) in sorted_files {
+            let file_payload = FilePayload {
+                path: path.to_owned(),
+                len: byte_range.end - byte_range.start,
+            };
+            payloads.push(Box::new(file_payload));
+        }
+
+        payloads.push(Box::new(footer_bytes.to_vec()));
+
+        Ok(SplitPayload {
+            payloads,
+            footer_range: self.current_offset as u64
+                ..self.current_offset as u64 + footer_bytes.len() as u64,
+        })
+    }
+}
+
+fn get_payload_with_range(
+    payloads: &[Box<dyn PutPayload>],
+) -> Vec<(Box<dyn PutPayload>, Range<usize>)> {
+    let mut current = 0;
+    payloads
+        .iter()
+        .map(|payload| {
+            let start = current;
+            current += payload.len();
+            (payload.clone(), start as usize..current as usize)
+        })
+        .collect()
+}
+
+fn do_ranges_overlap(range1: &Range<usize>, range2: &Range<usize>) -> bool {
+    !get_ranges_overlap(range1, range2).is_empty()
+}
+
+fn get_ranges_overlap(range1: &Range<usize>, range2: &Range<usize>) -> Range<usize> {
+    range1.start.max(range2.start)..range1.end.min(range2.end)
+}
+
+// Returns payloads and their relative ranges for an absolute range.
+fn chunk_payload_ranges(
+    payloads: &[Box<dyn PutPayload>],
+    range: Range<usize>,
+) -> Vec<(Box<dyn PutPayload>, Range<usize>)> {
+    let payload_with_range = get_payload_with_range(payloads);
+    let mut ranges = vec![];
+    let mut current_range = range;
+
+    while let Some((payload, payload_range)) = payload_with_range
+        .iter()
+        .find(|block| do_ranges_overlap(&block.1, &current_range))
+    {
+        let payload_range_absolute_end = current_range.end.min(payload_range.end);
+        let relative_range_in_payload = current_range.start - payload_range.start
+            ..payload_range_absolute_end - payload_range.start;
+
+        ranges.push((payload.clone(), relative_range_in_payload));
+
+        current_range = payload_range.end..current_range.end;
+    }
+
+    ranges
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs::File;
+    use std::io::Write;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_split_offset_computer() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let test_filepath1 = temp_dir.path().join("f1");
+        let test_filepath2 = temp_dir.path().join("f2");
+
+        let mut file1 = File::create(&test_filepath1)?;
+        file1.write_all(&[123, 76])?;
+
+        let mut file2 = File::create(&test_filepath2)?;
+        file2.write_all(&[99, 55, 44])?;
+
+        let _split_streamer =
+            get_split_payload_streamer(&[test_filepath1, test_filepath2], &[1, 2, 3])?;
+
+        Ok(())
+    }
+
+    #[cfg(test)]
+    async fn fetch_data(
+        split_streamer: &SplitPayload,
+        range: Range<u64>,
+    ) -> anyhow::Result<Vec<u8>> {
+        let mut data = vec![];
+        split_streamer
+            .range_byte_stream(range)
+            .await?
+            .into_async_read()
+            .read_to_end(&mut data)
+            .await?;
+        Ok(data)
+    }
+
+    #[test]
+    fn test_range_contains() {
+        assert!(do_ranges_overlap(&(0..1), &(0..1)));
+        assert!(do_ranges_overlap(&(0..1), &(0..2)));
+    }
+
+    #[test]
+    fn test_chunk_payloads() -> anyhow::Result<()> {
+        let payloads: Vec<Box<dyn PutPayload>> = vec![
+            Box::new(vec![1, 2, 3]),
+            Box::new(vec![4, 5, 6]),
+            Box::new(vec![7, 8, 9, 10]),
+        ];
+
+        assert_eq!(
+            chunk_payload_ranges(&payloads, 0..1)
+                .iter()
+                .map(|el| el.1.clone())
+                .collect::<Vec<_>>(),
+            vec![0..1]
+        );
+        assert_eq!(
+            chunk_payload_ranges(&payloads, 0..2)
+                .iter()
+                .map(|el| el.1.clone())
+                .collect::<Vec<_>>(),
+            vec![0..2]
+        );
+        assert_eq!(
+            chunk_payload_ranges(&payloads, 1..2)
+                .iter()
+                .map(|el| el.1.clone())
+                .collect::<Vec<_>>(),
+            vec![1..2]
+        );
+        assert_eq!(
+            chunk_payload_ranges(&payloads, 2..3)
+                .iter()
+                .map(|el| el.1.clone())
+                .collect::<Vec<_>>(),
+            vec![2..3]
+        );
+        assert_eq!(
+            chunk_payload_ranges(&payloads, 0..6)
+                .iter()
+                .map(|el| el.1.clone())
+                .collect::<Vec<_>>(),
+            vec![0..3, 0..3]
+        );
+        assert_eq!(
+            chunk_payload_ranges(&payloads, 0..5)
+                .iter()
+                .map(|el| el.1.clone())
+                .collect::<Vec<_>>(),
+            vec![0..3, 0..2]
+        );
+        assert_eq!(
+            chunk_payload_ranges(&payloads, 3..6)
+                .iter()
+                .map(|el| el.1.clone())
+                .collect::<Vec<_>>(),
+            vec![0..3]
+        );
+        assert_eq!(
+            chunk_payload_ranges(&payloads, 4..6)
+                .iter()
+                .map(|el| el.1.clone())
+                .collect::<Vec<_>>(),
+            vec![1..3]
+        );
+        assert_eq!(
+            chunk_payload_ranges(&payloads, 5..6)
+                .iter()
+                .map(|el| el.1.clone())
+                .collect::<Vec<_>>(),
+            vec![2..3]
+        );
+        assert_eq!(
+            chunk_payload_ranges(&payloads, 2..6)
+                .iter()
+                .map(|el| el.1.clone())
+                .collect::<Vec<_>>(),
+            vec![2..3, 0..3]
+        );
+        assert_eq!(
+            chunk_payload_ranges(&payloads, 2..5)
+                .iter()
+                .map(|el| el.1.clone())
+                .collect::<Vec<_>>(),
+            vec![2..3, 0..2]
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_split_streamer() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let test_filepath1 = temp_dir.path().join("a");
+        let test_filepath2 = temp_dir.path().join("b");
+
+        let mut file1 = File::create(&test_filepath1)?;
+        file1.write_all(&[123, 76])?;
+
+        let mut file2 = File::create(&test_filepath2)?;
+        file2.write_all(&[99, 55, 44])?;
+
+        let split_streamer = get_split_payload_streamer(
+            &[test_filepath1.clone(), test_filepath2.clone()],
+            &[1, 2, 3],
+        )?;
+
+        // border case 1 exact start of first block
+        assert_eq!(fetch_data(&split_streamer, 0..1).await?, vec![123]);
+        assert_eq!(fetch_data(&split_streamer, 0..2).await?, vec![123, 76]);
+        assert_eq!(fetch_data(&split_streamer, 0..3).await?, vec![123, 76, 99]);
+
+        // border 2 case skip and take cross adjacent blocks
+        assert_eq!(fetch_data(&split_streamer, 1..3).await?, vec![76, 99]);
+
+        // border 3 case skip and take in seperate blocks with full block between
+        assert_eq!(
+            fetch_data(&split_streamer, 1..6).await?,
+            vec![76, 99, 55, 44, 123]
+        );
+
+        // border case 4 exact middle block
+        assert_eq!(fetch_data(&split_streamer, 2..5).await?, vec![99, 55, 44]);
+
+        // border case 5, no skip but take in middle block
+        assert_eq!(fetch_data(&split_streamer, 2..4).await?, vec![99, 55]);
+
+        // border case 6 skip and take in middle block
+        assert_eq!(fetch_data(&split_streamer, 3..4).await?, vec![55]);
+
+        // border case 7 start exact last block - footer
+        assert_eq!(
+            fetch_data(&split_streamer, 5..10).await?,
+            vec![123, 34, 102, 105, 108]
+        );
+        // border case 8 skip and take in last block  - footer
+        assert_eq!(
+            fetch_data(&split_streamer, 6..10).await?,
+            vec![34, 102, 105, 108]
+        );
+
+        let total_len = split_streamer.len();
+        let all_data = fetch_data(&split_streamer, 0..total_len).await?;
+
+        // last 8 bytes are the length of the hotcache bytes
+        assert_eq!(all_data[all_data.len() - 8..], 3_u64.to_le_bytes());
+        Ok(())
+    }
+}

--- a/quickwit-storage/src/storage.rs
+++ b/quickwit-storage/src/storage.rs
@@ -17,129 +17,12 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use std::io::{self, SeekFrom};
 use std::ops::Range;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use async_trait::async_trait;
-use rusoto_core::ByteStream;
-use tokio::io::{AsyncReadExt, AsyncSeekExt};
-use tokio_util::io::ReaderStream;
 
-use crate::{OwnedBytes, StorageErrorKind, StorageResult};
-
-#[async_trait]
-/// PutPayloadProvider is used to upload data and support multipart.
-pub trait PutPayloadProvider: PutPayloadProviderClone + Send + Sync {
-    /// Return the total length of the payload.
-    async fn len(&self) -> io::Result<u64>;
-    /// Retrieve bytestream for specified range.
-    async fn range_byte_stream(&self, range: Range<u64>) -> io::Result<ByteStream>;
-
-    /// Retrieve complete bytestream.
-    async fn byte_stream(&self) -> io::Result<ByteStream> {
-        let total_len = self.len().await?;
-        let range = 0..total_len;
-        self.range_byte_stream(range).await
-    }
-
-    /// Load the whole Payload into memory.
-    async fn read_all(&self) -> io::Result<OwnedBytes> {
-        let total_len = self.len().await?;
-        let range = 0..total_len;
-        let mut reader = self.range_byte_stream(range).await?.into_async_read();
-
-        let mut data: Vec<u8> = Vec::with_capacity(total_len as usize);
-        tokio::io::copy(&mut reader, &mut data).await?;
-
-        Ok(OwnedBytes::new(data))
-    }
-}
-
-pub trait PutPayloadProviderClone {
-    fn box_clone(&self) -> Box<dyn PutPayloadProvider>;
-}
-
-impl<T> PutPayloadProviderClone for T
-where T: 'static + PutPayloadProvider + Clone
-{
-    fn box_clone(&self) -> Box<dyn PutPayloadProvider> {
-        Box::new(self.clone())
-    }
-}
-
-impl Clone for Box<dyn PutPayloadProvider> {
-    fn clone(&self) -> Box<dyn PutPayloadProvider> {
-        self.box_clone()
-    }
-}
-
-/// Payload argument of a put request.
-#[derive(Clone)]
-pub enum PutPayload {
-    /// Put data from the local file.
-    LocalFile(PathBuf),
-    /// Put data from a local buffer
-    InMemory(OwnedBytes),
-}
-
-impl PutPayload {
-    // Returns the len of the payload expressed in number of bytes.
-    pub(crate) async fn len(&self) -> io::Result<u64> {
-        match self {
-            Self::LocalFile(path) => {
-                let metadata = tokio::fs::metadata(path).await?;
-                Ok(metadata.len())
-            }
-            Self::InMemory(payload) => Ok(payload.len() as u64),
-        }
-    }
-}
-
-#[async_trait]
-impl PutPayloadProvider for PutPayload {
-    async fn len(&self) -> io::Result<u64> {
-        self.len().await
-    }
-
-    async fn range_byte_stream(&self, range: Range<u64>) -> io::Result<ByteStream> {
-        match self {
-            PutPayload::LocalFile(filepath) => {
-                let mut file: tokio::fs::File = tokio::fs::File::open(&filepath).await?;
-                file.seek(SeekFrom::Start(range.start)).await?;
-                let reader_stream = ReaderStream::new(file.take(range.end - range.start));
-                Ok(ByteStream::new(reader_stream))
-            }
-            PutPayload::InMemory(data) => Ok(ByteStream::from(
-                (&data[range.start as usize..range.end as usize]).to_vec(),
-            )),
-        }
-    }
-}
-
-impl From<PathBuf> for PutPayload {
-    fn from(file_path: PathBuf) -> Self {
-        PutPayload::LocalFile(file_path)
-    }
-}
-
-impl From<OwnedBytes> for PutPayload {
-    fn from(bytes: OwnedBytes) -> Self {
-        PutPayload::InMemory(bytes)
-    }
-}
-
-impl From<Vec<u8>> for PutPayload {
-    fn from(bytes: Vec<u8>) -> Self {
-        PutPayload::InMemory(OwnedBytes::new(bytes))
-    }
-}
-
-impl From<&'static [u8]> for PutPayload {
-    fn from(payload_bytes: &'static [u8]) -> Self {
-        From::from(OwnedBytes::new(payload_bytes))
-    }
-}
+use crate::{OwnedBytes, PutPayload, StorageErrorKind, StorageResult};
 
 /// Storage meant to receive and serve quickwit's split.
 ///
@@ -156,7 +39,7 @@ impl From<&'static [u8]> for PutPayload {
 #[async_trait]
 pub trait Storage: Send + Sync + 'static {
     /// Saves a file into the storage.
-    async fn put(&self, path: &Path, payload: Box<dyn PutPayloadProvider>) -> StorageResult<()>;
+    async fn put(&self, path: &Path, payload: Box<dyn PutPayload>) -> StorageResult<()>;
 
     /// Downloads an entire file and writes it into a local file.
     /// `output_path` is expected to be a file path (not a directory path).

--- a/quickwit-storage/tests/s3_storage.rs
+++ b/quickwit-storage/tests/s3_storage.rs
@@ -22,9 +22,7 @@
 
 use std::path::Path;
 
-use quickwit_storage::{
-    MultiPartPolicy, PutPayload, RegionProvider, S3CompatibleObjectStorage, Storage,
-};
+use quickwit_storage::{MultiPartPolicy, RegionProvider, S3CompatibleObjectStorage, Storage};
 
 #[tokio::test]
 #[cfg_attr(not(feature = "ci-test"), ignore)]
@@ -36,7 +34,7 @@ async fn test_upload_single_part_file() -> anyhow::Result<()> {
     object_storage
         .put(
             Path::new("test-s3-compatible-storage/hello_small.txt"),
-            Box::new(PutPayload::from(b"hello, happy tax payer!".to_vec())),
+            Box::new(b"hello, happy tax payer!".to_vec()),
         )
         .await?;
     Ok(())
@@ -60,7 +58,7 @@ async fn test_upload_multiple_part_file() -> anyhow::Result<()> {
     object_storage
         .put(
             Path::new("test-s3-compatible-storage/hello_large.txt"),
-            Box::new(PutPayload::from(test_buffer)),
+            Box::new(test_buffer),
         )
         .await?;
     Ok(())


### PR DESCRIPTION
### Description
Don't materialize the single split file in packager.rs, instead stream the compute bundle from the files in uploader.rs. This will save IOPS.

### How was this PR tested?
cargo test
