### PR TITLE
Build & push cross images 

### DIFF
--- a/.github/workflows/publish_cross_images.yml
+++ b/.github/workflows/publish_cross_images.yml
@@ -19,5 +19,5 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
-      - name: Build & push images
+      - name: Build and push cross images
         run: make cross-images

--- a/.github/workflows/publish_cross_images.yml
+++ b/.github/workflows/publish_cross_images.yml
@@ -1,0 +1,23 @@
+name: Publish custom cross images
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "build/cross-images/**"
+
+jobs:
+  build-cross-images:
+    name: Publish cross images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+      - name: Build & push images
+        run: make cross-images

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,12 +1,12 @@
 [target.x86_64-unknown-linux-gnu]
-image = "quickwit/cross-builder:x86_64-unknown-linux-gnu"
+image = "quickwit/cross:x86_64-unknown-linux-gnu"
 
 [target.x86_64-unknown-linux-musl]
-image = "quickwit/cross-builder:x86_64-unknown-linux-musl"
+image = "quickwit/cross:x86_64-unknown-linux-musl"
 RUSTFLAGS="LIB_LDFLAGS=-L/usr/lib/x86_64-linux-gnu CFLAGS=-I/usr/local/musl/include CC=musl-gcc"
 
 [target.aarch64-unknown-linux-gnu]
-image = "quickwit/cross-builder:aarch64-unknown-linux-gnu"
+image = "quickwit/cross:aarch64-unknown-linux-gnu"
 
 # TODO: https://github.com/quickwit-inc/quickwit/issues/715
 # [target.aarch64-unknown-linux-musl]

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,12 +1,12 @@
 [target.x86_64-unknown-linux-gnu]
-image = "quickwitinc/builder-x86_64-unknown-linux-gnu:latest"
+image = "quickwit/cross-builder:x86_64-unknown-linux-gnu"
 
 [target.x86_64-unknown-linux-musl]
-image = "quickwitinc/builder-x86_64-unknown-linux-musl:latest"
+image = "quickwit/cross-builder:x86_64-unknown-linux-musl"
 RUSTFLAGS="LIB_LDFLAGS=-L/usr/lib/x86_64-linux-gnu CFLAGS=-I/usr/local/musl/include CC=musl-gcc"
 
 [target.aarch64-unknown-linux-gnu]
-image = "quickwitinc/builder-aarch64-unknown-linux-gnu:latest"
+image = "quickwit/cross-builder:aarch64-unknown-linux-gnu"
 
 # TODO: https://github.com/quickwit-inc/quickwit/issues/715
 # [target.aarch64-unknown-linux-musl]

--- a/Makefile
+++ b/Makefile
@@ -33,12 +33,12 @@ test-all: docker-compose-up
 	QUICKWIT_ENV=local cargo test --all-features
 
 # This will build and push all custom cross images for cross-compilation.
-# You will need to login into dockerhub with `quickwitinc` account
+# You will need to login into Docker Hub with the `quickwit` account.
 IMAGE_TAGS = x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu x86_64-unknown-linux-musl
 
 .PHONY: cross-images
 cross-images:
 	for tag in ${IMAGE_TAGS}; do \
-		docker build --tag quickwit/cross-builder:$$tag --file ./build/cross-images/$$tag.dockerfile ./build/cross-images; \
-		docker push quickwit/cross-builder:$$tag; \
+		docker build --tag quickwit/cross:$$tag --file ./build/cross-images/$$tag.dockerfile ./build/cross-images; \
+		docker push quickwit/cross:$$tag; \
 	done

--- a/Makefile
+++ b/Makefile
@@ -34,11 +34,11 @@ test-all: docker-compose-up
 
 # This will build and push all custom cross images for cross-compilation.
 # You will need to login into dockerhub with `quickwitinc` account
-IMAGE_TAGS = x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu x86_64-unknown-linux-musl aarch64-unknown-linux-musl 
+IMAGE_TAGS = x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu x86_64-unknown-linux-musl
 
 .PHONY: cross-images
 cross-images:
 	for tag in ${IMAGE_TAGS}; do \
-		docker build --tag quickwitinc/builder-$$tag --file ./build/cross-images/$$tag.dockerfile ./build/cross-images; \
-		docker push quickwitinc/builder-$$tag:latest; \
+		docker build --tag quickwit/cross-builder:$$tag --file ./build/cross-images/$$tag.dockerfile ./build/cross-images; \
+		docker push quickwit/cross-builder:$$tag; \
 	done


### PR DESCRIPTION
### Description
Fix part of https://github.com/quickwit-inc/quickwit/issues/715
> @guilload We would also like to move all the images into this account https://hub.docker.com/orgs/quickwit, while creating a single image repository for all cross-images like quickwit/cross-builder:$tag with tag being the architecture target of the image.

So far making the `aarch64-unknown-linux-musl` has been harder than I anticipated. In the meantime,  this takes care of moving the cross images to our official Quickwit dockerhub account and automating the build & push process

### How was this PR tested?
pushed the newly built cross images 
