### PR TITLE
Use gRPC and discovery ports relative to REST port

### DIFF
--- a/quickwit-backward-compat/build.rs
+++ b/quickwit-backward-compat/build.rs
@@ -93,7 +93,7 @@ fn sample_index_metadata_for_regression() -> IndexMetadata {
         sort_field: Some("timestamp".to_string()),
         sort_order: Some(SortOrder::Asc),
         commit_timeout_secs: 301,
-        split_max_num_docs: 10_000_001,
+        split_num_docs_target: 10_000_001,
         merge_enabled: true,
         merge_policy,
         resources: indexing_resources,

--- a/quickwit-backward-compat/test-data/index-metadata/unversioned.expected.json
+++ b/quickwit-backward-compat/test-data/index-metadata/unversioned.expected.json
@@ -58,7 +58,7 @@
     },
     "sort_field": "timestamp",
     "sort_order": "asc",
-    "split_max_num_docs": 10000000,
+    "split_num_docs_target": 10000000,
     "timestamp_field": "timestamp"
   },
   "search_settings": {

--- a/quickwit-backward-compat/test-data/index-metadata/v0-cb4b352caf8990d0e7a54582a4478cd5.expected.json
+++ b/quickwit-backward-compat/test-data/index-metadata/v0-cb4b352caf8990d0e7a54582a4478cd5.expected.json
@@ -60,7 +60,7 @@
     },
     "sort_field": "timestamp",
     "sort_order": "asc",
-    "split_max_num_docs": 10000001,
+    "split_num_docs_target": 10000001,
     "timestamp_field": "timestamp"
   },
   "search_settings": {

--- a/quickwit-backward-compat/test-data/index-metadata/v0-cb4b352caf8990d0e7a54582a4478cd5.json
+++ b/quickwit-backward-compat/test-data/index-metadata/v0-cb4b352caf8990d0e7a54582a4478cd5.json
@@ -60,7 +60,7 @@
     },
     "sort_field": "timestamp",
     "sort_order": "asc",
