### PR TITLE
Renaming qspawn_blocking.

### DIFF
--- a/quickwit-search/src/leaf.rs
+++ b/quickwit-search/src/leaf.rs
@@ -221,7 +221,7 @@ async fn leaf_search_single_split(
         .try_into()?;
     let searcher = reader.searcher();
     warmup(&*searcher, &query, &quickwit_collector.fast_field_names()).await?;
-    let leaf_search_response = crate::qspawn_blocking(move || {
+    let leaf_search_response = crate::run_cpu_intensive(move || {
         let span = info_span!( "search", split_id = %split.split_id);
         let _span_guard = span.enter();
         searcher.search(&query, &quickwit_collector)

--- a/quickwit-search/src/lib.rs
+++ b/quickwit-search/src/lib.rs
@@ -61,7 +61,7 @@ pub use crate::root::root_search;
 pub use crate::search_response_rest::SearchResponseRest;
 pub use crate::search_stream::root_search_stream;
 pub use crate::service::{MockSearchService, SearchService, SearchServiceImpl};
-use crate::thread_pool::qspawn_blocking;
+use crate::thread_pool::run_cpu_intensive;
 
 /// Compute the SWIM port from the HTTP port.
 /// Add 1 to the HTTP port to get the SWIM port.

--- a/quickwit-search/src/search_stream/leaf.rs
+++ b/quickwit-search/src/search_stream/leaf.rs
@@ -164,7 +164,7 @@ async fn leaf_search_stream_single_split(
 
     let _ = span.enter();
     let m_request_fields = request_fields.clone();
-    let collect_handle = crate::qspawn_blocking(move || {
+    let collect_handle = crate::run_cpu_intensive(move || {
         let mut buffer = Vec::new();
         match m_request_fields.fast_field_types() {
             (Type::I64, None) => {


### PR DESCRIPTION
`quickwit_spawn_blocking` was a good candidate too.
I am a tad afraid that the difference in semantic is
not really a detail.

Contrary to spawn_blocking, with this function,
if noone await the result, no work is done.
