### PR TITLE
Terminate indexing pipeline once all merge operations have been done

### DIFF
--- a/quickwit-indexing/src/actors/mod.rs
+++ b/quickwit-indexing/src/actors/mod.rs
@@ -27,6 +27,7 @@ mod uploader;
 
 pub use pipeline_supervisor::{
     IndexingPipelineHandler, IndexingPipelineParams, IndexingPipelineSupervisor,
+    PipelineObservableState,
 };
 mod merge_executor;
 mod merge_planner;


### PR DESCRIPTION
Accurate termination condition:
- source + indexer + packager + uploader + publisher have exited successfully
- all actors of the merge pipeline are in `IDLE` state


## Test
I need to test it on a real dataset. For the moment, I did not find a nice way to add a unit test on the pipeline termination :/
