### PR TITLE
Split pruning by tags

### DIFF
--- a/quickwit-index-config/src/lib.rs
+++ b/quickwit-index-config/src/lib.rs
@@ -35,6 +35,7 @@ pub use default_index_config::{
     DefaultIndexConfig, DefaultIndexConfigBuilder, DocParsingError, FieldMappingEntry,
 };
 pub use error::QueryParserError;
+pub use query_builder::extract_tags_from_query;
 pub use wikipedia_config::WikipediaIndexConfig;
 
 /// Field name reserved for storing the source document.

--- a/quickwit-index-config/src/query_builder.rs
+++ b/quickwit-index-config/src/query_builder.rs
@@ -21,7 +21,7 @@ use quickwit_proto::SearchRequest;
 use tantivy::query::{Query, QueryParser, QueryParserError as TantivyQueryParserError};
 use tantivy::schema::{Field, Schema};
 use tantivy::tokenizer::TokenizerManager;
-use tantivy_query_grammar::{UserInputAst, UserInputLeaf};
+use tantivy_query_grammar::{UserInputAst, UserInputLeaf, UserInputLiteral};
 
 use crate::QueryParserError;
 
@@ -47,6 +47,43 @@ pub(crate) fn build_query(
     let query_parser = QueryParser::new(schema, search_fields, TokenizerManager::default());
     let query = query_parser.parse_query(&request.query)?;
     Ok(query)
+}
+
+/// Extracts all filters related to tag fields.
+/// Returns a list of `tag_field_name:tag_value` found in the query.
+pub fn extract_tags_from_query(
+    raw_query: &str,
+    tag_field_names: &[String],
+) -> Result<Vec<String>, QueryParserError> {
+    let user_input_ast = tantivy_query_grammar::parse_query(raw_query)
+        .map_err(|_| TantivyQueryParserError::SyntaxError)?;
+
+    Ok(collect_tag_filters(user_input_ast, tag_field_names))
+}
+
+fn collect_tag_filters(user_input_ast: UserInputAst, tag_field_names: &[String]) -> Vec<String> {
+    let mut fields = vec![];
+    match user_input_ast {
+        UserInputAst::Clause(sub_queries) => {
+            for (_, sub_ast) in sub_queries {
+                fields.extend(collect_tag_filters(sub_ast, tag_field_names));
+            }
+        }
+        UserInputAst::Boost(ast, _) => fields.extend(collect_tag_filters(*ast, tag_field_names)),
+        UserInputAst::Leaf(leaf) => match *leaf {
+            UserInputLeaf::Literal(UserInputLiteral {
+                field_name: Some(field_name),
+                phrase,
+            }) if tag_field_names.contains(&field_name) => {
+                fields.push(format!("{}:{}", field_name, phrase))
+            }
+            // Currently, we don't support range queries. Even if we did, it wouldn't be relevant
+            // for this tag based pruning. Unless we want to support prefix matching
+            // for tags. (TODO: discuss)
+            _ => (),
+        },
+    }
+    fields
 }
 
 fn has_range_clause(user_input_ast: UserInputAst) -> bool {
@@ -80,7 +117,7 @@ mod test {
     use quickwit_proto::SearchRequest;
     use tantivy::schema::{Schema, TEXT};
 
-    use super::build_query;
+    use super::{build_query, extract_tags_from_query};
 
     enum TestExpectation {
         Err(&'static str),
@@ -180,6 +217,39 @@ mod test {
             vec![],
             TestExpectation::Ok("TermQuery"),
         )?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_extract_tags_from_query() -> anyhow::Result<()> {
+        assert!(matches!(
+            extract_tags_from_query(":>", &["bart".to_string(), "lisa".to_string()]),
+            Err(..)
+        ));
+
+        assert_eq!(extract_tags_from_query("*", &[])?, Vec::<String>::new());
+
+        assert_eq!(
+            extract_tags_from_query("*", &["user".to_string(), "lang".to_string()])?,
+            Vec::<String>::new()
+        );
+
+        assert_eq!(
+            extract_tags_from_query(
+                "title:>foo lang:fr",
+                &["user".to_string(), "lang".to_string()]
+            )?,
+            vec!["lang:fr".to_string()]
+        );
+
+        assert_eq!(
+            extract_tags_from_query(
+                "title:foo user:bart lang:fr",
+                &["user".to_string(), "lang".to_string()]
+            )?,
+            vec!["user:bart".to_string(), "lang:fr".to_string()]
+        );
 
         Ok(())
     }


### PR DESCRIPTION
### Description
Closes https://github.com/quickwit-inc/quickwit/issues/823
- Implemented split running by tag. 
Possible refactoring need to be discussed with @fulmicoton as currently we kind of call `tantivy_query_grammar::parse_query(query)` many times during a request. 

### How was this PR tested?
- unit test added
