### PR TITLE
Improve logging for splits batch: avoid repeating each times all the …

### DIFF
--- a/quickwit-indexing/src/actors/merge_split_downloader.rs
+++ b/quickwit-indexing/src/actors/merge_split_downloader.rs
@@ -61,9 +61,16 @@ impl Actor for MergeSplitDownloader {
                     num_docs=num_docs,
                     num_splits=splits.len())
             }
-            MergeOperation::Demux { .. } => {
-                // FIXME once demux is here.
-                info_span!("demux", msg_id = &msg_id)
+            MergeOperation::Demux {
+                demux_split_ids,
+                splits,
+            } => {
+                let num_docs: usize = splits.iter().map(|split| split.num_records).sum();
+                info_span!("demux",
+                    msg_id=&msg_id,
+                    demux_split_ids=?demux_split_ids,
+                    num_docs=num_docs,
+                    num_splits=splits.len())
             }
         }
     }

--- a/quickwit-indexing/src/actors/uploader.rs
+++ b/quickwit-indexing/src/actors/uploader.rs
@@ -92,7 +92,7 @@ impl Actor for Uploader {
     }
 
     fn message_span(&self, msg_id: u64, batch: &PackagedSplitBatch) -> Span {
-        info_span!("", msg_id=&msg_id, split=?batch.split_ids())
+        info_span!("", msg_id=&msg_id, num_splits=%batch.split_ids().len())
     }
 }
 
@@ -149,7 +149,7 @@ async fn stage_and_upload_split(
     let split_metadata_and_footer_offsets = create_split_metadata(packaged_split);
     let index_id = packaged_split.index_id.clone();
     let split_metadata = split_metadata_and_footer_offsets.split_metadata.clone();
-    info!("staging-split");
+    info!(split_id = packaged_split.split_id.as_str(), "staging-split");
     metastore
         .stage_split(&index_id, split_metadata_and_footer_offsets)
         .await?;
@@ -159,7 +159,7 @@ async fn stage_and_upload_split(
         .path()
         .join(BUNDLE_FILENAME);
 
-    info!("storing-split");
+    info!(split_id = packaged_split.split_id.as_str(), "storing-split");
     split_store
         .store_split(&split_metadata, &bundle_path)
         .await?;
@@ -206,6 +206,7 @@ impl AsyncActor for Uploader {
         let counters = self.counters.clone();
         let index_id = batch.index_id();
         let span = Span::current();
+        info!(split_ids=?split_ids, "start-stage-and-store-splits");
         tokio::spawn(
             async move {
                 fail_point!("uploader:intask:before");
@@ -219,7 +220,7 @@ impl AsyncActor for Uploader {
                     )
                     .await;
                     if let Err(cause) = upload_result {
-                        warn!(cause=%cause, "Failed to upload split. Killing!");
+                        warn!(cause=%cause, split_id=%split.split_id, "Failed to upload split. Killing!");
                         kill_switch.kill();
                         bail!("Failed to upload split `{}`. Killing!", split.split_id);
                     }
@@ -236,7 +237,7 @@ impl AsyncActor for Uploader {
                         &publisher_message
                     );
                 }
-                info!("success-stage-and-store-split");
+                info!("success-stage-and-store-splits");
                 // We explicitely drop it in order to force move the permit guard into the async
                 // task.
                 mem::drop(permit_guard);


### PR DESCRIPTION
…split ids and show the current split id that is uploaded or packaged.

