### PR TITLE
Add new states to actors.

### DIFF
--- a/quickwit-actors/src/actor.rs
+++ b/quickwit-actors/src/actor.rs
@@ -255,6 +255,14 @@ impl<Message> ActorContext<Message> {
         self.actor_state.get_state()
     }
 
+    pub(crate) fn process(&mut self) {
+        self.actor_state.process();
+    }
+
+    pub(crate) fn idle(&mut self) {
+        self.actor_state.idle();
+    }
+
     pub(crate) fn pause(&mut self) {
         self.actor_state.pause();
     }


### PR DESCRIPTION
Two new states are now replacing the `Running` state:
- `Processing`: it corresponds to an actor that is processing messages, it has at least one message
- `Idle`: when an actor has no more message to process, it goes in `Idle` state.

## Purpose
It will be useful to define the right condition to terminate the indexing pipeline.


