### PR TITLE
Adding automated tag pruning logic

### DIFF
--- a/quickwit-cli/src/cli.yaml
+++ b/quickwit-cli/src/cli.yaml
@@ -111,11 +111,6 @@ subcommands:
                         about: Filters out documents after that timestamp (time-series indexes only).
                         long: end-timestamp
                         value_name: TIMESTAMP
-                    - tags:
-                        about: Restricts search to splits matching the specified tags.
-                        long: tags
-                        value_name: TAG
-                        multiple_values: true
             - merge:
                 display_order: 4
                 about: Merges an index.
@@ -204,7 +199,7 @@ subcommands:
         about: Operations (add, delete, describe...) on splits.
         subcommands:
             - extract:
-                about: Downloads and extracts a split to a directory. 
+                about: Downloads and extracts a split to a directory.
                 args:
                     - index-id:
                         about: ID of the target index.

--- a/quickwit-cli/src/index.rs
+++ b/quickwit-cli/src/index.rs
@@ -33,7 +33,7 @@ use quickwit_common::uri::normalize_uri;
 use quickwit_common::GREEN_COLOR;
 use quickwit_config::{IndexConfig, IndexerConfig, SourceConfig};
 use quickwit_core::{create_index, delete_index, garbage_collect_index, reset_index};
-use quickwit_index_config::match_tag_field_name;
+use quickwit_index_config::tag_pruning::match_tag_field_name;
 use quickwit_indexing::actors::{IndexingPipeline, IndexingPipelineParams};
 use quickwit_indexing::models::IndexingStatistics;
 use quickwit_indexing::source::FileSourceParams;
@@ -82,7 +82,6 @@ pub struct SearchIndexArgs {
     pub search_fields: Option<Vec<String>>,
     pub start_timestamp: Option<i64>,
     pub end_timestamp: Option<i64>,
-    pub tags: Option<Vec<String>>,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -232,10 +231,6 @@ impl IndexCliCommand {
         } else {
             None
         };
-        let tags = matches
-            .values_of("tags")
-            .map(|values| values.map(|value| value.to_string()).collect());
-
         Ok(Self::Search(SearchIndexArgs {
             index_id,
             query,
@@ -244,7 +239,6 @@ impl IndexCliCommand {
             search_fields,
             start_timestamp,
             end_timestamp,
-            tags,
             metastore_uri,
         }))
     }
@@ -350,7 +344,7 @@ pub async fn describe_index_cli(args: DescribeIndexArgs) -> anyhow::Result<()> {
     let metastore = metastore_uri_resolver.resolve(&args.metastore_uri).await?;
     let index_metadata = metastore.index_metadata(&args.index_id).await?;
     let splits = metastore
-        .list_splits(&args.index_id, SplitState::Published, None, &[])
+        .list_splits(&args.index_id, SplitState::Published, None, None)
         .await?;
 
     let splits_num_docs = splits
@@ -679,7 +673,6 @@ pub async fn search_index(args: SearchIndexArgs) -> anyhow::Result<SearchRespons
         end_timestamp: args.end_timestamp,
         max_hits: args.max_hits as u64,
         start_offset: args.start_offset as u64,
-        tags: args.tags.unwrap_or_default(),
     };
     let search_response: SearchResponse =
         single_node_search(&search_request, &*metastore, storage_uri_resolver.clone()).await?;

--- a/quickwit-cli/src/main.rs
+++ b/quickwit-cli/src/main.rs
@@ -284,7 +284,6 @@ mod tests {
                 search_fields: None,
                 start_timestamp: None,
                 end_timestamp: None,
-                tags: None,
                 metastore_uri,
             })) if &index_id == "wikipedia" && &query == "Barack Obama" && &metastore_uri == "file:///indexes"
         ));
@@ -308,9 +307,6 @@ mod tests {
             "0",
             "--end-timestamp",
             "1",
-            "--tags",
-            "device:rpi",
-            "city:paris",
             "--search-fields",
             "title",
             "url",
@@ -326,11 +322,11 @@ mod tests {
                 search_fields: Some(field_names),
                 start_timestamp: Some(0),
                 end_timestamp: Some(1),
-                tags: Some(tags),
                 metastore_uri,
-            })) if &index_id == "wikipedia" && query == "Barack Obama"
-                && field_names == vec!["title".to_string(), "url".to_string()]
-                && tags == vec!["device:rpi".to_string(), "city:paris".to_string()] && &metastore_uri == "file:///indexes"
+            })) if &index_id == "wikipedia"
+                  && query == "Barack Obama"
+                  && field_names == vec!["title".to_string(), "url".to_string()]
+                  && &metastore_uri == "file:///indexes"
         ));
         Ok(())
     }

--- a/quickwit-cli/tests/cli.rs
+++ b/quickwit-cli/tests/cli.rs
@@ -230,35 +230,42 @@ fn test_cmd_search() -> Result<()> {
         result["numHits"] == Value::Number(Number::from(2i64))
     }));
 
-    // search with tags
-    make_command(
-        format!(
-            "index search --index-id {} --metastore-uri {} --query level:info --tags city:paris \
-             device:rpi",
-            test_env.index_id, test_env.metastore_uri,
-        )
-        .as_str(),
-    )
+    // search with tag pruning
+    crate::helpers::make_command_with_list_of_args(&[
+        "index",
+        "search",
+        "--index-id",
+        &test_env.index_id,
+        "--metastore-uri",
+        &test_env.metastore_uri,
+        "--query",
+        "+level:info +city:paris",
+    ])
     .assert()
     .success()
     .stdout(predicate::function(|output: &[u8]| {
         let result: Value = serde_json::from_slice(output).unwrap();
-        result["numHits"] == Value::Number(Number::from(2i64))
+        result["numHits"] == Value::Number(Number::from(1i64))
     }));
 
-    make_command(
-        format!(
-            "index search --index-id {} --metastore-uri {} --query level:info --tags city:conakry",
-            test_env.index_id, &test_env.metastore_uri,
-        )
-        .as_str(),
-    )
+    // search with tag pruning
+    crate::helpers::make_command_with_list_of_args(&[
+        "index",
+        "search",
+        "--index-id",
+        &test_env.index_id,
+        "--metastore-uri",
+        &test_env.metastore_uri,
+        "--query",
+        "level:info AND city:conakry",
+    ])
     .assert()
     .success()
     .stdout(predicate::function(|output: &[u8]| {
         let result: Value = serde_json::from_slice(output).unwrap();
         result["numHits"] == Value::Number(Number::from(0i64))
     }));
+
     Ok(())
 }
 

--- a/quickwit-cli/tests/helpers.rs
+++ b/quickwit-cli/tests/helpers.rs
@@ -78,7 +78,7 @@ const DEFAULT_SERVER_CONFIG: &str = r#"
       rest_listen_port: #indexer.rest_listen_port
       grpc_listen_port: #indexer.grpc_listen_port
       discovery_listen_port: #indexer.discovery_listen_port
- 
+
     searcher:
       data_dir_path: #data_dir_path
       host_key_path: #data_dir_path/host_key
@@ -111,6 +111,17 @@ pub fn make_command(arguments: &str) -> Command {
     )
     .env(AWS_DEFAULT_REGION_ENV, "us-east-1")
     .args(arguments.split_whitespace());
+    cmd
+}
+
+pub fn make_command_with_list_of_args(arguments: &[&str]) -> Command {
+    let mut cmd = Command::cargo_bin(PACKAGE_BIN_NAME).unwrap();
+    cmd.env(
+        quickwit_telemetry::DISABLE_TELEMETRY_ENV_KEY,
+        "disable-for-tests",
+    )
+    .env(AWS_DEFAULT_REGION_ENV, "us-east-1")
+    .args(arguments.iter());
     cmd
 }
 

