### PR TITLE
Fix failing build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ IMAGE_TAGS = x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu x86_64-unknown-l
 
 .PHONY: cross-images
 cross-images:
-	for tag in ${IMAGE_TAGS}; do \
+	@for tag in ${IMAGE_TAGS}; do \
 		docker build --tag quickwit/cross:$$tag --file ./build/cross-images/$$tag.dockerfile ./build/cross-images; \
 		docker push quickwit/cross:$$tag; \
 	done
@@ -48,8 +48,9 @@ TARGET ?= x86_64-unknown-linux-gnu
 .PHONY: build
 build:
 	@echo "Building binary for target=${TARGET}"
-	if [ "${TARGET}" = "x86_64-unknown-linux-musl" ]; then \
-        cross build --release --features release-feature-set --target ${TARGET}; \
-    else \
-        cross build --release --features release-feature-vendored-set --target ${TARGET}; \
-    fi
+	@which cross > /dev/null 2>&1 || (echo "Cross is not installed. Please install using 'cargo install cross'." && exit 1)
+	@if [ "${TARGET}" = "x86_64-unknown-linux-musl" ]; then \
+		cross build --release --features release-feature-set --target ${TARGET}; \
+	else \
+		cross build --release --features release-feature-vendored-set --target ${TARGET}; \
+	fi

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 DOCKER_SERVICES ?= all
 
 help:
-	@grep '^[^#[:space:]].*:' Makefile
+	@grep '^[^\.#[:space:]].*:' Makefile
 
 # Usage:
 # `make docker-compose-up` starts all the services.
@@ -43,16 +43,13 @@ cross-images:
 		docker push quickwit/cross:$$tag; \
 	done
 
-
-# TODO: To be replaced by https://github.com/quickwit-inc/quickwit/issues/237
-.PHONY: build-x86_64-unknown-linux-gnu
-build-x86_64-unknown-linux-gnu:
-	cross build --release --features release-feature-vendored-set --target x86_64-unknown-linux-gnu
-
-.PHONY: build-aarch64-unknown-linux-gnu
-build-aarch64-unknown-linux-gnu: 
-	cross build --release --features release-feature-vendored-set --target aarch64-unknown-linux-gnu
-
-.PHONY: build-x86_64-unknown-linux-musl
-build-x86_64-unknown-linux-musl:
-	cross build --release --features release-feature-set --target x86_64-unknown-linux-musl 
+# TODO: to be replaced by https://github.com/quickwit-inc/quickwit/issues/237
+TARGET ?= x86_64-unknown-linux-gnu
+.PHONY: build
+build:
+	@echo "Building binary for target=${TARGET}"
+	if [ "${TARGET}" = "x86_64-unknown-linux-musl" ]; then \
+        cross build --release --features release-feature-set --target ${TARGET}; \
+    else \
+        cross build --release --features release-feature-vendored-set --target ${TARGET}; \
+    fi

--- a/Makefile
+++ b/Makefile
@@ -42,3 +42,17 @@ cross-images:
 		docker build --tag quickwit/cross:$$tag --file ./build/cross-images/$$tag.dockerfile ./build/cross-images; \
 		docker push quickwit/cross:$$tag; \
 	done
+
+
+# TODO: To be replaced by https://github.com/quickwit-inc/quickwit/issues/237
+.PHONY: build-x86_64-unknown-linux-gnu
+build-x86_64-unknown-linux-gnu:
+	cross build --release --features release-feature-vendored-set --target x86_64-unknown-linux-gnu
+
+.PHONY: build-aarch64-unknown-linux-gnu
+build-aarch64-unknown-linux-gnu: 
+	cross build --release --features release-feature-vendored-set --target aarch64-unknown-linux-gnu
+
+.PHONY: build-x86_64-unknown-linux-musl
+build-x86_64-unknown-linux-musl:
+	cross build --release --features release-feature-set --target x86_64-unknown-linux-musl 

--- a/build/cross-images/x86_64-unknown-linux-musl.dockerfile
+++ b/build/cross-images/x86_64-unknown-linux-musl.dockerfile
@@ -1,4 +1,11 @@
 FROM ekidd/rust-musl-builder:latest
+
+RUN echo "Upgrading CMake" && \
+    sudo apt-get remove cmake -y && \
+    curl -fLO https://www.cmake.org/files/v3.12/cmake-3.12.1.tar.gz && \
+    tar -xvzf cmake-3.12.1.tar.gz && \
+    cd cmake-3.12.1/ && ./configure && \
+    sudo make install
     
 ENV CC=musl-gcc \
     CFLAGS=-I/usr/local/musl/include \


### PR DESCRIPTION
### Description
Closes https://github.com/quickwit-inc/quickwit/issues/761
Reason of the failure: https://github.com/alexcrichton/cmake-rs/issues/131

Added convenience make commands in the meantime. You need to install [cross](https://github.com/rust-embedded/cross)
- `make build-x86_64-unknown-linux-gnu`
-  `make build-aarch64-unknown-linux-gnu`
-  `make build-x86_64-unknown-linux-musl`

### How was this PR tested?
Run the build on CI


