### PR TITLE
update quickstart docs to work with metastore

### DIFF
--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -71,22 +71,24 @@ And here is the complete config:
 Now we can create the index with the command:
 
 ```bash
-./quickwit new --index-uri file:///your-path-to-your-index/wikipedia --index-config-path ./wikipedia_index_config.json
+
+./quickwit new --index-uri file:///your-path-to-your-index/wikipedia --index-config-path ./wikipedia_index_config.json --index-id wikipedia --metastore-uri file:///path-to-your-metastore
 ```
 
-To simplify our command, we now assume that the index is to be created in the current directory and use `pwd` variable to specify the index uri:
+The metastore is like a directory of indexes that has it's own storage and some meta information about the indexes.
+
+To simplify our command, we now assume that the index and metastore are to be created in the current directory and use the `pwd` command to specify the index uri:
 
 ```bash
-./quickwit new --index-uri file:///$(pwd)/wikipedia --index-config-path ./wikipedia_index_config.json
+./quickwit new --index-uri file://$(pwd)/wikipedia --index-config-path ./wikipedia_index_config.json --index-id wikipedia --metastore-uri file://$(pwd)/metastore/
 ```
 
-Check that an empty directory `/$(pwd)/wikipedia` has been created, Quickwit will write index files here and a `quickwit.json` which contains the [index metadata](../overview/architecture.md#index-metadata).
+Check that an empty directory `$(pwd)/wikipedia` has been created, Quickwit will write index files here and a `quickwit.json` which contains the [index metadata](../overview/architecture.md#index-metadata).
 You're now ready to fill the index.
-
 
 :::note
 
-Behind the scenes, Quickwit will parse the index-uri and use the last part to infer your `index name`. In the example above, our index name is Wikipedia. This `index name` will be useful when using the search REST API.
+The `index id` will be useful when using the search REST API.
 
 :::
 
@@ -101,13 +103,13 @@ Let's download [a bunch of wikipedia articles (10 000)](https://quickwit-dataset
 curl -o wiki-articles-10000.json https://quickwit-datasets-public.s3.amazonaws.com/wiki-articles-10000.json
 
 # Index our 10k documents.
-./quickwit index --index-uri file:///$(pwd)/wikipedia --input-path wiki-articles-10000.json
+./quickwit index --index-id wikipedia --data-dir-path ./wikipedia --metastore-uri file://$(pwd)/metastore --input-path wiki-articles-10000.json
 ```
 
 Wait one second or two and check if it worked by using `search` command:
 
 ```bash
-./quickwit search --index-uri file:///$(pwd)/wikipedia --query "barack AND obama"
+./quickwit search --index-id wikipedia --metastore-uri file://$(pwd)/metastore --query "barack AND obama"
 ```
 
 It should return 10 hits. Now you're ready to serve our search API.
@@ -119,6 +121,7 @@ The command `serve` starts an http server which provides a [REST API](../referen
 
 ```bash
 ./quickwit serve --index-uri file:///$(pwd)/wikipedia
+quickwit serve --metastore-uri file://$(pwd)/metastore
 ```
 
 Check it's working with a simple GET request in the browser or via cURL:
@@ -148,7 +151,7 @@ Don't forget to encode correctly the query params to avoid bad request (status 4
 Let's do some cleanup by deleting the index:
 
 ```bash
-./quickwit delete --index-uri file:///$(pwd)/wikipedia
+./quickwit delete --index-id wikipedia --metastore-uri file:///$(pwd)/metastore
 ```
 
 Congrats! You can level up with the following tutorials to discover all Quickwit features.
@@ -158,11 +161,11 @@ Congrats! You can level up with the following tutorials to discover all Quickwit
 
 ```bash
 curl -o wikipedia_index_config.json https://raw.githubusercontent.com/quickwit-inc/quickwit/main/examples/index_configs/wikipedia_index_config.json
-./quickwit new --index-uri file:///$(pwd)/wikipedia --index-config-path ./wikipedia_index_config.json
+./quickwit new --index-uri file://$(pwd)/wikipedia --index-config-path ./wikipedia_index_config.json --index-id wikipedia --metastore-uri file://$(pwd)/metastore/
 curl -o wiki-articles-10000.json https://quickwit-datasets-public.s3.amazonaws.com/wiki-articles-10000.json
-./quickwit index --index-uri file:///$(pwd)/wikipedia --input-path wiki-articles-10000.json
-./quickwit search --index-uri file:///$(pwd)/wikipedia --query "barack AND obama"
-./quickwit delete --index-uri file:///$(pwd)/wikipedia
+./quickwit index --index-id wikipedia --data-dir-path ./wikipedia --metastore-uri file://$(pwd)/metastore --input-path wiki-articles-10000.json
+./quickwit search --index-id wikipedia --metastore-uri file://$(pwd)/metastore --query "barack AND obama"
+./quickwit delete --index-id wikipedia --metastore-uri file:///$(pwd)/metastore
 ```
 
 


### PR DESCRIPTION
### Description
This updates the quickstart document to include the metastore-related arguments in the quickwit commands.

Note that this has been tested with the current `main` branch, so this should only be published on the quickwit website once this command line API change makes it to the current release (which 0.1.0 may not have).

### How was this PR tested?
I followed the quickstart document with quickwit built from source and ran the original and changed commands on my local machine.

This fixes #737.