--- a/quickwit-core/src/index.rs
+++ b/quickwit-core/src/index.rs
@@ -79,10 +79,10 @@ pub async fn delete_index(
 
     // Schedule staged and published splits for deletion.
     let staged_splits = metastore
-        .list_splits(index_id, SplitState::Staged, None, &[])
+        .list_splits(index_id, SplitState::Staged, None, None)
         .await?;
     let published_splits = metastore
-        .list_splits(index_id, SplitState::Published, None, &[])
+        .list_splits(index_id, SplitState::Published, None, None)
         .await?;
     let split_ids = staged_splits
         .iter()
@@ -95,7 +95,7 @@ pub async fn delete_index(
 
     // Select split to delete
     let splits_to_delete = metastore
-        .list_splits(index_id, SplitState::ScheduledForDeletion, None, &[])
+        .list_splits(index_id, SplitState::ScheduledForDeletion, None, None)
         .await?
         .into_iter()
         .map(|metadata| metadata.split_metadata)

--- a/quickwit-index-config/src/config.rs
+++ b/quickwit-index-config/src/config.rs
@@ -28,40 +28,6 @@ use tantivy::Document;
 
 use crate::{DocParsingError, QueryParserError, SortBy};
 
-/// Separator used to format tags into `{field_name}:{value}`
-pub const TAG_FIELD_VALUE_SEPARATOR: &str = ":";
-
-/// Wilcard value use to collapse too many tag values into one.
-pub const TOO_MANY_TAG_VALUES: &str = "*";
-
-/// Character use to escape tag value when there is collision with the wilcard
-/// tag values.
-pub const TAGS_VALUE_ESCAPE: &str = "\\";
-
-/// Returns true if tag_string is of form `{field_name}:any_value`.
-pub fn match_tag_field_name(field_name: &str, tag_string: &str) -> bool {
-    tag_string.starts_with(&format!("{}{}", field_name, TAG_FIELD_VALUE_SEPARATOR))
-}
-
-/// Creates the wildcard tag value for a field name: `{field_name}:*`.
-pub fn build_too_many_tag_value(field_name: &str) -> String {
-    format!(
-        "{}{}{}",
-        field_name, TAG_FIELD_VALUE_SEPARATOR, TOO_MANY_TAG_VALUES
-    )
-}
-
-/// Creates a tag value for a field name of this format `{field_name}:value`.
-pub fn build_tag_value(field_name: &str, field_value: &str) -> String {
-    if field_value == TOO_MANY_TAG_VALUES {
-        return format!(
-            "{}{}{}{}",
-            field_name, TAG_FIELD_VALUE_SEPARATOR, TAGS_VALUE_ESCAPE, field_value
-        );
-    }
-    format!("{}{}{}", field_name, TAG_FIELD_VALUE_SEPARATOR, field_value)
-}
-
 /// The `IndexConfig` trait defines the way of defining how a (json) document,
 /// and the fields it contains, are stored and indexed.
 ///

--- a/quickwit-index-config/src/lib.rs
+++ b/quickwit-index-config/src/lib.rs
@@ -30,7 +30,10 @@ mod error;
 mod query_builder;
 mod sort_by;
 
-pub use config::{build_tag_value, build_too_many_tag_value, match_tag_field_name, IndexConfig};
+/// Pruning tags manipulation.
+pub mod tag_pruning;
+
+pub use config::IndexConfig;
 pub use default_index_config::{
     DefaultIndexConfig, DefaultIndexConfigBuilder, DocParsingError, FieldMappingEntry, SortByConfig,
 };
@@ -39,13 +42,6 @@ pub use sort_by::{SortBy, SortOrder};
 
 /// Field name reserved for storing the source document.
 pub const SOURCE_FIELD_NAME: &str = "_source";
-
-/// Maximum distinct values allowed for a tag field within a split.
-pub const MAX_VALUES_PER_TAG_FIELD: usize = if cfg!(any(test, feature = "testsuite")) {
-    6
-} else {
-    1000
-};
 
 /// Returns a default `DefaultIndexConfig` for unit tests.
 #[cfg(any(test, feature = "testsuite"))]

--- a/quickwit-index-config/src/query_builder.rs
+++ b/quickwit-index-config/src/query_builder.rs
@@ -110,7 +110,6 @@ mod test {
             end_timestamp: None,
             max_hits: 20,
             start_offset: 0,
-            tags: vec![],
         };
 
         let default_field_names = vec!["title".to_string(), "desc".to_string()];

--- a/quickwit-index-config/src/tag_pruning.rs
+++ b/quickwit-index-config/src/tag_pruning.rs
@@ -1,0 +1,478 @@
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use std::collections::BTreeSet;
+use std::fmt::Display;
+
+use tantivy::query::QueryParserError as TantivyQueryParserError;
+use tantivy_query_grammar::{Occur, UserInputAst, UserInputLeaf, UserInputLiteral};
+
+use crate::QueryParserError;
+
+fn user_input_ast_to_tags_filter_ast(user_input_ast: UserInputAst) -> Option<TagFilterAst> {
+    let filters_ast = collect_tag_filters(user_input_ast);
+    let term_filters_ast = simplify_ast(filters_ast)?;
+    Some(expand_to_tag_ast(term_filters_ast))
+}
+
+/// Returns true if and only if tag is of form `{field_name}:any_value`.
+pub fn match_tag_field_name(field_name: &str, tag: &str) -> bool {
+    tag.len() > field_name.len()
+        && tag.as_bytes()[field_name.len()] == b':'
+        && tag.starts_with(field_name)
+}
+
+/// Tags a user query and returns a TagFilterAst that
+/// represents a filtering predicate over a set of tags.
+///
+/// If the predicate evaluates to false for a given set of tags
+/// associated with a split, we are guaranteed that no documents
+/// in the split matches the query.
+pub fn extract_tags_from_query(user_query: &str) -> Result<Option<TagFilterAst>, QueryParserError> {
+    let user_input_ast = tantivy_query_grammar::parse_query(user_query)
+        .map_err(|_| TantivyQueryParserError::SyntaxError)?;
+    Ok(user_input_ast_to_tags_filter_ast(user_input_ast))
+}
+
+/// Intermediary AST that may contain leaf that are
+/// equivalent to the "Uninformative" predicate.
+#[derive(Debug, PartialEq, Eq, Clone)]
+enum UnsimplifiedTagFilterAst {
+    And(Vec<UnsimplifiedTagFilterAst>),
+    Or(Vec<UnsimplifiedTagFilterAst>),
+    Tag {
+        is_present: bool,
+        field: String,
+        value: String,
+    },
+    /// Uninformative represents a node which could be
+    /// True or False regardless of the tag values.
+    ///
+    /// Any subnode of the `UserInputAST` can be
+    /// replaced by `Uninformative` while still being correct.
+    Uninformative,
+}
+
+/// Represents a tag filter used for split pruning.
+#[derive(Debug, PartialEq, Clone)]
+enum TermFiltersAST {
+    And(Vec<TermFiltersAST>),
+    Or(Vec<TermFiltersAST>),
+    Term {
+        is_present: bool,
+        field: String,
+        value: String,
+    },
+}
+
+/// Records terms into a set of tags.
+///
+/// If no terms are available for a given field, it is still
+/// beneficial to call this method with an empty array for values.
+///
+/// In that case, we will record a tag marking that the field has been
+/// processed, allowing for pruning of the split.
+pub fn append_to_tag_set(field: &str, values: &[String], tag_set: &mut BTreeSet<String>) {
+    tag_set.insert(field_tag(field));
+    for value in values {
+        tag_set.insert(term_tag(field, value));
+    }
+}
+
+/// Represents a predicate over the set of tags associated with a given split.
+#[allow(missing_docs)]
+#[derive(Debug, PartialEq, Clone)]
+pub enum TagFilterAst {
+    And(Vec<TagFilterAst>),
+    Or(Vec<TagFilterAst>),
+    Tag {
+        /// If set to false, the predicate tests for the absence of the tag.
+        is_present: bool,
+        tag: String,
+    },
+}
+
+impl Display for TagFilterAst {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let (is_or, children) = match self {
+            TagFilterAst::And(children) => (false, children),
+            TagFilterAst::Or(children) => (true, children),
+            TagFilterAst::Tag { is_present, tag } => {
+                if !is_present {
+                    write!(f, "¬")?;
+                }
+                write!(f, "{}", tag)?;
+                return Ok(());
+            }
+        };
+        if children.is_empty() {
+            return Ok(());
+        }
+        if children.len() == 1 {
+            write!(f, "{}", children[0])?;
+            return Ok(());
+        }
+        if is_or {
+            write!(f, "(")?;
+        }
+        let mut children_it = children.iter();
+        write!(f, "{}", children_it.next().unwrap())?;
+        for child in children_it {
+            if is_or {
+                write!(f, " ∨ {}", child)?;
+            } else {
+                write!(f, " ∧ {}", child)?;
+            }
+        }
+        if is_or {
+            write!(f, ")")?;
+        }
+        Ok(())
+    }
+}
+
+impl TagFilterAst {
+    /// Evaluates the tag filter predicate over a set of tags.
+    pub fn evaluate(&self, tag_set: &BTreeSet<String>) -> bool {
+        match self {
+            TagFilterAst::And(children) => {
+                children.iter().all(|child_ast| child_ast.evaluate(tag_set))
+            }
+            TagFilterAst::Or(children) => {
+                children.iter().any(|child_ast| child_ast.evaluate(tag_set))
+            }
+            TagFilterAst::Tag { is_present, tag } => tag_set.contains(tag) == *is_present,
+        }
+    }
+}
+
+// Takes a tag AST and simplify it in such a way that the resulting tree:
+// - represents a boolean expression that is equivalent to the original ast
+// - it can be equal to true, or to false, but if it is isn't True and False does not appear in the
+//   AST
+// - it does not contain any NOT clause.
+//
+// Returning None here, is to be interpreted as returning `True`.
+//
+// The latter two conditions are enforced by the type system.
+fn simplify_ast(ast: UnsimplifiedTagFilterAst) -> Option<TermFiltersAST> {
+    match ast {
+        UnsimplifiedTagFilterAst::And(conditions) => {
+            let mut pruned_conditions: Vec<TermFiltersAST> =
+                conditions.into_iter().filter_map(simplify_ast).collect();
+            match pruned_conditions.len() {
+                0 => None,
+                1 => pruned_conditions.pop().unwrap().into(),
+                _ => TermFiltersAST::And(pruned_conditions).into(),
+            }
+        }
+        UnsimplifiedTagFilterAst::Or(conditions) => {
+            let mut pruned_conditions: Vec<TermFiltersAST> = Vec::new();
+            for condition in conditions {
+                // If we get None as part of the condition here, we return None
+                // directly. (Remember None == True0.
+                pruned_conditions.push(simplify_ast(condition)?);
+            }
+            match pruned_conditions.len() {
+                0 => None,
+                1 => pruned_conditions.pop().unwrap().into(),
+                _ => TermFiltersAST::Or(pruned_conditions).into(),
+            }
+        }
+        UnsimplifiedTagFilterAst::Tag {
+            is_present,
+            field,
+            value,
+        } => TermFiltersAST::Term {
+            is_present,
+            field,
+            value,
+        }
+        .into(),
+        UnsimplifiedTagFilterAst::Uninformative => None,
+    }
+}
+
+fn field_tag(field: &str) -> String {
+    format!("{}!", field)
+}
+
+fn term_tag(field: &str, value: &str) -> String {
+    format!("{}:{}", field, value)
+}
+
+fn expand_to_tag_ast(terms_filter_ast: TermFiltersAST) -> TagFilterAst {
+    match terms_filter_ast {
+        TermFiltersAST::And(children) => {
+            TagFilterAst::And(children.into_iter().map(expand_to_tag_ast).collect())
+        }
+        TermFiltersAST::Or(children) => {
+            TagFilterAst::Or(children.into_iter().map(expand_to_tag_ast).collect())
+        }
+        TermFiltersAST::Term {
+            is_present,
+            field,
+            value,
+        } => {
+            let field_is_tag = TagFilterAst::Tag {
+                is_present: false,
+                tag: field_tag(&field),
+            };
+            let term_tag = TagFilterAst::Tag {
+                is_present,
+                tag: term_tag(&field, &value),
+            };
+            TagFilterAst::Or(vec![field_is_tag, term_tag])
+        }
+    }
+}
+
+fn collect_tag_filters_for_clause(
+    clause: Vec<(Occur, UnsimplifiedTagFilterAst)>,
+) -> UnsimplifiedTagFilterAst {
+    if clause.is_empty() {
+        return UnsimplifiedTagFilterAst::Uninformative;
+    }
+    if clause.iter().any(|(occur, _)| occur == &Occur::Must) {
+        let removed_should_clause: Vec<UnsimplifiedTagFilterAst> = clause
+            .into_iter()
+            .filter_map(|(occur, ast)| match occur {
+                Occur::Must => Some(ast),
+                Occur::MustNot => Some(negate_ast(ast)),
+                Occur::Should => None,
+            })
+            .collect();
+        // We will handle the case where removed_should_clause.len() == 1 in the simply
+        // phase.
+        return UnsimplifiedTagFilterAst::And(removed_should_clause);
+    }
+    let converted_not_clause = clause
+        .into_iter()
+        .map(|(occur, ast)| match occur {
+            Occur::MustNot => negate_ast(ast),
+            Occur::Should => ast,
+            Occur::Must => {
+                unreachable!("This should never happen due to check above.")
+            }
+        })
+        .collect();
+    UnsimplifiedTagFilterAst::Or(converted_not_clause)
+}
+
+/// Negate the unsimplified ast, pushing the negation to the leaf
+/// using De Morgan's law
+/// - NOT( A AND B )=> NOT(A) OR NOT(B)
+/// - NOT( A OR B )=> NOT(A) AND NOT(B)
+/// - NOT( Tag ) => NotTag
+/// - NOT( NotTag ) => Tag
+/// - NOT( Uninformative ) => Uninformative.
+fn negate_ast(clause: UnsimplifiedTagFilterAst) -> UnsimplifiedTagFilterAst {
+    match clause {
+        UnsimplifiedTagFilterAst::And(leaves) => {
+            UnsimplifiedTagFilterAst::Or(leaves.into_iter().map(negate_ast).collect())
+        }
+        UnsimplifiedTagFilterAst::Or(leaves) => {
+            UnsimplifiedTagFilterAst::And(leaves.into_iter().map(negate_ast).collect())
+        }
+        UnsimplifiedTagFilterAst::Tag {
+            is_present,
+            field,
+            value,
+        } => UnsimplifiedTagFilterAst::Tag {
+            is_present: !is_present,
+            field,
+            value,
+        },
+        UnsimplifiedTagFilterAst::Uninformative => UnsimplifiedTagFilterAst::Uninformative,
+    }
+}
+
+/// query implies this boolean formula.
+
+/// TermQuery on fields that are not tag fields are transformed into the predicate `Uninformative`.
+///
+///
+/// In other words, we are guaranteed that if we were to run the query
+/// described by this predicate only, the matched documents would all
+/// be in the original query too (The opposite is rarely true).
+fn collect_tag_filters(user_input_ast: UserInputAst) -> UnsimplifiedTagFilterAst {
+    match user_input_ast {
+        UserInputAst::Clause(sub_queries) => {
+            let clause_with_resolved_occur: Vec<(Occur, UnsimplifiedTagFilterAst)> = sub_queries
+                .into_iter()
+                .map(|(occur_opt, ast)| {
+                    (occur_opt.unwrap_or(Occur::Should), collect_tag_filters(ast))
+                })
+                .collect();
+            collect_tag_filters_for_clause(clause_with_resolved_occur)
+        }
+        UserInputAst::Boost(ast, _) => collect_tag_filters(*ast),
+        UserInputAst::Leaf(leaf) => match *leaf {
+            UserInputLeaf::Literal(UserInputLiteral {
+                field_name: Some(field_name),
+                phrase,
+            }) => UnsimplifiedTagFilterAst::Tag {
+                is_present: true,
+                field: field_name,
+                value: phrase,
+            },
+            UserInputLeaf::Literal(UserInputLiteral {
+                field_name: None, ..
+            })
+            | UserInputLeaf::All
+            | UserInputLeaf::Range { .. } => UnsimplifiedTagFilterAst::Uninformative,
+        },
+    }
+}
+
+/// Helper to build a TagFilterAst checking for the presence of a tag
+pub fn tag(tag: impl ToString) -> TagFilterAst {
+    TagFilterAst::Tag {
+        is_present: true,
+        tag: tag.to_string(),
+    }
+}
+
+/// Helper to build a TagFilterAst checking for the absence of a tag
+pub fn no_tag(tag: impl ToString) -> TagFilterAst {
+    TagFilterAst::Tag {
+        is_present: false,
+        tag: tag.to_string(),
+    }
+}
+#[cfg(test)]
+mod test {
+    use super::extract_tags_from_query;
+
+    #[test]
+    fn test_extract_tags_from_query_invalid_query() -> anyhow::Result<()> {
+        assert!(matches!(extract_tags_from_query(":>"), Err(..)));
+        Ok(())
+    }
+
+    #[test]
+    fn test_extract_tags_from_query_all() -> anyhow::Result<()> {
+        assert_eq!(extract_tags_from_query("*")?, None);
+        Ok(())
+    }
+
+    #[test]
+    fn test_extract_tags_from_query_range_query() -> anyhow::Result<()> {
+        assert_eq!(extract_tags_from_query("title:>foo lang:fr")?, None);
+        Ok(())
+    }
+
+    #[test]
+    fn test_extract_tags_from_query_range_query_conjunction() -> anyhow::Result<()> {
+        assert_eq!(
+            &extract_tags_from_query("title:>foo AND lang:fr")?
+                .unwrap()
+                .to_string(),
+            "(¬lang! ∨ lang:fr)"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_extract_tags_from_query_mixed_disjunction() -> anyhow::Result<()> {
+        assert_eq!(
+            &extract_tags_from_query("title:foo user:bart lang:fr")?
+                .unwrap()
+                .to_string(),
+            "((¬title! ∨ title:foo) ∨ (¬user! ∨ user:bart) ∨ (¬lang! ∨ lang:fr))"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_extract_tags_from_query_and_or() -> anyhow::Result<()> {
+        assert_eq!(
+            extract_tags_from_query("title:foo AND (user:bart OR lang:fr)")?
+                .unwrap()
+                .to_string(),
+            "(¬title! ∨ title:foo) ∧ ((¬user! ∨ user:bart) ∨ (¬lang! ∨ lang:fr))"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_conjunction_of_tags() -> anyhow::Result<()> {
+        assert_eq!(
+            &extract_tags_from_query("(user:bart AND lang:fr)")?
+                .unwrap()
+                .to_string(),
+            "(¬user! ∨ user:bart) ∧ (¬lang! ∨ lang:fr)"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_disjunction_of_tags() -> anyhow::Result<()> {
+        assert_eq!(
+            &extract_tags_from_query("(user:bart OR lang:fr)")?
+                .unwrap()
+                .to_string(),
+            "((¬user! ∨ user:bart) ∨ (¬lang! ∨ lang:fr))"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_disjunction_of_tag_disjunction_with_not_clause() -> anyhow::Result<()> {
+        assert_eq!(
+            extract_tags_from_query("(user:bart -lang:fr)")?
+                .unwrap()
+                .to_string(),
+            "((¬user! ∨ user:bart) ∨ (¬lang! ∨ ¬lang:fr))"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_disjunction_of_tag_conjunction_with_not_clause() -> anyhow::Result<()> {
+        assert_eq!(
+            &extract_tags_from_query("user:bart AND NOT lang:fr")?
+                .unwrap()
+                .to_string(),
+            "(¬user! ∨ user:bart) ∧ (¬lang! ∨ ¬lang:fr)"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_disjunction_of_tag_must_should() -> anyhow::Result<()> {
+        assert_eq!(
+            &extract_tags_from_query("(+user:bart lang:fr)")?
+                .unwrap()
+                .to_string(),
+            "(¬user! ∨ user:bart)"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_match_tag_field_name() {
+        assert!(super::match_tag_field_name("tagfield", "tagfield:val"));
+        assert!(super::match_tag_field_name("tagfield", "tagfield:"));
+        assert!(!super::match_tag_field_name("tagfield", "tagfield"));
+        assert!(!super::match_tag_field_name("tagfield", "tag:val"));
+        assert!(!super::match_tag_field_name("tagfield", "tagfiele:val"));
+        assert!(!super::match_tag_field_name("tagfield", "t:val"));
+    }
+}

--- a/quickwit-index-config/src/tag_pruning.rs
+++ b/quickwit-index-config/src/tag_pruning.rs
@@ -254,7 +254,7 @@ fn collect_tag_filters_for_clause(
                 Occur::Should => None,
             })
             .collect();
-        // We will handle the case where removed_should_clause.len() == 1 in the simply
+        // We will handle the case where removed_should_clause.len() == 1 in the simplify
         // phase.
         return UnsimplifiedTagFilterAst::And(removed_should_clause);
     }
@@ -337,7 +337,7 @@ fn collect_tag_filters(user_input_ast: UserInputAst) -> UnsimplifiedTagFilterAst
     }
 }
 
-/// Helper to build a TagFilterAst checking for the presence of a tag
+/// Helper to build a TagFilterAst checking for the presence of a tag.
 pub fn tag(tag: impl ToString) -> TagFilterAst {
     TagFilterAst::Tag {
         is_present: true,
@@ -345,7 +345,7 @@ pub fn tag(tag: impl ToString) -> TagFilterAst {
     }
 }
 
-/// Helper to build a TagFilterAst checking for the absence of a tag
+/// Helper to build a TagFilterAst checking for the absence of a tag.
 pub fn no_tag(tag: impl ToString) -> TagFilterAst {
     TagFilterAst::Tag {
         is_present: false,

--- a/quickwit-indexing/src/actors/indexing_pipeline.rs
+++ b/quickwit-indexing/src/actors/indexing_pipeline.rs
@@ -236,7 +236,7 @@ impl IndexingPipeline {
         let published_splits = self
             .params
             .metastore
-            .list_splits(&self.params.index_id, SplitState::Published, None, &[])
+            .list_splits(&self.params.index_id, SplitState::Published, None, None)
             .await?
             .into_iter()
             .map(|split| split.split_metadata)

--- a/quickwit-indexing/src/actors/packager.rs
+++ b/quickwit-indexing/src/actors/packager.rs
@@ -275,7 +275,7 @@ fn create_packaged_split(
             .map(|segment| segment.inverted_index(named_field.field))
             .collect::<Result<Vec<_>, _>>()?;
 
-        match try_extract_terms(&named_field, &inverted_indexes, MAX_VALUES_PER_TAG_FIELD) {
+        match try_extract_terms(named_field, &inverted_indexes, MAX_VALUES_PER_TAG_FIELD) {
             Ok(terms) => {
                 append_to_tag_set(&named_field.name, &terms, &mut tags);
             }

--- a/quickwit-indexing/src/garbage_collection.rs
+++ b/quickwit-indexing/src/garbage_collection.rs
@@ -85,7 +85,7 @@ pub async fn run_garbage_collect(
     let grace_period_timestamp = Utc::now().timestamp() - staged_grace_period.as_secs() as i64;
 
     let deletable_staged_splits: Vec<SplitMetadata> = metastore
-        .list_splits(index_id, SplitState::Staged, None, &[])
+        .list_splits(index_id, SplitState::Staged, None, None)
         .await?
         .into_iter()
         // TODO: Update metastore API and push this filter down.
@@ -98,7 +98,7 @@ pub async fn run_garbage_collect(
 
     if dry_run {
         let mut scheduled_for_delete_splits = metastore
-            .list_splits(index_id, SplitState::ScheduledForDeletion, None, &[])
+            .list_splits(index_id, SplitState::ScheduledForDeletion, None, None)
             .await?
             .into_iter()
             .map(|meta| meta.split_metadata)
@@ -124,7 +124,7 @@ pub async fn run_garbage_collect(
     // We wait another 2 minutes until the split is actually deleted.
     let grace_period_deletion = Utc::now().timestamp() - deletion_grace_period.as_secs() as i64;
     let splits_to_delete = metastore
-        .list_splits(index_id, SplitState::ScheduledForDeletion, None, &[])
+        .list_splits(index_id, SplitState::ScheduledForDeletion, None, None)
         .await?
         .into_iter()
         // TODO: Update metastore API and push this filter down.

--- a/quickwit-indexing/src/merge_policy.rs
+++ b/quickwit-indexing/src/merge_policy.rs
@@ -22,7 +22,7 @@ use std::fmt;
 use std::ops::Range;
 
 use itertools::Itertools;
-use quickwit_index_config::match_tag_field_name;
+use quickwit_index_config::tag_pruning::match_tag_field_name;
 use quickwit_metastore::SplitMetadata;
 use tracing::debug;
 

--- a/quickwit-metastore/src/metastore/mod.rs
+++ b/quickwit-metastore/src/metastore/mod.rs
@@ -30,6 +30,7 @@ use chrono::Utc;
 use quickwit_config::{
     DocMapping, IndexingResources, IndexingSettings, SearchSettings, SourceConfig,
 };
+use quickwit_index_config::tag_pruning::TagFilterAst;
 use quickwit_index_config::{
     DefaultIndexConfig as DefaultDocMapper, DefaultIndexConfigBuilder as DocMapperBuilder,
     IndexConfig as DocMapper, SortBy, SortByConfig, SortOrder,
@@ -412,7 +413,7 @@ pub trait Metastore: Send + Sync + 'static {
         index_id: &str,
         split_state: SplitState,
         time_range: Option<Range<i64>>,
-        tags: &[Vec<String>],
+        tags: Option<TagFilterAst>,
     ) -> MetastoreResult<Vec<Split>>;
 
     /// Lists the splits without filtering.
@@ -439,56 +440,4 @@ pub trait Metastore: Send + Sync + 'static {
 
     /// Returns the Metastore uri.
     fn uri(&self) -> String;
-}
-
-/// Finds out if a split matches a tag filter expression.
-///
-/// `filter_tags` is an array of array of tags representing a boolean expression
-/// of the form `[ [A OR B OR...] AND [C OR D OR ...] AND ...]`
-/// Returns true if filter_tags is empty, or if the split's tags match
-/// the filter_tags expression.
-pub fn match_tags_filter(split_tags: &[String], filter_tags: &[Vec<String>]) -> bool {
-    if filter_tags.is_empty() {
-        return true;
-    }
-
-    for or_tags in filter_tags {
-        let is_match = or_tags
-            .iter()
-            .map(|tag| split_tags.contains(tag))
-            .any(|contains| contains);
-        if !is_match {
-            return false;
-        }
-    }
-    true
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_match_tags_filter() {
-        assert!(match_tags_filter(&["foo".to_string()], &[]));
-        assert!(!match_tags_filter(&[], &[vec!["foo".to_string()]]));
-
-        assert!(match_tags_filter(
-            &["foo:bar".to_string()],
-            &[vec!["foo:bar".to_string()]]
-        ));
-        assert!(match_tags_filter(
-            &["foo:*".to_string()],
-            &[vec!["foo:bar".to_string(), "foo:*".to_string()]]
-        ));
-
-        assert!(!match_tags_filter(
-            &["foo".to_string()],
-            &[vec!["foo".to_string()], vec!["bar".to_string()]]
-        ));
-        assert!(match_tags_filter(
-            &["foo".to_string(), "bar".to_string()],
-            &[vec!["foo".to_string()], vec!["bar".to_string()]]
-        ));
-    }
 }

--- a/quickwit-metastore/src/metastore/single_file_metastore/mod.rs
+++ b/quickwit-metastore/src/metastore/single_file_metastore/mod.rs
@@ -26,6 +26,7 @@ use std::ops::Range;
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use quickwit_index_config::tag_pruning::TagFilterAst;
 use quickwit_storage::Storage;
 use tokio::sync::{Mutex, OwnedMutexGuard, RwLock};
 
@@ -299,7 +300,7 @@ impl Metastore for SingleFileMetastore {
         index_id: &str,
         state: SplitState,
         time_range_opt: Option<Range<i64>>,
-        tags: &[Vec<String>],
+        tags: Option<TagFilterAst>,
     ) -> MetastoreResult<Vec<Split>> {
         self.read(index_id, |metadata_set| {
             metadata_set.list_splits(state, time_range_opt, tags)
@@ -483,14 +484,14 @@ mod tests {
 
         // empty
         let split = metastore
-            .list_splits(index_id, SplitState::Published, None, &[])
+            .list_splits(index_id, SplitState::Published, None, None)
             .await
             .unwrap();
         assert!(split.is_empty());
 
         // not empty
         let split = metastore
-            .list_splits(index_id, SplitState::Staged, None, &[])
+            .list_splits(index_id, SplitState::Staged, None, None)
             .await
             .unwrap();
         assert!(!split.is_empty());
@@ -568,7 +569,7 @@ mod tests {
         futures::future::try_join_all(handles).await.unwrap();
 
         let splits = metastore
-            .list_splits(index_id, SplitState::Published, None, &[])
+            .list_splits(index_id, SplitState::Published, None, None)
             .await
             .unwrap();
 

--- a/quickwit-metastore/src/tests.rs
+++ b/quickwit-metastore/src/tests.rs
@@ -24,6 +24,7 @@ pub mod test_suite {
 
     use async_trait::async_trait;
     use chrono::Utc;
+    use quickwit_index_config::tag_pruning::{tag, TagFilterAst};
     use tokio::time::{sleep, Duration};
 
     use crate::checkpoint::CheckpointDelta;
@@ -1097,7 +1098,7 @@ pub mod test_suite {
         // List all splits on a non-existent index
         {
             let result = metastore
-                .list_splits("non-existent-index", SplitState::Staged, None, &[])
+                .list_splits("non-existent-index", SplitState::Staged, None, None)
                 .await
                 .unwrap_err();
             assert!(matches!(result, MetastoreError::IndexDoesNotExist { .. }));
@@ -1140,7 +1141,7 @@ pub mod test_suite {
                 end: 99i64,
             });
             let splits = metastore
-                .list_splits(index_id, SplitState::Staged, time_range_opt, &[])
+                .list_splits(index_id, SplitState::Staged, time_range_opt, None)
                 .await
                 .unwrap();
             let split_ids: HashSet<String> = splits
@@ -1158,7 +1159,7 @@ pub mod test_suite {
                 end: i64::MAX,
             });
             let splits = metastore
-                .list_splits(index_id, SplitState::Staged, time_range_opt, &[])
+                .list_splits(index_id, SplitState::Staged, time_range_opt, None)
                 .await
                 .unwrap();
             let split_ids: HashSet<String> = splits
@@ -1176,7 +1177,7 @@ pub mod test_suite {
                 end: 200,
             });
             let splits = metastore
-                .list_splits(index_id, SplitState::Staged, time_range_opt, &[])
+                .list_splits(index_id, SplitState::Staged, time_range_opt, None)
                 .await
                 .unwrap();
             let split_ids: HashSet<String> = splits
@@ -1191,7 +1192,7 @@ pub mod test_suite {
 
             let range = Some(Range { start: 0, end: 100 });
             let splits = metastore
-                .list_splits(index_id, SplitState::Staged, range, &[])
+                .list_splits(index_id, SplitState::Staged, range, None)
                 .await
                 .unwrap();
             let split_ids: HashSet<String> = splits
@@ -1206,7 +1207,7 @@ pub mod test_suite {
 
             let range = Some(Range { start: 0, end: 101 });
             let splits = metastore
-                .list_splits(index_id, SplitState::Staged, range, &[])
+                .list_splits(index_id, SplitState::Staged, range, None)
                 .await
                 .unwrap();
             let split_ids: HashSet<String> = splits
@@ -1221,7 +1222,7 @@ pub mod test_suite {
 
             let range = Some(Range { start: 0, end: 199 });
             let splits = metastore
-                .list_splits(index_id, SplitState::Staged, range, &[])
+                .list_splits(index_id, SplitState::Staged, range, None)
                 .await
                 .unwrap();
             let split_ids: HashSet<String> = splits
@@ -1236,7 +1237,7 @@ pub mod test_suite {
 
             let range = Some(Range { start: 0, end: 200 });
             let splits = metastore
-                .list_splits(index_id, SplitState::Staged, range, &[])
+                .list_splits(index_id, SplitState::Staged, range, None)
                 .await
                 .unwrap();
             let split_ids: HashSet<String> = splits
@@ -1251,7 +1252,7 @@ pub mod test_suite {
 
             let range = Some(Range { start: 0, end: 201 });
             let splits = metastore
-                .list_splits(index_id, SplitState::Staged, range, &[])
+                .list_splits(index_id, SplitState::Staged, range, None)
                 .await
                 .unwrap();
             let split_ids: HashSet<String> = splits
@@ -1266,7 +1267,7 @@ pub mod test_suite {
 
             let range = Some(Range { start: 0, end: 299 });
             let splits = metastore
-                .list_splits(index_id, SplitState::Staged, range, &[])
+                .list_splits(index_id, SplitState::Staged, range, None)
                 .await
                 .unwrap();
             let split_ids: HashSet<String> = splits
@@ -1281,7 +1282,7 @@ pub mod test_suite {
 
             let range = Some(Range { start: 0, end: 300 });
             let splits = metastore
-                .list_splits(index_id, SplitState::Staged, range, &[])
+                .list_splits(index_id, SplitState::Staged, range, None)
                 .await
                 .unwrap();
             let split_ids: HashSet<String> = splits
@@ -1296,7 +1297,7 @@ pub mod test_suite {
 
             let range = Some(Range { start: 0, end: 301 });
             let splits = metastore
-                .list_splits(index_id, SplitState::Staged, range, &[])
+                .list_splits(index_id, SplitState::Staged, range, None)
                 .await
                 .unwrap();
             let split_ids: HashSet<String> = splits
@@ -1314,7 +1315,7 @@ pub mod test_suite {
                 end: 400,
             });
             let splits = metastore
-                .list_splits(index_id, SplitState::Staged, range, &[])
+                .list_splits(index_id, SplitState::Staged, range, None)
                 .await
                 .unwrap();
             let split_ids: HashSet<String> = splits
@@ -1332,7 +1333,7 @@ pub mod test_suite {
                 end: 400,
             });
             let splits = metastore
-                .list_splits(index_id, SplitState::Staged, range, &[])
+                .list_splits(index_id, SplitState::Staged, range, None)
                 .await
                 .unwrap();
             let split_ids: HashSet<String> = splits
@@ -1350,7 +1351,7 @@ pub mod test_suite {
                 end: 400,
             });
             let splits = metastore
-                .list_splits(index_id, SplitState::Staged, range, &[])
+                .list_splits(index_id, SplitState::Staged, range, None)
                 .await
                 .unwrap();
             let split_ids: HashSet<String> = splits
@@ -1368,7 +1369,7 @@ pub mod test_suite {
                 end: 400,
             });
             let splits = metastore
-                .list_splits(index_id, SplitState::Staged, range, &[])
+                .list_splits(index_id, SplitState::Staged, range, None)
                 .await
                 .unwrap();
             let split_ids: HashSet<String> = splits
@@ -1386,7 +1387,7 @@ pub mod test_suite {
                 end: 400,
             });
             let splits = metastore
-                .list_splits(index_id, SplitState::Staged, range, &[])
+                .list_splits(index_id, SplitState::Staged, range, None)
                 .await
                 .unwrap();
             let split_ids: HashSet<String> = splits
@@ -1404,7 +1405,7 @@ pub mod test_suite {
                 end: 400,
             });
             let splits = metastore
-                .list_splits(index_id, SplitState::Staged, range, &[])
+                .list_splits(index_id, SplitState::Staged, range, None)
                 .await
                 .unwrap();
             let split_ids: HashSet<String> = splits
@@ -1422,7 +1423,7 @@ pub mod test_suite {
                 end: 400,
             });
             let splits = metastore
-                .list_splits(index_id, SplitState::Staged, range, &[])
+                .list_splits(index_id, SplitState::Staged, range, None)
                 .await
                 .unwrap();
             let split_ids: HashSet<String> = splits
@@ -1440,7 +1441,7 @@ pub mod test_suite {
                 end: 400,
             });
             let splits = metastore
-                .list_splits(index_id, SplitState::Staged, range, &[])
+                .list_splits(index_id, SplitState::Staged, range, None)
                 .await
                 .unwrap();
             let split_ids: HashSet<String> = splits
@@ -1458,7 +1459,7 @@ pub mod test_suite {
                 end: 400,
             });
             let splits = metastore
-                .list_splits(index_id, SplitState::Staged, range, &[])
+                .list_splits(index_id, SplitState::Staged, range, None)
                 .await
                 .unwrap();
             let split_ids: HashSet<String> = splits
@@ -1476,7 +1477,7 @@ pub mod test_suite {
                 end: 400,
             });
             let splits = metastore
-                .list_splits(index_id, SplitState::Staged, range, &[])
+                .list_splits(index_id, SplitState::Staged, range, None)
                 .await
                 .unwrap();
             let split_ids: HashSet<String> = splits
@@ -1494,7 +1495,7 @@ pub mod test_suite {
                 end: 1100,
             });
             let splits = metastore
-                .list_splits(index_id, SplitState::Staged, range, &[])
+                .list_splits(index_id, SplitState::Staged, range, None)
                 .await
                 .unwrap();
             let split_ids: HashSet<String> = splits
@@ -1525,7 +1526,7 @@ pub mod test_suite {
 
             let range = None;
             let splits = metastore
-                .list_splits(index_id, SplitState::Staged, range, &[])
+                .list_splits(index_id, SplitState::Staged, range, None)
                 .await
                 .unwrap();
             let split_ids: HashSet<String> = splits
@@ -1540,9 +1541,9 @@ pub mod test_suite {
             assert_eq!(split_ids.contains("list-splits-six"), true);
 
             let range = None;
-            let tags = vec![vec!["bar".to_string(), "baz".to_string()]];
+            let tag_filter_ast = TagFilterAst::And(vec![tag("bar:"), tag("baz:baz")]);
             let splits = metastore
-                .list_splits(index_id, SplitState::Staged, range, &tags)
+                .list_splits(index_id, SplitState::Staged, range, Some(tag_filter_ast))
                 .await
                 .unwrap();
             let split_ids: HashSet<String> = splits

--- a/quickwit-proto/proto/search_api.proto
+++ b/quickwit-proto/proto/search_api.proto
@@ -73,8 +73,8 @@ message SearchRequest {
   // The results with rank [start_offset..start_offset + max_hits) are returned.
   uint64 start_offset = 7;
 
-  // Split tag filter
-  repeated string tags = 8;
+  // deprecated tag field
+  reserved 8;
 }
 
 message SearchResponse {
@@ -111,7 +111,7 @@ message LeafSearchRequest {
   // This ids are resolved from the index_uri defined in the search_request.
   repeated SplitIdAndFooterOffsets split_metadata = 4;
 
-  // `IndexConfig` as json serialized trait. 
+  // `IndexConfig` as json serialized trait.
   string index_config = 5;
 
   // Index URI. The index URI defines the location of the storage that contains the
@@ -234,8 +234,7 @@ message SearchStreamRequest {
   // The output format
   OutputFormat output_format = 7;
 
-  // Split tag filter
-  repeated string tags = 8;
+  reserved 8; // deprecated field: tags
 
   // The field by which we want to partition
   optional string partition_by_field = 9;
@@ -250,7 +249,7 @@ message LeafSearchStreamRequest {
   // This ids are resolved from the index_uri defined in the stream request.
   repeated SplitIdAndFooterOffsets split_metadata = 2;
 
-  // `IndexConfig` as json serialized trait. 
+  // `IndexConfig` as json serialized trait.
   string index_config = 5;
 
   // Index URI. The index URI defines the location of the storage that contains the

--- a/quickwit-proto/src/lib.rs
+++ b/quickwit-proto/src/lib.rs
@@ -36,7 +36,6 @@ impl From<SearchStreamRequest> for SearchRequest {
             end_timestamp: item.end_timestamp,
             max_hits: 0,
             start_offset: 0,
-            tags: item.tags,
         }
     }
 }

--- a/quickwit-proto/src/quickwit.rs
+++ b/quickwit-proto/src/quickwit.rs
@@ -28,9 +28,6 @@ pub struct SearchRequest {
     /// The results with rank [start_offset..start_offset + max_hits) are returned.
     #[prost(uint64, tag = "7")]
     pub start_offset: u64,
-    /// Split tag filter
-    #[prost(string, repeated, tag = "8")]
-    pub tags: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -210,9 +207,6 @@ pub struct SearchStreamRequest {
     /// The output format
     #[prost(enumeration = "OutputFormat", tag = "7")]
     pub output_format: i32,
-    /// Split tag filter
-    #[prost(string, repeated, tag = "8")]
-    pub tags: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     /// The field by which we want to partition
     #[prost(string, optional, tag = "9")]
     pub partition_by_field: ::core::option::Option<::prost::alloc::string::String>,

--- a/quickwit-search/src/cluster_client.rs
+++ b/quickwit-search/src/cluster_client.rs
@@ -227,7 +227,6 @@ mod tests {
             end_timestamp: None,
             max_hits: 10,
             start_offset: 0,
-            tags: vec![],
         };
         LeafSearchRequest {
             search_request: Some(search_request),
@@ -258,7 +257,6 @@ mod tests {
             fast_field: "fast".to_string(),
             output_format: 0,
             partition_by_field: None,
-            tags: vec![],
         };
         LeafSearchStreamRequest {
             request: Some(search_request),

--- a/quickwit-search/src/lib.rs
+++ b/quickwit-search/src/lib.rs
@@ -45,7 +45,8 @@ use std::net::SocketAddr;
 use std::ops::Range;
 
 use anyhow::Context;
-use quickwit_metastore::{Metastore, MetastoreResult, SplitMetadata, SplitState};
+use quickwit_index_config::tag_pruning::extract_tags_from_query;
+use quickwit_metastore::{Metastore, SplitMetadata, SplitState};
 use quickwit_proto::{PartialHit, SearchRequest, SearchResponse, SplitIdAndFooterOffsets};
 use quickwit_storage::StorageUriResolver;
 use tantivy::DocAddress;
@@ -107,8 +108,11 @@ fn partial_hit_sorting_key(partial_hit: &PartialHit) -> (Reverse<u64>, GlobalDoc
     )
 }
 
-fn extract_time_range(search_request: &SearchRequest) -> Option<Range<i64>> {
-    match (search_request.start_timestamp, search_request.end_timestamp) {
+fn extract_time_range(
+    start_timestamp_opt: Option<i64>,
+    end_timestamp_opt: Option<i64>,
+) -> Option<Range<i64>> {
+    match (start_timestamp_opt, end_timestamp_opt) {
         (Some(start_timestamp), Some(end_timestamp)) => Some(Range {
             start: start_timestamp,
             end: end_timestamp,
@@ -137,20 +141,17 @@ fn extract_split_and_footer_offsets(split_metadata: &SplitMetadata) -> SplitIdAn
 async fn list_relevant_splits(
     search_request: &SearchRequest,
     metastore: &dyn Metastore,
-) -> MetastoreResult<Vec<SplitMetadata>> {
-    let time_range_opt = extract_time_range(search_request);
+) -> crate::Result<Vec<SplitMetadata>> {
+    let time_range_opt =
+        extract_time_range(search_request.start_timestamp, search_request.end_timestamp);
     // TODO: will be removed after #issues/823 is solved
-    let tags_filter = if search_request.tags.is_empty() {
-        vec![]
-    } else {
-        vec![search_request.tags.clone()]
-    };
+    let tags_filter = extract_tags_from_query(&search_request.query)?;
     let split_metas = metastore
         .list_splits(
             &search_request.index_id,
             SplitState::Published,
             time_range_opt,
-            &tags_filter,
+            tags_filter,
         )
         .await?;
     Ok(split_metas
@@ -201,6 +202,7 @@ pub async fn single_node_search(
 
 #[cfg(test)]
 mod tests {
+
     use assert_json_diff::assert_json_include;
     use quickwit_indexing::TestSandbox;
     use serde_json::json;
@@ -233,7 +235,6 @@ mod tests {
             end_timestamp: None,
             max_hits: 2,
             start_offset: 0,
-            tags: vec![],
         };
         let single_node_result = single_node_search(
             &search_request,
@@ -273,6 +274,8 @@ mod tests {
     async fn test_single_node_several_splits() -> anyhow::Result<()> {
         let index_id = "single-node-several-splits";
         let doc_mapping_yaml = r#"
+            tag_fields:
+              - "owner"
             field_mappings:
               - name: title
                 type: text
@@ -296,7 +299,6 @@ mod tests {
             end_timestamp: None,
             max_hits: 6,
             start_offset: 0,
-            tags: vec![],
         };
         let single_node_result = single_node_search(
             &search_request,
@@ -360,7 +362,6 @@ mod tests {
             end_timestamp: Some(20),
             max_hits: 15,
             start_offset: 0,
-            tags: vec![],
         };
         let single_node_response = single_node_search(
             &search_request,
@@ -382,7 +383,6 @@ mod tests {
             end_timestamp: Some(20),
             max_hits: 25,
             start_offset: 0,
-            tags: vec![],
         };
         let single_node_response = single_node_search(
             &search_request,
@@ -404,7 +404,6 @@ mod tests {
             end_timestamp: None,
             max_hits: 25,
             start_offset: 0,
-            tags: vec!["foo".to_string()],
         };
         let single_node_response = single_node_search(
             &search_request,
@@ -414,6 +413,70 @@ mod tests {
         .await?;
         assert_eq!(single_node_response.num_hits, 0);
         assert_eq!(single_node_response.hits.len(), 0);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_single_node_split_pruning_by_tags() -> anyhow::Result<()> {
+        let doc_mapping_yaml = r#"
+            field_mappings:
+              - name: owner
+                type: text
+        "#;
+        let index_id = "single-node-pruning-by-tags";
+        let test_sandbox = TestSandbox::create(index_id, doc_mapping_yaml, "{}", &[]).await?;
+        let owners = ["paul", "adrien"];
+        for owner in owners {
+            let mut docs = vec![];
+            for i in 0..10 {
+                docs.push(json!({"body": format!("content num #{}", i + 1), "owner": owner}));
+            }
+            test_sandbox.add_documents(docs).await?;
+        }
+
+        let selected_splits = list_relevant_splits(
+            &SearchRequest {
+                index_id: index_id.to_string(),
+                query: "owner:francois".to_string(),
+                ..Default::default()
+            },
+            &*test_sandbox.metastore(),
+        )
+        .await?;
+        assert_eq!(selected_splits.len(), 0);
+
+        let selected_splits = list_relevant_splits(
+            &SearchRequest {
+                index_id: index_id.to_string(),
+                query: "".to_string(),
+                ..Default::default()
+            },
+            &*test_sandbox.metastore(),
+        )
+        .await?;
+        assert_eq!(selected_splits.len(), 2);
+
+        let selected_splits = list_relevant_splits(
+            &SearchRequest {
+                index_id: index_id.to_string(),
+                query: "owner:francois AND owner:paul AND owner:adrien".to_string(),
+                ..Default::default()
+            },
+            &*test_sandbox.metastore(),
+        )
+        .await?;
+        assert_eq!(selected_splits.len(), 2);
+
+        let mut split_tags = selected_splits
+            .iter()
+            .flat_map(|split| split.tags.clone())
+            .collect::<Vec<_>>();
+        split_tags.sort();
+        assert_eq!(
+            split_tags,
+            vec!["owner:adrien".to_string(), "owner:paul".to_string()]
+        );
 
         Ok(())
     }

--- a/quickwit-search/src/retry/search.rs
+++ b/quickwit-search/src/retry/search.rs
@@ -74,7 +74,6 @@ mod tests {
                 end_timestamp: None,
                 max_hits: 10,
                 start_offset: 0,
-                tags: vec![],
             }),
             index_config: "index_config".to_string(),
             index_uri: "uri".to_string(),

--- a/quickwit-search/src/retry/search_stream.rs
+++ b/quickwit-search/src/retry/search_stream.rs
@@ -84,7 +84,6 @@ mod tests {
                 end_timestamp: None,
                 max_hits: 10,
                 start_offset: 0,
-                tags: vec![],
             }),
             index_config: "index_config".to_string(),
             index_uri: "uri".to_string(),

--- a/quickwit-search/src/root.rs
+++ b/quickwit-search/src/root.rs
@@ -291,7 +291,6 @@ mod tests {
             end_timestamp: None,
             max_hits: 10,
             start_offset: 0,
-            tags: vec![],
         };
         let mut metastore = MockMetastore::new();
         metastore
@@ -303,10 +302,9 @@ mod tests {
                 ))
             });
         metastore.expect_list_splits().returning(
-            |_index_id: &str,
-             _split_state: SplitState,
-             _time_range: Option<Range<i64>>,
-             _tags: &[Vec<String>]| { Ok(vec![mock_split("split1")]) },
+            |_index_id: &str, _split_state: SplitState, _time_range: Option<Range<i64>>, _tags| {
+                Ok(vec![mock_split("split1")])
+            },
         );
         let mut mock_search_service = MockSearchService::new();
         mock_search_service.expect_leaf_search().returning(
@@ -350,7 +348,6 @@ mod tests {
             end_timestamp: None,
             max_hits: 10,
             start_offset: 0,
-            tags: vec![],
         };
         let mut metastore = MockMetastore::new();
         metastore
@@ -362,10 +359,7 @@ mod tests {
                 ))
             });
         metastore.expect_list_splits().returning(
-            |_index_id: &str,
-             _split_state: SplitState,
-             _time_range: Option<Range<i64>>,
-             _tags: &[Vec<String>]| {
+            |_index_id: &str, _split_state: SplitState, _time_range: Option<Range<i64>>, _tags| {
                 Ok(vec![mock_split("split1"), mock_split("split2")])
             },
         );
@@ -433,7 +427,6 @@ mod tests {
             end_timestamp: None,
             max_hits: 10,
             start_offset: 0,
-            tags: vec![],
         };
         let mut metastore = MockMetastore::new();
         metastore
@@ -445,10 +438,7 @@ mod tests {
                 ))
             });
         metastore.expect_list_splits().returning(
-            |_index_id: &str,
-             _split_state: SplitState,
-             _time_range: Option<Range<i64>>,
-             _tags: &[Vec<String>]| {
+            |_index_id: &str, _split_state: SplitState, _time_range: Option<Range<i64>>, _tags| {
                 Ok(vec![mock_split("split1"), mock_split("split2")])
             },
         );
@@ -542,7 +532,6 @@ mod tests {
             end_timestamp: None,
             max_hits: 10,
             start_offset: 0,
-            tags: vec![],
         };
         let mut metastore = MockMetastore::new();
         metastore
@@ -554,10 +543,7 @@ mod tests {
                 ))
             });
         metastore.expect_list_splits().returning(
-            |_index_id: &str,
-             _split_state: SplitState,
-             _time_range: Option<Range<i64>>,
-             _tags: &[Vec<String>]| {
+            |_index_id: &str, _split_state: SplitState, _time_range: Option<Range<i64>>, _tags| {
                 Ok(vec![mock_split("split1"), mock_split("split2")])
             },
         );
@@ -667,7 +653,6 @@ mod tests {
             end_timestamp: None,
             max_hits: 10,
             start_offset: 0,
-            tags: vec![],
         };
         let mut metastore = MockMetastore::new();
         metastore
@@ -679,10 +664,9 @@ mod tests {
                 ))
             });
         metastore.expect_list_splits().returning(
-            |_index_id: &str,
-             _split_state: SplitState,
-             _time_range: Option<Range<i64>>,
-             _tags: &[Vec<String>]| { Ok(vec![mock_split("split1")]) },
+            |_index_id: &str, _split_state: SplitState, _time_range: Option<Range<i64>>, _tags| {
+                Ok(vec![mock_split("split1")])
+            },
         );
         let mut first_call = true;
         let mut mock_search_service1 = MockSearchService::new();
@@ -739,7 +723,6 @@ mod tests {
             end_timestamp: None,
             max_hits: 10,
             start_offset: 0,
-            tags: vec![],
         };
         let mut metastore = MockMetastore::new();
         metastore
@@ -751,10 +734,9 @@ mod tests {
                 ))
             });
         metastore.expect_list_splits().returning(
-            |_index_id: &str,
-             _split_state: SplitState,
-             _time_range: Option<Range<i64>>,
-             _tags: &[Vec<String>]| { Ok(vec![mock_split("split1")]) },
+            |_index_id: &str, _split_state: SplitState, _time_range: Option<Range<i64>>, _tags| {
+                Ok(vec![mock_split("split1")])
+            },
         );
 
         let mut mock_search_service1 = MockSearchService::new();
@@ -798,7 +780,6 @@ mod tests {
             end_timestamp: None,
             max_hits: 10,
             start_offset: 0,
-            tags: vec![],
         };
         let mut metastore = MockMetastore::new();
         metastore
@@ -810,10 +791,9 @@ mod tests {
                 ))
             });
         metastore.expect_list_splits().returning(
-            |_index_id: &str,
-             _split_state: SplitState,
-             _time_range: Option<Range<i64>>,
-             _tags: &[Vec<String>]| { Ok(vec![mock_split("split1")]) },
+            |_index_id: &str, _split_state: SplitState, _time_range: Option<Range<i64>>, _tags| {
+                Ok(vec![mock_split("split1")])
+            },
         );
         // Service1 - broken node.
         let mut mock_search_service1 = MockSearchService::new();
@@ -882,7 +862,6 @@ mod tests {
             end_timestamp: None,
             max_hits: 10,
             start_offset: 0,
-            tags: vec![],
         };
         let mut metastore = MockMetastore::new();
         metastore
@@ -894,10 +873,9 @@ mod tests {
                 ))
             });
         metastore.expect_list_splits().returning(
-            |_index_id: &str,
-             _split_state: SplitState,
-             _time_range: Option<Range<i64>>,
-             _tags: &[Vec<String>]| { Ok(vec![mock_split("split1")]) },
+            |_index_id: &str, _split_state: SplitState, _time_range: Option<Range<i64>>, _tags| {
+                Ok(vec![mock_split("split1")])
+            },
         );
 
         // Service1 - working node.

--- a/quickwit-search/src/search_stream/leaf.rs
+++ b/quickwit-search/src/search_stream/leaf.rs
@@ -470,7 +470,6 @@ mod tests {
             fast_field: "ts".to_string(),
             output_format: 0,
             partition_by_field: None,
-            tags: vec![],
         };
         let splits = test_sandbox.metastore().list_all_splits(index_id).await?;
         let splits_offsets = splits
@@ -565,7 +564,6 @@ mod tests {
             fast_field: "fast_field".to_string(),
             output_format: 1,
             partition_by_field: Some(String::from("partition_by_fast_field")),
-            tags: vec![],
         };
         let splits = test_sandbox.metastore().list_all_splits(index_id).await?;
         let splits_offsets = splits

--- a/quickwit-serve/src/lib.rs
+++ b/quickwit-serve/src/lib.rs
@@ -175,7 +175,6 @@ mod tests {
             fast_field: "timestamp".to_string(),
             output_format: OutputFormat::Csv as i32,
             partition_by_field: None,
-            tags: vec![],
         };
         let mut metastore = MockMetastore::new();
         metastore
@@ -187,10 +186,7 @@ mod tests {
                 ))
             });
         metastore.expect_list_splits().returning(
-            |_index_id: &str,
-             _split_state: SplitState,
-             _time_range: Option<Range<i64>>,
-             _tags: &[Vec<String>]| {
+            |_index_id: &str, _split_state: SplitState, _time_range: Option<Range<i64>>, _tags| {
                 Ok(vec![mock_split("split_1"), mock_split("split_2")])
             },
         );

--- a/quickwit-serve/src/rest.rs
+++ b/quickwit-serve/src/rest.rs
@@ -148,10 +148,6 @@ pub struct SearchRequestQueryString {
     /// The output format.
     #[serde(default)]
     pub format: Format,
-    /// The tag filter.
-    #[serde(default)]
-    #[serde(deserialize_with = "from_simple_list")]
-    pub tags: Option<Vec<String>>,
 }
 
 async fn search_endpoint<TSearchService: SearchService>(
@@ -167,7 +163,6 @@ async fn search_endpoint<TSearchService: SearchService>(
         end_timestamp: search_request.end_timestamp,
         max_hits: search_request.max_hits,
         start_offset: search_request.start_offset,
-        tags: search_request.tags.unwrap_or_default(),
     };
     let search_response = search_service.root_search(search_request).await?;
     let search_response_rest =
@@ -229,10 +224,6 @@ pub struct SearchStreamRequestQueryString {
     pub output_format: OutputFormat,
     #[serde(default)]
     pub partition_by_field: Option<String>,
-    /// The tag filter.
-    #[serde(default)]
-    #[serde(deserialize_with = "from_simple_list")]
-    pub tags: Option<Vec<String>>,
 }
 
 async fn search_stream_endpoint<TSearchService: SearchService>(
@@ -248,7 +239,6 @@ async fn search_stream_endpoint<TSearchService: SearchService>(
         end_timestamp: search_request.end_timestamp,
         fast_field: search_request.fast_field,
         output_format: search_request.output_format as i32,
-        tags: search_request.tags.unwrap_or_default(),
         partition_by_field: search_request.partition_by_field,
     };
     let mut data = search_service.root_search_stream(request).await?;
@@ -431,7 +421,6 @@ mod tests {
                 max_hits: 10,
                 start_offset: 22,
                 format: Format::default(),
-                tags: None
             }
         );
     }
@@ -458,7 +447,6 @@ mod tests {
                 max_hits: 20,
                 start_offset: 0,
                 format: Format::default(),
-                tags: None
             }
         );
     }
@@ -482,7 +470,6 @@ mod tests {
                 start_offset: 0,
                 format: Format::Json,
                 search_fields: None,
-                tags: None
             }
         );
     }
@@ -499,7 +486,7 @@ mod tests {
         assert_eq!(resp.status(), 400);
         let resp_json: serde_json::Value = serde_json::from_slice(resp.body())?;
         let exp_resp_json = serde_json::json!({
-            "error": "InvalidArgument: failed with reason: unknown field `endUnixTimestamp`, expected one of `query`, `searchField`, `startTimestamp`, `endTimestamp`, `maxHits`, `startOffset`, `format`, `tags`."
+            "error": "InvalidArgument: failed with reason: unknown field `endUnixTimestamp`, expected one of `query`, `searchField`, `startTimestamp`, `endTimestamp`, `maxHits`, `startOffset`, `format`."
         });
         assert_eq!(resp_json, exp_resp_json);
         Ok(())
@@ -661,7 +648,6 @@ mod tests {
                 fast_field: "external_id".to_string(),
                 output_format: OutputFormat::Csv,
                 partition_by_field: None,
-                tags: None
             }
         );
     }
@@ -671,7 +657,7 @@ mod tests {
         let (index, req) = warp::test::request()
             .path(
                 "/api/v1/my-index/search/stream?query=obama&fastField=external_id&\
-                 outputFormat=clickHouseRowBinary&tags=lang:english",
+                 outputFormat=clickHouseRowBinary",
             )
             .filter(&super::search_stream_filter())
             .await
@@ -687,7 +673,6 @@ mod tests {
                 fast_field: "external_id".to_string(),
                 output_format: OutputFormat::ClickHouseRowBinary,
                 partition_by_field: None,
-                tags: Some(vec!["lang:english".to_string()])
             }
         );
     }


### PR DESCRIPTION
A predicate is extracted from the user in the form of an AST.
This predicate is guaranteed to be true for all doc matching the
initial query.

This predicate is expanded using the rules described in #887.
Likewise, in the packager, the tags are expanded using the
same rules

In the PostgreSQL code, the predicate is expanded into a SQL
expression.
Other metastore may rely on direct predicate
evaluation algorithm, over the AST.

Co-authored-by: Ryad ZENINE <r.zenine@gmail.com>
Co-authored-by: Paul Masurel <paul@quickwit.io>