-    "split_max_num_docs": 10000001,
+    "split_num_docs_target": 10000001,
     "timestamp_field": "timestamp"
   },
   "search_settings": {

--- a/quickwit-cli/src/main.rs
+++ b/quickwit-cli/src/main.rs
@@ -196,11 +196,6 @@ mod tests {
             .try_get_matches_from(vec!["new", "--index-uri", "file:///indexes/wikipedia"])
             .unwrap_err();
 
-        let expected_index_config_uri = format!(
-            "file://{}{}conf.yaml",
-            std::env::current_dir().unwrap().display(),
-            std::path::MAIN_SEPARATOR
-        );
         let app = App::from(yaml).setting(AppSettings::NoBinaryName);
         let matches = app.try_get_matches_from(vec![
             "index",
@@ -208,9 +203,13 @@ mod tests {
             "--index-config-uri",
             "conf.yaml",
             "--metastore-uri",
-            "file:///indexes",
+            "/indexes",
         ])?;
         let command = CliCommand::parse_cli_args(&matches)?;
+        let expected_index_config_uri = format!(
+            "file://{}/conf.yaml",
+            std::env::current_dir().unwrap().display()
+        );
         let expected_cmd = CliCommand::Index(IndexCliCommand::Create(CreateIndexArgs {
             metastore_uri: "file:///indexes".to_string(),
             index_config_uri: expected_index_config_uri.clone(),
@@ -219,7 +218,8 @@ mod tests {
         assert_eq!(command, expected_cmd);
 
         const QUICKWIT_METASTORE_URI_ENV_KEY: &str = "QUICKWIT_METASTORE_URI";
-        env::set_var(QUICKWIT_METASTORE_URI_ENV_KEY, "file:///indexes");
+        env::set_var(QUICKWIT_METASTORE_URI_ENV_KEY, "/indexes");
+
         let app = App::from(yaml).setting(AppSettings::NoBinaryName);
         let matches = app.try_get_matches_from(vec![
             "index",
@@ -482,9 +482,8 @@ mod tests {
         ])?;
         let command = CliCommand::parse_cli_args(&matches)?;
         let expected_server_config_uri = format!(
-            "file://{}{}conf.toml",
-            std::env::current_dir().unwrap().display(),
-            std::path::MAIN_SEPARATOR
+            "file://{}/conf.toml",
+            std::env::current_dir().unwrap().display()
         );
         assert!(matches!(
             command,

--- a/quickwit-cluster/src/cluster.rs
+++ b/quickwit-cluster/src/cluster.rs
@@ -207,8 +207,10 @@ impl Cluster {
 
     /// Specify the address of a running node and join the cluster to which the node belongs.
     pub async fn add_peer_node(&self, peer_addr: SocketAddr) {
-        info!(self_addr = ?self.listen_addr, peer_addr = ?peer_addr, "Adding peer node.");
-        self.artillery_cluster.add_seed_node(peer_addr);
+        if peer_addr != self.listen_addr {
+            info!(self_addr = ?self.listen_addr, peer_addr = ?peer_addr, "Adding peer node.");
+            self.artillery_cluster.add_seed_node(peer_addr);
+        }
     }
 
     /// Leave the cluster.

--- a/quickwit-config/resources/tests/index_config/hdfs-logs.json
+++ b/quickwit-config/resources/tests/index_config/hdfs-logs.json
@@ -47,7 +47,7 @@
         "sort_field": "timestamp",
         "sort_order": "asc",
         "commit_timeout_secs": 61,
-        "split_max_num_docs": 10000001,
+        "split_num_docs_target": 10000001,
         "merge_policy": {
             "demux_factor": 7,
             "merge_factor": 9,

--- a/quickwit-config/resources/tests/index_config/hdfs-logs.toml
+++ b/quickwit-config/resources/tests/index_config/hdfs-logs.toml
@@ -19,7 +19,7 @@ timestamp_field = "timestamp"
 sort_field = "timestamp"
 sort_order = "asc"
 commit_timeout_secs = 61
-split_max_num_docs = 10_000_001
+split_num_docs_target = 10_000_001
 
 [indexing_settings.merge_policy]
 demux_factor = 7

--- a/quickwit-config/resources/tests/index_config/hdfs-logs.yaml
+++ b/quickwit-config/resources/tests/index_config/hdfs-logs.yaml
@@ -32,7 +32,7 @@ indexing_settings:
   sort_field: timestamp
   sort_order: asc
   commit_timeout_secs: 61
-  split_max_num_docs: 10000001
+  split_num_docs_target: 10000001
   merge_policy:
     demux_factor: 7
     merge_factor: 9

--- a/quickwit-config/resources/tests/server_config/server.json
+++ b/quickwit-config/resources/tests/server_config/server.json
@@ -6,8 +6,6 @@
         "data_dir_path": "/opt/quickwit/data",
         "rest_listen_address": "0.0.0.0",
         "rest_listen_port": 1111,
-        "grpc_listen_address": "0.0.0.0",
-        "grpc_listen_port": 2222,
         "split_store_max_num_bytes": "1T",
         "split_store_max_num_splits": 10000
     },
@@ -16,13 +14,9 @@
         "host_key_path": "/opt/quickwit/host_key",
         "rest_listen_address": "0.0.0.0",
         "rest_listen_port": 11111,
-        "grpc_listen_address": "0.0.0.0",
-        "grpc_listen_port": 22222,
-        "discovery_listen_address": "0.0.0.0",
-        "discovery_listen_port": 33333,
         "peer_seeds": [
-            "quickwit-searcher-0.local:33333",
-            "quickwit-searcher-1.local:33333"
+            "quickwit-searcher-0.local",
+            "quickwit-searcher-1.local"
         ],
         "fast_field_cache_capacity": "10G",
         "split_footer_cache_capacity": "1G"

--- a/quickwit-config/resources/tests/server_config/server.toml
+++ b/quickwit-config/resources/tests/server_config/server.toml
@@ -5,8 +5,6 @@ metastore_uri = "postgres://username:password@host:port/db"
 data_dir_path = "/opt/quickwit/data"
 rest_listen_address = "0.0.0.0"
 rest_listen_port = 1111
-grpc_listen_address = "0.0.0.0"
-grpc_listen_port = 2222
 split_store_max_num_bytes = "1T"
 split_store_max_num_splits = 10_000
 
@@ -15,11 +13,7 @@ data_dir_path = "/opt/quickwit/data"
 host_key_path = "/opt/quickwit/host_key"
 rest_listen_address = "0.0.0.0"
 rest_listen_port = 11111
-grpc_listen_address = "0.0.0.0"
-grpc_listen_port = 22222
-discovery_listen_address = "0.0.0.0"
-discovery_listen_port = 33333
-peer_seeds = [ "quickwit-searcher-0.local:33333", "quickwit-searcher-1.local:33333" ]
+peer_seeds = [ "quickwit-searcher-0.local", "quickwit-searcher-1.local" ]
 fast_field_cache_capacity = "10G"
 split_footer_cache_capacity = "1G"
 

--- a/quickwit-config/resources/tests/server_config/server.yaml
+++ b/quickwit-config/resources/tests/server_config/server.yaml
@@ -4,8 +4,6 @@ indexer:
   data_dir_path: /opt/quickwit/data
   rest_listen_address: 0.0.0.0
   rest_listen_port: 1111
-  grpc_listen_address: 0.0.0.0
-  grpc_listen_port: 2222
   split_store_max_num_bytes: 1T
   split_store_max_num_splits: 10000
 searcher:
@@ -13,13 +11,9 @@ searcher:
   host_key_path: /opt/quickwit/host_key
   rest_listen_address: 0.0.0.0
   rest_listen_port: 11111
-  grpc_listen_address: 0.0.0.0
-  grpc_listen_port: 22222
-  discovery_listen_address: 0.0.0.0
-  discovery_listen_port: 33333
   peer_seeds:
-    - quickwit-searcher-0.local:33333
-    - quickwit-searcher-1.local:33333
+    - quickwit-searcher-0.local
+    - quickwit-searcher-1.local
   fast_field_cache_capacity: 10G
   split_footer_cache_capacity: 1G
 storage:

--- a/quickwit-config/src/index_config.rs
+++ b/quickwit-config/src/index_config.rs
@@ -124,9 +124,10 @@ pub struct IndexingSettings {
     pub sort_order: Option<SortOrder>,
     #[serde(default = "IndexingSettings::default_commit_timeout_secs")]
     pub commit_timeout_secs: usize,
-    /// The maximum number of documents allowed in a split.
-    #[serde(default = "IndexingSettings::default_split_max_num_docs")]
-    pub split_max_num_docs: usize,
+    /// A split containing a number of docs greather than or equal to this value is considered
+    /// mature.
+    #[serde(default = "IndexingSettings::default_split_num_docs_target")]
+    pub split_num_docs_target: usize,
     #[serde(default = "IndexingSettings::default_merge_enabled")]
     pub merge_enabled: bool,
     #[serde(default)]
@@ -144,7 +145,7 @@ impl IndexingSettings {
         60
     }
 
-    fn default_split_max_num_docs() -> usize {
+    fn default_split_num_docs_target() -> usize {
         10_000_000
     }
 
@@ -178,7 +179,7 @@ impl Default for IndexingSettings {
             sort_field: None,
             sort_order: None,
             commit_timeout_secs: Self::default_commit_timeout_secs(),
-            split_max_num_docs: Self::default_split_max_num_docs(),
+            split_num_docs_target: Self::default_split_num_docs_target(),
             merge_enabled: Self::default_merge_enabled(),
             merge_policy: MergePolicy::default(),
             resources: IndexingResources::default(),
@@ -309,7 +310,7 @@ mod tests {
                 assert_eq!(index_config.indexing_settings.commit_timeout_secs, 61);
 
                 assert_eq!(
-                    index_config.indexing_settings.split_max_num_docs,
+                    index_config.indexing_settings.split_num_docs_target,
                     10_000_001
                 );
                 assert_eq!(

--- a/quickwit-config/src/index_config.rs
+++ b/quickwit-config/src/index_config.rs
@@ -253,19 +253,14 @@ impl IndexConfig {
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
-
     use super::*;
 
     fn get_resource_path(resource_filename: &str) -> String {
-        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-            .join("resources")
-            .join("tests")
-            .join("index_config")
-            .join(resource_filename)
-            .to_str()
-            .expect("Invalid resource file name.")
-            .to_string()
+        format!(
+            "{}/resources/tests/index_config/{}",
+            env!("CARGO_MANIFEST_DIR"),
+            resource_filename
+        )
     }
 
     macro_rules! test_parser {

--- a/quickwit-config/src/server_config.rs
+++ b/quickwit-config/src/server_config.rs
@@ -301,14 +301,11 @@ mod tests {
     use super::*;
 
     fn get_resource_path(resource_filename: &str) -> String {
-        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-            .join("resources")
-            .join("tests")
-            .join("server_config")
-            .join(resource_filename)
-            .to_str()
-            .expect("Invalid resource file name.")
-            .to_string()
+        format!(
+            "{}/resources/tests/server_config/{}",
+            env!("CARGO_MANIFEST_DIR"),
+            resource_filename
+        )
     }
 
     fn set_data_dir_path(server_config: &mut ServerConfig, path: PathBuf) {

--- a/quickwit-config/src/server_config.rs
+++ b/quickwit-config/src/server_config.rs
@@ -45,10 +45,6 @@ pub struct IndexerConfig {
     pub rest_listen_address: String,
     #[serde(default = "IndexerConfig::default_rest_listen_port")]
     pub rest_listen_port: u16,
-    #[serde(default = "default_listen_address")]
-    pub grpc_listen_address: String,
-    #[serde(default = "IndexerConfig::default_grpc_listen_port")]
-    pub grpc_listen_port: u16,
     #[serde(default = "IndexerConfig::default_split_store_max_num_bytes")]
     pub split_store_max_num_bytes: Byte,
     #[serde(default = "IndexerConfig::default_split_store_max_num_splits")]
@@ -58,10 +54,6 @@ pub struct IndexerConfig {
 impl IndexerConfig {
     fn default_rest_listen_port() -> u16 {
         7180
-    }
-
-    fn default_grpc_listen_port() -> u16 {
-        7181
     }
 
     fn default_split_store_max_num_bytes() -> Byte {
@@ -79,7 +71,6 @@ impl IndexerConfig {
         let indexer_config = IndexerConfig {
             data_dir_path: temp_dir.path().to_path_buf(),
             rest_listen_port: find_available_port()?,
-            grpc_listen_port: find_available_port()?,
             split_store_max_num_bytes: Byte::from_bytes(50_000_000),
             split_store_max_num_splits: 100,
             ..Default::default()
@@ -104,8 +95,6 @@ impl Default for IndexerConfig {
             data_dir_path: default_data_dir_path(),
             rest_listen_address: default_listen_address(),
             rest_listen_port: Self::default_rest_listen_port(),
-            grpc_listen_address: default_listen_address(),
-            grpc_listen_port: Self::default_grpc_listen_port(),
             split_store_max_num_bytes: Self::default_split_store_max_num_bytes(),
             split_store_max_num_splits: Self::default_split_store_max_num_splits(),
         }
@@ -123,16 +112,7 @@ pub struct SearcherConfig {
     pub rest_listen_address: String,
     #[serde(default = "SearcherConfig::default_rest_listen_port")]
     pub rest_listen_port: u16,
-    #[serde(default = "default_listen_address")]
-    pub grpc_listen_address: String,
-    #[serde(default = "SearcherConfig::default_grpc_listen_port")]
-    pub grpc_listen_port: u16,
-    #[serde(default = "default_listen_address")]
-    pub discovery_listen_address: String,
-    #[serde(default = "SearcherConfig::default_discovery_listen_port")]
-    pub discovery_listen_port: u16,
     #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub peer_seeds: Vec<String>,
     #[serde(default = "SearcherConfig::default_fast_field_cache_capacity")]
     pub fast_field_cache_capacity: Byte,
@@ -147,14 +127,6 @@ impl SearcherConfig {
 
     fn default_rest_listen_port() -> u16 {
         7280
-    }
-
-    fn default_grpc_listen_port() -> u16 {
-        7281
-    }
-
-    fn default_discovery_listen_port() -> u16 {
-        7282
     }
 
     fn default_fast_field_cache_capacity() -> Byte {
@@ -175,19 +147,38 @@ impl SearcherConfig {
     pub fn grpc_socket_addr(&self) -> anyhow::Result<SocketAddr> {
         socket_addr_from_str(format!(
             "{}:{}",
-            self.grpc_listen_address, self.grpc_listen_port
+            self.rest_listen_address,
+            self.rest_listen_port + 1
         ))
     }
 
     pub fn discovery_socket_addr(&self) -> anyhow::Result<SocketAddr> {
         socket_addr_from_str(format!(
             "{}:{}",
-            self.discovery_listen_address, self.discovery_listen_port
+            self.rest_listen_address,
+            self.rest_listen_port + 2
         ))
     }
 
     pub fn peer_socket_addrs(&self) -> anyhow::Result<Vec<SocketAddr>> {
-        self.peer_seeds.iter().map(socket_addr_from_str).collect()
+        let peer_socket_addrs: Vec<SocketAddr> = self
+            .peer_seeds
+            .iter()
+            .flat_map(|peer_seed| {
+                socket_addr_from_str(format!("{}:{}", peer_seed, self.rest_listen_port + 2))
+                    .map_err(
+                        |_| warn!(address = %peer_seed, "Failed to resolve peer seed address."),
+                    )
+            })
+            .collect();
+
+        if !self.peer_seeds.is_empty() && peer_socket_addrs.is_empty() {
+            bail!(
+                "Failed to resolve any of the peer seed addresses: `{}`",
+                self.peer_seeds.join(", ")
+            )
+        }
+        Ok(peer_socket_addrs)
     }
 }
 
@@ -213,10 +204,6 @@ impl Default for SearcherConfig {
             host_key_path: Self::default_host_key_path(),
             rest_listen_address: default_listen_address(),
             rest_listen_port: Self::default_rest_listen_port(),
-            grpc_listen_address: default_listen_address(),
-            grpc_listen_port: Self::default_grpc_listen_port(),
-            discovery_listen_address: default_listen_address(),
-            discovery_listen_port: Self::default_discovery_listen_port(),
             peer_seeds: Vec::new(),
             fast_field_cache_capacity: Self::default_fast_field_cache_capacity(),
             split_footer_cache_capacity: Self::default_split_footer_cache_capacity(),
@@ -336,8 +323,6 @@ mod tests {
                         data_dir_path: PathBuf::from("/opt/quickwit/data"),
                         rest_listen_address: "0.0.0.0".to_string(),
                         rest_listen_port: 1111,
-                        grpc_listen_address: "0.0.0.0".to_string(),
-                        grpc_listen_port: 2222,
                         split_store_max_num_bytes: Byte::from_str("1T").unwrap(),
                         split_store_max_num_splits: 10_000,
                     }
@@ -350,13 +335,9 @@ mod tests {
                         host_key_path: PathBuf::from("/opt/quickwit/host_key"),
                         rest_listen_address: "0.0.0.0".to_string(),
                         rest_listen_port: 11111,
-                        grpc_listen_address: "0.0.0.0".to_string(),
-                        grpc_listen_port: 22222,
-                        discovery_listen_address: "0.0.0.0".to_string(),
-                        discovery_listen_port: 33333,
                         peer_seeds: vec![
-                            "quickwit-searcher-0.local:33333".to_string(),
-                            "quickwit-searcher-1.local:33333".to_string()
+                            "quickwit-searcher-0.local".to_string(),
+                            "quickwit-searcher-1.local".to_string()
                         ],
                         fast_field_cache_capacity: Byte::from_str("10G").unwrap(),
                         split_footer_cache_capacity: Byte::from_str("1G").unwrap(),
@@ -488,5 +469,36 @@ mod tests {
             .unwrap();
         set_data_dir_path(&mut server_config, env::current_dir().unwrap());
         assert!(server_config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_peer_socket_addrs() {
+        {
+            let searcher_config = SearcherConfig {
+                rest_listen_port: 1789,
+                peer_seeds: Vec::new(),
+                ..Default::default()
+            };
+            assert!(searcher_config.peer_socket_addrs().unwrap().is_empty());
+        }
+        {
+            let searcher_config = SearcherConfig {
+                rest_listen_port: 1789,
+                peer_seeds: vec!["unresolvable-host".to_string()],
+                ..Default::default()
+            };
+            assert!(searcher_config.peer_socket_addrs().is_err());
+        }
+        {
+            let searcher_config = SearcherConfig {
+                rest_listen_port: 1789,
+                peer_seeds: vec!["unresolvable-host".to_string(), "127.0.0.1".to_string()],
+                ..Default::default()
+            };
+            assert_eq!(
+                searcher_config.peer_socket_addrs().unwrap(),
+                vec!["127.0.0.1:1791".parse().unwrap()]
+            );
+        }
     }
 }

--- a/quickwit-indexing/src/actors/indexer.rs
+++ b/quickwit-indexing/src/actors/indexer.rs
@@ -350,7 +350,7 @@ impl Indexer {
             ctx,
         )?;
         if self.counters.num_docs_in_split
-            >= self.indexer_state.indexing_settings.split_max_num_docs as u64
+            >= self.indexer_state.indexing_settings.split_num_docs_target as u64
         {
             self.send_to_packager(CommitTrigger::NumDocsLimit, ctx)?;
         }
@@ -428,7 +428,7 @@ mod tests {
         let doc_mapper = Arc::new(quickwit_index_config::default_config_for_tests());
         let indexing_directory = IndexingDirectory::for_test().await?;
         let mut indexing_settings = IndexingSettings::for_test();
-        indexing_settings.split_max_num_docs = 3;
+        indexing_settings.split_num_docs_target = 3;
         indexing_settings.sort_field = Some("timestamp".to_string());
         indexing_settings.sort_order = Some(SortOrder::Desc);
         indexing_settings.timestamp_field = Some("timestamp".to_string());

--- a/quickwit-indexing/src/actors/indexing_pipeline.rs
+++ b/quickwit-indexing/src/actors/indexing_pipeline.rs
@@ -215,7 +215,7 @@ impl IndexingPipeline {
             merge_enabled: self.params.indexing_settings.merge_enabled,
             merge_factor: self.params.indexing_settings.merge_policy.merge_factor,
             max_merge_factor: self.params.indexing_settings.merge_policy.max_merge_factor,
-            split_max_num_docs: self.params.indexing_settings.split_max_num_docs,
+            split_num_docs_target: self.params.indexing_settings.split_num_docs_target,
             ..Default::default()
         };
         let merge_policy: Arc<dyn MergePolicy> = Arc::new(stable_multitenant_merge_policy);
@@ -315,8 +315,8 @@ impl IndexingPipeline {
             merge_packager_mailbox,
             self.params.indexing_settings.timestamp_field.clone(),
             self.params.indexing_settings.demux_field.clone(),
-            self.params.indexing_settings.split_max_num_docs as usize,
-            self.params.indexing_settings.split_max_num_docs as usize * 2,
+            self.params.indexing_settings.split_num_docs_target as usize,
+            self.params.indexing_settings.split_num_docs_target as usize * 2,
         );
         let (merge_executor_mailbox, merge_executor_handler) = ctx
             .spawn_actor(merge_executor)

--- a/quickwit-indexing/src/merge_policy.rs
+++ b/quickwit-indexing/src/merge_policy.rs
@@ -145,7 +145,6 @@ pub trait MergePolicy: Send + Sync + fmt::Debug {
 /// build a demux operation with it, and loop.
 #[derive(Clone, Debug)]
 pub struct StableMultitenantWithTimestampMergePolicy {
-    /// We never merge segments larger than this size.
     pub demux_enabled: bool,
     pub demux_factor: usize,
     pub demux_field_name: Option<String>,
@@ -153,7 +152,12 @@ pub struct StableMultitenantWithTimestampMergePolicy {
     pub merge_enabled: bool,
     pub merge_factor: usize,
     pub max_merge_factor: usize,
-    pub split_max_num_docs: usize,
+    /// The merge policy aims to eventually produce mature splits that have a larger size but
+    /// are within close range of `split_num_docs_target`.
+    ///
+    /// In other words, splits that contain a number of documents greater than or equal to
+    /// `split_num_docs_target` are considered mature and never merged.
+    pub split_num_docs_target: usize,
 }
 
 impl Default for StableMultitenantWithTimestampMergePolicy {
@@ -166,7 +170,7 @@ impl Default for StableMultitenantWithTimestampMergePolicy {
             merge_enabled: true,
             merge_factor: 10,
             max_merge_factor: 12,
-            split_max_num_docs: 10_000_000,
+            split_num_docs_target: 10_000_000,
         }
     }
 }
@@ -242,7 +246,7 @@ impl StableMultitenantWithTimestampMergePolicy {
         }
         // Once a split has been demuxed, we don't want to merge it even in the
         // case where its number of docs is under `max_merge_docs`.
-        split.num_docs >= self.split_max_num_docs || split.demux_num_ops > 0
+        split.num_docs >= self.split_num_docs_target || split.demux_num_ops > 0
     }
 
     /// A mature split for demux is a split that won't undergo demux operation in the future.
@@ -268,7 +272,7 @@ impl StableMultitenantWithTimestampMergePolicy {
             // split will be demuxed.
             return true;
         };
-        if split.num_docs >= self.demux_factor * self.split_max_num_docs {
+        if split.num_docs >= self.demux_factor * self.split_num_docs_target {
             return true;
         }
         let split_tags_contains_less_than_2_demux_values = split
@@ -278,7 +282,7 @@ impl StableMultitenantWithTimestampMergePolicy {
             .count()
             < 2;
         split_tags_contains_less_than_2_demux_values
-            || (split.num_docs < self.split_max_num_docs || split.demux_num_ops > 0)
+            || (split.num_docs < self.split_num_docs_target || split.demux_num_ops > 0)
     }
 
     fn merge_operations(&self, splits: &mut Vec<SplitMetadata>) -> Vec<MergeOperation> {
@@ -363,22 +367,23 @@ impl StableMultitenantWithTimestampMergePolicy {
         assert!(
             splits
                 .iter()
-                .all(|split| split.num_docs < self.split_max_num_docs * self.demux_factor),
+                .all(|split| split.num_docs < self.split_num_docs_target * self.demux_factor),
             "Each split size must satisfy `max_merge_docs <= size < demux_factor * max_merge_docs`"
         );
         let mut total_num_docs_left: usize = splits.iter().map(|split| split.num_docs).sum();
-        if splits.is_empty() || total_num_docs_left < self.demux_factor * self.split_max_num_docs {
+        if splits.is_empty() || total_num_docs_left < self.demux_factor * self.split_num_docs_target
+        {
             return Vec::new();
         }
         let mut operations = Vec::new();
         while !splits.is_empty()
-            && total_num_docs_left >= self.demux_factor * self.split_max_num_docs
+            && total_num_docs_left >= self.demux_factor * self.split_num_docs_target
         {
             let mut end_split_idx = 0;
             let mut num_docs_to_demux = 0;
             for (split_idx, split) in splits.iter().enumerate().take(self.demux_factor) {
                 num_docs_to_demux += split.num_docs;
-                if num_docs_to_demux >= self.demux_factor * self.split_max_num_docs {
+                if num_docs_to_demux >= self.demux_factor * self.split_num_docs_target {
                     end_split_idx = split_idx;
                     break;
                 }
@@ -410,7 +415,7 @@ impl StableMultitenantWithTimestampMergePolicy {
         assert!(
             splits
                 .iter()
-                .all(|split| split.num_docs < self.split_max_num_docs),
+                .all(|split| split.num_docs < self.split_num_docs_target),
             "All splits are expected to be smaller than `max_merge_docs`."
         );
         if splits.is_empty() {
@@ -475,7 +480,7 @@ impl StableMultitenantWithTimestampMergePolicy {
         let num_docs_in_merge: usize = splits.iter().map(|split| split.num_docs).sum();
 
         // The resulting split will exceed `max_merge_docs`.
-        if num_docs_in_merge >= self.split_max_num_docs {
+        if num_docs_in_merge >= self.split_num_docs_target {
             return MergeCandidateSize::OneMoreSplitWouldBeTooBig;
         }
 
@@ -490,14 +495,14 @@ impl StableMultitenantWithTimestampMergePolicy {
         assert!(self.min_level_num_docs > 0);
         assert!(self.merge_factor > 1);
         assert!(self.max_merge_factor >= self.merge_factor);
-        assert!(self.split_max_num_docs > self.min_level_num_docs);
+        assert!(self.split_num_docs_target > self.min_level_num_docs);
         let mut levels_start_num_docs = vec![1];
         let mut level_end_doc = self.min_level_num_docs;
-        while level_end_doc < self.split_max_num_docs {
+        while level_end_doc < self.split_num_docs_target {
             levels_start_num_docs.push(level_end_doc);
             level_end_doc *= growth_factor;
         }
-        levels_start_num_docs.push(self.split_max_num_docs);
+        levels_start_num_docs.push(self.split_num_docs_target);
         levels_start_num_docs
     }
 
@@ -612,11 +617,11 @@ mod tests {
         split.demux_num_ops = 1;
         assert!(merge_policy.is_mature(&split));
         // Split with docs > max_merge_docs and demux_generation = 0 is mature.
-        split.num_docs = merge_policy.split_max_num_docs + 1;
+        split.num_docs = merge_policy.split_num_docs_target + 1;
         split.demux_num_ops = 0;
         assert!(merge_policy.is_mature(&split));
         // Split with docs > max_merge_docs and demux_generation = 1 is mature.
-        split.num_docs = merge_policy.split_max_num_docs + 1;
+        split.num_docs = merge_policy.split_num_docs_target + 1;
         split.demux_num_ops = 1;
         assert!(merge_policy.is_mature(&split));
     }
@@ -639,7 +644,7 @@ mod tests {
         // Split under max_merge_docs and demux_generation = 0 is not mature.
         assert!(!merge_policy.is_mature(&split));
         // Split with docs >= max_merge_docs and demux_generation = 0 is not mature.
-        split.num_docs = merge_policy.split_max_num_docs + 1;
+        split.num_docs = merge_policy.split_num_docs_target + 1;
         split.demux_num_ops = 0;
         assert!(!merge_policy.is_mature(&split));
         // Split with docs > max_merge_docs, demux_generation of 0 and wrong tags is also mature.
@@ -661,11 +666,11 @@ mod tests {
         split.demux_num_ops = 1;
         assert!(merge_policy.is_mature(&split));
         // Split with docs > max_merge_docs and demux_generation = 1 is mature.
-        split.num_docs = merge_policy.split_max_num_docs + 1;
+        split.num_docs = merge_policy.split_num_docs_target + 1;
         split.demux_num_ops = 1;
         assert!(merge_policy.is_mature(&split));
         // Split with num docs >= max_merge_docs * demux_factor is mature.
-        split.num_docs = merge_policy.demux_factor * merge_policy.split_max_num_docs;
+        split.num_docs = merge_policy.demux_factor * merge_policy.split_num_docs_target;
         split.demux_num_ops = 0;
         assert!(merge_policy.is_mature(&split));
         // Split with docs > max_merge_docs, demux_generation of 0 and wrong tags is also mature.
@@ -674,7 +679,7 @@ mod tests {
             "other_field:2".to_string(),
         ]);
         split.tags = other_tags;
-        split.num_docs = merge_policy.split_max_num_docs + 1;
+        split.num_docs = merge_policy.split_num_docs_target + 1;
         split.demux_num_ops = 0;
         assert!(merge_policy.is_mature(&split));
     }
@@ -919,7 +924,7 @@ mod tests {
             merge_enabled: true,
             merge_factor: 10,
             max_merge_factor: 12,
-            split_max_num_docs: 10_000_000,
+            split_num_docs_target: 10_000_000,
         };
         let mut demux_candidates = create_splits_with_tags(
             vec![


### PR DESCRIPTION
### Description
- Use gRPC and discovery ports relative to REST port
- Rename `split_max_num_docs` to `split_num_docs_target`
- Simplify `get_resource_path`

### How was this PR tested?
`make test-all`
