### PR TITLE
Rename `SplitInfo` to `Split`

### DIFF
--- a/quickwit-indexing/src/actors/garbage_collector.rs
+++ b/quickwit-indexing/src/actors/garbage_collector.rs
@@ -140,13 +140,13 @@ mod tests {
     use std::path::Path;
 
     use quickwit_actors::Universe;
-    use quickwit_metastore::{MockMetastore, SplitInfo, SplitMetadata, SplitState};
+    use quickwit_metastore::{MockMetastore, Split, SplitMetadata, SplitState};
     use quickwit_storage::MockStorage;
 
     use super::*;
 
-    fn make_split(id: &str) -> SplitInfo {
-        SplitInfo {
+    fn make_split(id: &str) -> Split {
+        Split {
             split_metadata: SplitMetadata {
                 split_id: id.to_string(),
                 footer_offsets: 5..20,

--- a/quickwit-indexing/src/actors/merge_executor.rs
+++ b/quickwit-indexing/src/actors/merge_executor.rs
@@ -937,8 +937,9 @@ mod tests {
             test_index_builder.add_documents(docs).await?;
         }
         let metastore = test_index_builder.metastore();
-        let split_infos = metastore.list_all_splits(index_id).await?;
-        let splits: Vec<SplitMetadata> = split_infos
+        let splits: Vec<SplitMetadata> = metastore
+            .list_all_splits(index_id)
+            .await?
             .into_iter()
             .map(|split| split.split_metadata)
             .collect();
@@ -952,7 +953,7 @@ mod tests {
             merge_scratch_directory.named_temp_child("downloaded-splits")?;
         let storage = test_index_builder.index_storage(index_id)?;
         for split in &splits {
-            let split_filename = split_file(split.split_id());
+            let split_filename = split_file(&split.split_id);
             let dest_filepath = downloaded_splits_directory.path().join(&split_filename);
             storage
                 .copy_to_file(Path::new(&split_filename), &dest_filepath)

--- a/quickwit-indexing/src/lib.rs
+++ b/quickwit-indexing/src/lib.rs
@@ -41,7 +41,7 @@ pub mod source;
 mod split_store;
 mod test_utils;
 
-pub use test_utils::{mock_split_info, mock_split_meta, TestSandbox};
+pub use test_utils::{mock_split, mock_split_meta, TestSandbox};
 
 pub use self::garbage_collection::{delete_splits_with_files, run_garbage_collect, FileEntry};
 pub use self::merge_policy::{MergePolicy, StableMultitenantWithTimestampMergePolicy};

--- a/quickwit-indexing/src/test_utils.rs
+++ b/quickwit-indexing/src/test_utils.rs
@@ -25,7 +25,7 @@ use byte_unit::Byte;
 use quickwit_index_config::IndexConfig;
 use quickwit_metastore::checkpoint::Checkpoint;
 use quickwit_metastore::{
-    IndexMetadata, Metastore, MetastoreUriResolver, SplitInfo, SplitMetadata, SplitState,
+    IndexMetadata, Metastore, MetastoreUriResolver, Split, SplitMetadata, SplitState,
 };
 use quickwit_storage::{Storage, StorageResolverError, StorageUriResolver};
 
@@ -139,9 +139,9 @@ impl TestSandbox {
     }
 }
 
-/// Mock split info helper.
-pub fn mock_split_info(split_id: &str) -> SplitInfo {
-    SplitInfo {
+/// Mock split helper.
+pub fn mock_split(split_id: &str) -> Split {
+    Split {
         split_state: SplitState::Published,
         update_timestamp: 0,
         split_metadata: SplitMetadata {

--- a/quickwit-metastore/src/lib.rs
+++ b/quickwit-metastore/src/lib.rs
@@ -63,7 +63,7 @@ pub use metastore::single_file_metastore::SingleFileMetastore;
 pub use metastore::MockMetastore;
 pub use metastore::{IndexMetadata, Metastore};
 pub use metastore_resolver::{MetastoreFactory, MetastoreUriResolver};
-pub use split_metadata::{SplitInfo, SplitMetadata, SplitState};
+pub use split_metadata::{Split, SplitMetadata, SplitState};
 pub(crate) use split_metadata_version::VersionedSplitMetadataDeserializeHelper;
 
 fn decorate_results_with_output<F: Future<Output = anyhow::Result<()>>>(

--- a/quickwit-metastore/src/metastore/mod.rs
+++ b/quickwit-metastore/src/metastore/mod.rs
@@ -30,7 +30,7 @@ use quickwit_index_config::IndexConfig;
 use serde::{Deserialize, Serialize};
 
 use crate::checkpoint::{Checkpoint, CheckpointDelta};
-use crate::{MetastoreResult, SplitInfo, SplitMetadata, SplitState};
+use crate::{MetastoreResult, Split, SplitMetadata, SplitState};
 
 /// An index metadata carries all meta data about an index.
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -143,11 +143,11 @@ pub trait Metastore: Send + Sync + 'static {
         split_state: SplitState,
         time_range: Option<Range<i64>>,
         tags: &[String],
-    ) -> MetastoreResult<Vec<SplitInfo>>;
+    ) -> MetastoreResult<Vec<Split>>;
 
     /// Lists the splits without filtering.
     /// Returns a list of all splits currently known to the metastore regardless of their state.
-    async fn list_all_splits(&self, index_id: &str) -> MetastoreResult<Vec<SplitInfo>>;
+    async fn list_all_splits(&self, index_id: &str) -> MetastoreResult<Vec<Split>>;
 
     /// Marks a list of splits for deletion.
     /// This API will change the state to `ScheduledForDeletion` so that it is not referenced by the

--- a/quickwit-metastore/src/split_metadata.rs
+++ b/quickwit-metastore/src/split_metadata.rs
@@ -29,7 +29,7 @@ use crate::VersionedSplitMetadataDeserializeHelper;
 
 /// Carries split metadata.
 #[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq, Eq)]
-pub struct SplitInfo {
+pub struct Split {
     /// The state of the split.
     pub split_state: SplitState,
 
@@ -40,8 +40,8 @@ pub struct SplitInfo {
     pub split_metadata: SplitMetadata,
 }
 
-impl SplitInfo {
-    /// Creates a new instance of split metadata.
+impl Split {
+    /// Creates a new empty split with ID `split_id`.
     pub fn new(split_id: String) -> Self {
         let split_metadata = SplitMetadata {
             split_id,
@@ -54,11 +54,10 @@ impl SplitInfo {
             footer_offsets: Default::default(),
         };
 
-        SplitInfo {
+        Split {
             split_metadata,
-            update_timestamp: Utc::now().timestamp(),
-
             split_state: SplitState::New,
+            update_timestamp: Utc::now().timestamp(),
         }
     }
 

--- a/quickwit-search/src/root.rs
+++ b/quickwit-search/src/root.rs
@@ -243,7 +243,7 @@ mod tests {
     use std::ops::Range;
 
     use quickwit_index_config::WikipediaIndexConfig;
-    use quickwit_indexing::mock_split_info;
+    use quickwit_indexing::mock_split;
     use quickwit_metastore::checkpoint::Checkpoint;
     use quickwit_metastore::{IndexMetadata, MockMetastore, SplitState};
     use quickwit_proto::SplitSearchError;
@@ -306,7 +306,7 @@ mod tests {
             |_index_id: &str,
              _split_state: SplitState,
              _time_range: Option<Range<i64>>,
-             _tags: &[String]| { Ok(vec![mock_split_info("split1")]) },
+             _tags: &[String]| { Ok(vec![mock_split("split1")]) },
         );
         let mut mock_search_service = MockSearchService::new();
         mock_search_service.expect_leaf_search().returning(
@@ -367,9 +367,7 @@ mod tests {
             |_index_id: &str,
              _split_state: SplitState,
              _time_range: Option<Range<i64>>,
-             _tags: &[String]| {
-                Ok(vec![mock_split_info("split1"), mock_split_info("split2")])
-            },
+             _tags: &[String]| { Ok(vec![mock_split("split1"), mock_split("split2")]) },
         );
         let mut mock_search_service1 = MockSearchService::new();
         mock_search_service1.expect_leaf_search().returning(
@@ -452,9 +450,7 @@ mod tests {
             |_index_id: &str,
              _split_state: SplitState,
              _time_range: Option<Range<i64>>,
-             _tags: &[String]| {
-                Ok(vec![mock_split_info("split1"), mock_split_info("split2")])
-            },
+             _tags: &[String]| { Ok(vec![mock_split("split1"), mock_split("split2")]) },
         );
 
         let mut mock_search_service1 = MockSearchService::new();
@@ -563,9 +559,7 @@ mod tests {
             |_index_id: &str,
              _split_state: SplitState,
              _time_range: Option<Range<i64>>,
-             _tags: &[String]| {
-                Ok(vec![mock_split_info("split1"), mock_split_info("split2")])
-            },
+             _tags: &[String]| { Ok(vec![mock_split("split1"), mock_split("split2")]) },
         );
         let mut mock_search_service1 = MockSearchService::new();
         mock_search_service1
@@ -690,7 +684,7 @@ mod tests {
             |_index_id: &str,
              _split_state: SplitState,
              _time_range: Option<Range<i64>>,
-             _tags: &[String]| { Ok(vec![mock_split_info("split1")]) },
+             _tags: &[String]| { Ok(vec![mock_split("split1")]) },
         );
         let mut first_call = true;
         let mut mock_search_service1 = MockSearchService::new();
@@ -764,7 +758,7 @@ mod tests {
             |_index_id: &str,
              _split_state: SplitState,
              _time_range: Option<Range<i64>>,
-             _tags: &[String]| { Ok(vec![mock_split_info("split1")]) },
+             _tags: &[String]| { Ok(vec![mock_split("split1")]) },
         );
 
         let mut mock_search_service1 = MockSearchService::new();
@@ -825,7 +819,7 @@ mod tests {
             |_index_id: &str,
              _split_state: SplitState,
              _time_range: Option<Range<i64>>,
-             _tags: &[String]| { Ok(vec![mock_split_info("split1")]) },
+             _tags: &[String]| { Ok(vec![mock_split("split1")]) },
         );
         // Service1 - broken node.
         let mut mock_search_service1 = MockSearchService::new();
@@ -911,7 +905,7 @@ mod tests {
             |_index_id: &str,
              _split_state: SplitState,
              _time_range: Option<Range<i64>>,
-             _tags: &[String]| { Ok(vec![mock_split_info("split1")]) },
+             _tags: &[String]| { Ok(vec![mock_split("split1")]) },
         );
 
         // Service1 - working node.

--- a/quickwit-search/src/search_stream/root.rs
+++ b/quickwit-search/src/search_stream/root.rs
@@ -110,7 +110,7 @@ mod tests {
     use std::ops::Range;
 
     use quickwit_index_config::WikipediaIndexConfig;
-    use quickwit_indexing::mock_split_info;
+    use quickwit_indexing::mock_split;
     use quickwit_metastore::checkpoint::Checkpoint;
     use quickwit_metastore::{IndexMetadata, MockMetastore, SplitState};
     use quickwit_proto::OutputFormat;
@@ -147,7 +147,7 @@ mod tests {
             |_index_id: &str,
              _split_state: SplitState,
              _time_range: Option<Range<i64>>,
-             _tags: &[String]| { Ok(vec![mock_split_info("split1")]) },
+             _tags: &[String]| { Ok(vec![mock_split("split1")]) },
         );
         let mut mock_search_service = MockSearchService::new();
         let (result_sender, result_receiver) = tokio::sync::mpsc::unbounded_channel();
@@ -209,7 +209,7 @@ mod tests {
             |_index_id: &str,
              _split_state: SplitState,
              _time_range: Option<Range<i64>>,
-             _tags: &[String]| { Ok(vec![mock_split_info("split1")]) },
+             _tags: &[String]| { Ok(vec![mock_split("split1")]) },
         );
         let mut mock_search_service = MockSearchService::new();
         let (result_sender, result_receiver) = tokio::sync::mpsc::unbounded_channel();
@@ -267,9 +267,7 @@ mod tests {
             |_index_id: &str,
              _split_state: SplitState,
              _time_range: Option<Range<i64>>,
-             _tags: &[String]| {
-                Ok(vec![mock_split_info("split1"), mock_split_info("split2")])
-            },
+             _tags: &[String]| { Ok(vec![mock_split("split1"), mock_split("split2")]) },
         );
         let mut mock_search_service = MockSearchService::new();
         let (result_sender, result_receiver) = tokio::sync::mpsc::unbounded_channel();

--- a/quickwit-serve/src/lib.rs
+++ b/quickwit-serve/src/lib.rs
@@ -156,7 +156,7 @@ mod tests {
 
     use futures::TryStreamExt;
     use quickwit_index_config::WikipediaIndexConfig;
-    use quickwit_indexing::mock_split_info;
+    use quickwit_indexing::mock_split;
     use quickwit_metastore::checkpoint::Checkpoint;
     use quickwit_metastore::{IndexMetadata, MockMetastore, SplitState};
     use quickwit_proto::search_service_server::SearchServiceServer;
@@ -216,7 +216,7 @@ mod tests {
              _split_state: SplitState,
              _time_range: Option<Range<i64>>,
              _tags: &[String]| {
-                Ok(vec![mock_split_info("split_1"), mock_split_info("split_2")])
+                Ok(vec![mock_split("split_1"), mock_split("split_2")])
             },
         );
         let mut mock_search_service = MockSearchService::new();


### PR DESCRIPTION
### Description
Rename `SplitInfo` to `Split`. I also squizzed in a light refactor in the Postgres metastore.

### How was this PR tested?
`make test-all`
