### PR TITLE
Update deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "c98233c6673d8601ab23e77eb38f999c51100d46c5703b17288c57fddf3a1ffe"
 dependencies = [
  "bstr",
  "doc-comment",
- "predicates 2.0.3",
+ "predicates",
  "predicates-core",
  "predicates-tree",
  "wait-timeout",
@@ -128,26 +128,20 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
-
-[[package]]
-name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "backoff"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fe17f59a06fe8b87a6fc8bf53bb70b3aba76d7685f432487a68cd5552853625"
+checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
 dependencies = [
  "futures-core",
  "getrandom 0.2.3",
  "instant",
- "pin-project",
+ "pin-project-lite",
  "rand 0.8.4",
  "tokio",
 ]
@@ -348,15 +342,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "cloudabi"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
-dependencies = [
- "bitflags",
 ]
 
 [[package]]
@@ -614,12 +599,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "difference"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
-
-[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -675,9 +654,9 @@ checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 
 [[package]]
 name = "downcast"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bb454f0228b18c7f4c3b0ebbee346ed9c52e7443b0999cd543ff3571205701d"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
 name = "downcast-rs"
@@ -746,17 +725,6 @@ dependencies = [
 
 [[package]]
 name = "fail"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be3c61c59fdc91f5dbc3ea31ee8623122ce80057058be560654c5d410d181a6"
-dependencies = [
- "lazy_static",
- "log",
- "rand 0.7.3",
-]
-
-[[package]]
-name = "fail"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec3245a0ca564e7f3c797d20d833a6870f57a728ac967d5225b3ffdef4465011"
@@ -783,9 +751,9 @@ dependencies = [
 
 [[package]]
 name = "fixedbitset"
-version = "0.2.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
+checksum = "398ea4fabe40b9b0d885340a2a991a44c8a645624075ad966d21f88688e2b69e"
 
 [[package]]
 name = "flate2"
@@ -797,15 +765,6 @@ dependencies = [
  "crc32fast",
  "libc",
  "miniz_oxide",
-]
-
-[[package]]
-name = "float-cmp"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1267f4ac4f343772758f7b1bdcbe767c218bbab93bb432acbf5162bbf85a6c4"
-dependencies = [
- "num-traits",
 ]
 
 [[package]]
@@ -878,12 +837,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-
-[[package]]
 name = "futures"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -938,7 +891,7 @@ version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18e4a4b95cea4b4ccbcf1c5675ca7c4ee4e9e75eb79944d07defde18068f79bb"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
  "proc-macro-hack",
  "proc-macro2",
  "quote",
@@ -963,7 +916,7 @@ version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36568465210a3a6ee45e1f165136d68671471a501e632e9a98d96872222b5481"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -1258,7 +1211,7 @@ version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
  "hashbrown",
 ]
 
@@ -1415,15 +1368,6 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ea2d928b485416e8908cff2d97d621db22b27f7b3b6729e438bcf42c671ba91"
-dependencies = [
- "hashbrown",
-]
-
-[[package]]
-name = "lru"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c748cfe47cb8da225c37595b3108bea1c198c84aaae8ea0ba76d01dda9fc803"
@@ -1508,7 +1452,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
 ]
 
 [[package]]
@@ -1555,7 +1499,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
 dependencies = [
  "adler",
- "autocfg 1.0.1",
+ "autocfg",
 ]
 
 [[package]]
@@ -1582,51 +1526,24 @@ dependencies = [
 
 [[package]]
 name = "mockall"
-version = "0.9.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d614ad23f9bb59119b8b5670a85c7ba92c5e9adf4385c81ea00c51c8be33d5"
+checksum = "3d4d70639a72f972725db16350db56da68266ca368b2a1fe26724a903ad3d6b8"
 dependencies = [
  "cfg-if 1.0.0",
  "downcast",
  "fragile",
  "lazy_static",
- "mockall_derive 0.9.1",
- "predicates 1.0.8",
- "predicates-tree",
-]
-
-[[package]]
-name = "mockall"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ab571328afa78ae322493cacca3efac6a0f2e0a67305b4df31fd439ef129ac0"
-dependencies = [
- "cfg-if 1.0.0",
- "downcast",
- "fragile",
- "lazy_static",
- "mockall_derive 0.10.2",
- "predicates 1.0.8",
+ "mockall_derive",
+ "predicates",
  "predicates-tree",
 ]
 
 [[package]]
 name = "mockall_derive"
-version = "0.9.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd4234635bca06fc96c7368d038061e0aae1b00a764dc817e900dc974e3deea"
-dependencies = [
- "cfg-if 1.0.0",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "mockall_derive"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7e25b214433f669161f414959594216d8e6ba83b6679d3db96899c0b4639033"
+checksum = "79ef208208a0dea3f72221e26e904cdc6db2e481d9ade89081ddd494f1dbaa6b"
 dependencies = [
  "cfg-if 1.0.0",
  "proc-macro2",
@@ -1697,7 +1614,7 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
  "num-integer",
  "num-traits",
 ]
@@ -1708,7 +1625,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
  "num-traits",
 ]
 
@@ -1718,7 +1635,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
 ]
 
 [[package]]
@@ -1800,7 +1717,7 @@ version = "0.9.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6517987b3f8226b5da3661dad65ff7f300cc59fb5ea8333ca191fc65fde3edf"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
  "cc",
  "libc",
  "openssl-src",
@@ -1919,9 +1836,9 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "petgraph"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7"
+checksum = "4a13a2fa9d0b63e5f22328828741e523766fff0ee9e779316902290dff3f824f"
 dependencies = [
  "fixedbitset",
  "indexmap",
@@ -1982,25 +1899,12 @@ dependencies = [
 
 [[package]]
 name = "predicates"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49cfaf7fdaa3bfacc6fa3e7054e65148878354a5cfddcf661df4c851f8021df"
-dependencies = [
- "difference",
- "float-cmp 0.8.0",
- "normalize-line-endings",
- "predicates-core",
- "regex",
-]
-
-[[package]]
-name = "predicates"
 version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c6ce811d0b2e103743eec01db1c50612221f173084ce2f7941053e94b6bb474"
 dependencies = [
  "difflib",
- "float-cmp 0.9.0",
+ "float-cmp",
  "itertools",
  "normalize-line-endings",
  "predicates-core",
@@ -2123,7 +2027,7 @@ dependencies = [
  "quick-error 2.0.1",
  "rand 0.8.4",
  "rand_chacha 0.3.1",
- "rand_xorshift 0.3.0",
+ "rand_xorshift",
  "regex-syntax 0.6.25",
  "rusty-fork",
  "tempfile",
@@ -2131,9 +2035,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de5e2533f59d08fcf364fd374ebda0692a70bd6d7e66ef97f306f45c6c5d8020"
+checksum = "444879275cb4fd84958b1a1d5420d15e6fcf7c235fe47f053c9c2a80aceb6001"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -2141,27 +2045,29 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "355f634b43cdd80724ee7848f95770e7e70eefa6dcf14fea676216573b8fd603"
+checksum = "62941722fb675d463659e49c4f3fe1fe792ff24fe5bbaa9c08cd3b98a1c354f5"
 dependencies = [
  "bytes",
  "heck",
  "itertools",
+ "lazy_static",
  "log",
  "multimap",
  "petgraph",
  "prost",
  "prost-types",
+ "regex",
  "tempfile",
  "which",
 ]
 
 [[package]]
 name = "prost-derive"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "600d2f334aa05acb02a755e217ef1ab6dea4d51b58b7846588b747edec04efba"
+checksum = "f9cc1a3263e07e0bf68e96268f37665207b49560d98739662cdfaae215c720fe"
 dependencies = [
  "anyhow",
  "itertools",
@@ -2172,9 +2078,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "603bbd6394701d13f3f25aada59c7de9d35a6a5887cfc156181234a44002771b"
+checksum = "534b7a0e836e3c482d2693070f982e39e7611da9695d4d1f5a4b186b51faef0a"
 dependencies = [
  "bytes",
  "prost",
@@ -2265,7 +2171,7 @@ dependencies = [
  "openssl-probe",
  "opentelemetry",
  "opentelemetry-jaeger",
- "predicates 2.0.3",
+ "predicates",
  "quickwit-actors",
  "quickwit-common",
  "quickwit-config",
@@ -2361,7 +2267,7 @@ dependencies = [
  "byte-unit",
  "futures",
  "futures-util",
- "mockall 0.9.1",
+ "mockall",
  "quickwit-actors",
  "quickwit-common",
  "quickwit-directories",
@@ -2413,7 +2319,7 @@ dependencies = [
  "dyn-clone",
  "itertools",
  "matches",
- "mockall 0.9.1",
+ "mockall",
  "once_cell",
  "quickwit-proto",
  "regex",
@@ -2436,12 +2342,12 @@ dependencies = [
  "backoff",
  "byte-unit",
  "bytes",
- "fail 0.4.0",
+ "fail",
  "flume",
  "futures",
  "itertools",
  "libz-sys",
- "mockall 0.9.1",
+ "mockall",
  "once_cell",
  "openssl",
  "proptest",
@@ -2480,7 +2386,7 @@ dependencies = [
  "diesel_migrations",
  "dotenv",
  "futures",
- "mockall 0.9.1",
+ "mockall",
  "openssl",
  "quickwit-config",
  "quickwit-index-config",
@@ -2518,8 +2424,8 @@ dependencies = [
  "http",
  "hyper",
  "itertools",
- "lru 0.6.6",
- "mockall 0.9.1",
+ "lru",
+ "mockall",
  "once_cell",
  "opentelemetry",
  "quickwit-cluster",
@@ -2556,7 +2462,7 @@ dependencies = [
  "futures",
  "futures-util",
  "hyper",
- "mockall 0.10.2",
+ "mockall",
  "once_cell",
  "opentelemetry",
  "prometheus",
@@ -2595,9 +2501,9 @@ dependencies = [
  "bytes",
  "ec2_instance_metadata",
  "futures",
- "lru 0.6.6",
+ "lru",
  "md5",
- "mockall 0.9.1",
+ "mockall",
  "once_cell",
  "quickwit-common",
  "rand 0.8.4",
@@ -2670,25 +2576,6 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
-dependencies = [
- "autocfg 0.1.7",
- "libc",
- "rand_chacha 0.1.1",
- "rand_core 0.4.2",
- "rand_hc 0.1.0",
- "rand_isaac",
- "rand_jitter",
- "rand_os",
- "rand_pcg",
- "rand_xorshift 0.1.1",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
@@ -2714,16 +2601,6 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
-dependencies = [
- "autocfg 0.1.7",
- "rand_core 0.3.1",
-]
-
-[[package]]
-name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
@@ -2741,21 +2618,6 @@ dependencies = [
  "ppv-lite86",
  "rand_core 0.6.3",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -2777,15 +2639,6 @@ dependencies = [
 
 [[package]]
 name = "rand_hc"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
-name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
@@ -2803,60 +2656,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_isaac"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
-name = "rand_jitter"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
-dependencies = [
- "libc",
- "rand_core 0.4.2",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "rand_os"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
-dependencies = [
- "cloudabi",
- "fuchsia-cprng",
- "libc",
- "rand_core 0.4.2",
- "rdrand",
- "wasm-bindgen",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "rand_pcg"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
-dependencies = [
- "autocfg 0.1.7",
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_xorshift"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
 name = "rand_xorshift"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2871,7 +2670,7 @@ version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
  "crossbeam-deque",
  "either",
  "rayon-core",
@@ -2892,9 +2691,9 @@ dependencies = [
 
 [[package]]
 name = "rdkafka"
-version = "0.26.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af78bc431a82ef178c4ad6db537eb9cc25715a8591d27acc30455ee7227a76f4"
+checksum = "1de127f294f2dba488ed46760b129d5ecbeabbd337ccbf3739cb29d50db2161c"
 dependencies = [
  "futures",
  "libc",
@@ -2909,9 +2708,9 @@ dependencies = [
 
 [[package]]
 name = "rdkafka-sys"
-version = "4.1.0+1.7.0"
+version = "4.2.0+1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e212ccf56a2d4e0b9f874a1cad295495769e0cdbabe60e02b4f654d369a2d6a1"
+checksum = "9e542c6863b04ce0fa0c5719bc6b7b348cf8dd21af1bb03c9db5f9805b2a6473"
 dependencies = [
  "cmake",
  "libc",
@@ -2919,15 +2718,6 @@ dependencies = [
  "num_enum",
  "openssl-sys",
  "pkg-config",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -3621,7 +3411,7 @@ dependencies = [
  "crc32fast",
  "crossbeam",
  "downcast-rs",
- "fail 0.5.0",
+ "fail",
  "fastdivide",
  "fastfield_codecs",
  "fnv",
@@ -3631,7 +3421,7 @@ dependencies = [
  "itertools",
  "levenshtein_automata",
  "log",
- "lru 0.7.0",
+ "lru",
  "lz4_flex",
  "measure_time",
  "memmap2",
@@ -3851,7 +3641,7 @@ version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "588b2d10a336da58d877567cd8fb8a14b463e2104910f8132cd054b4b96e29ee"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
  "bytes",
  "libc",
  "memchr",
@@ -3949,9 +3739,9 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.5.2"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "796c5e1cd49905e65dd8e700d4cb1dffcbfdb4fc9d017de08c1a537afd83627c"
+checksum = "ff08f4649d10a70ffa3522ca559031285d8e421d727ac85c60825761818f5d0a"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -3980,9 +3770,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.5.2"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12b52d07035516c2b74337d2ac7746075e7dcae7643816c1b12c5ff8a7484c08"
+checksum = "9403f1bafde247186684b230dc6f38b5cd514584e8bec1dd32514be4745fa757"
 dependencies = [
  "proc-macro2",
  "prost-build",
@@ -4198,13 +3988,12 @@ dependencies = [
 
 [[package]]
 name = "ulid"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e95a59b292ca0cf9b45be2e52294d1ca6cb24eb11b08ef4376f73f1a00c549"
+checksum = "220b18413e1fe5e85a5580b22f44241f82404a66c792c9f3c9eda74c52d9a22e"
 dependencies = [
  "chrono",
- "lazy_static",
- "rand 0.6.5",
+ "rand 0.8.4",
 ]
 
 [[package]]

--- a/quickwit-cluster/Cargo.toml
+++ b/quickwit-cluster/Cargo.toml
@@ -19,8 +19,8 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"
 tokio = { version = "1.7", features = [ "full" ] }
-tokio-stream = { version = "0.1.6", features = [ "sync" ] }
-tonic = "0.5.2"
+tokio-stream = { version = "0.1", features = [ "sync" ] }
+tonic = "0.6"
 tracing = "0.1"
 uuid = "0.8"
 

--- a/quickwit-core/Cargo.toml
+++ b/quickwit-core/Cargo.toml
@@ -31,9 +31,9 @@ uuid = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tracing = '0.1'
-tokio-stream = "0.1.6"
+tokio-stream = "0.1"
 tempfile = '3'
 
 [dev-dependencies]
-mockall = '0.9'
+mockall = "0.11"
 quickwit-metastore = { version = "0.1.0", path = "../quickwit-metastore", features=["testsuite"]}

--- a/quickwit-index-config/Cargo.toml
+++ b/quickwit-index-config/Cargo.toml
@@ -29,11 +29,11 @@ typetag = "0.1"
 path = '../quickwit-proto'
 
 [dependencies.mockall]
-version = "0.9"
+version = "0.11"
 optional = true
 
 [dev-dependencies]
-mockall = '0.9'
+mockall = "0.11"
 
 [dev-dependencies.matches]
 version = "0.1.8"

--- a/quickwit-indexing/Cargo.toml
+++ b/quickwit-indexing/Cargo.toml
@@ -12,9 +12,9 @@ documentation = "https://quickwit.io/docs/"
 [dependencies]
 anyhow = "1"
 async-trait = "0.1"
-backoff = { version = "0.3", features = ["tokio"] }
+backoff = { version = "0.4", features = ["tokio"] }
 byte-unit = { version = "4", default-features = false, features = ["serde"] }
-fail = "0.4"
+fail = "0.5"
 flume = "0.10"
 futures = "0.3"
 itertools = "0.10"
@@ -26,7 +26,7 @@ quickwit-directories = {path = "../quickwit-directories"}
 quickwit-index-config = {path = "../quickwit-index-config", features=["testsuite"]}
 quickwit-metastore = {path = "../quickwit-metastore" }
 quickwit-storage = { version = "0.1.0", path = "../quickwit-storage" }
-rdkafka = { version = "0.26", default-features = false, features = ["tokio", "libz", "ssl", "cmake-build"], optional = true }
+rdkafka = { version = "0.28", default-features = false, features = ["tokio", "libz", "ssl", "cmake-build"], optional = true }
 openssl = { version = "0.10.36", default-features = false, optional = true}
 libz-sys = {version = "1.1.3", optional = true}
 rusoto_core = { version = "0.47", default-features = false, features = ["rustls"], optional = true }
@@ -39,8 +39,8 @@ tempfile = "3.2"
 thiserror = "1"
 tokio = { version = "1", features = ["sync"] }
 tracing = "0.1"
-ulid = "0.4"
-tokio-stream = "0.1.6"
+ulid = "0.5"
+tokio-stream = "0.1"
 arc-swap = "1.4"
 
 [features]
@@ -52,7 +52,7 @@ kinesis-external-service = []
 
 [dev-dependencies]
 bytes = "1"
-mockall = "0.9"
+mockall = "0.11"
 proptest = "1"
 quickwit-common = {path="../quickwit-common", version="0.1"}
 quickwit-metastore = {path = "../quickwit-metastore", features=["testsuite"]}

--- a/quickwit-metastore/Cargo.toml
+++ b/quickwit-metastore/Cargo.toml
@@ -30,7 +30,7 @@ quickwit-index-config = { version = "0.1.0", path = "../quickwit-index-config" }
 quickwit-storage = { version = "0.1.0", path = "../quickwit-storage" }
 
 [dependencies.mockall]
-version = "0.9"
+version = "0.11"
 optional = true
 
 [dependencies.tempfile]
@@ -39,7 +39,7 @@ optional = true
 
 [dev-dependencies]
 dotenv = "0.15"
-mockall = '0.9'
+mockall = "0.11"
 quickwit-storage = { version = "0.1.0", path = "../quickwit-storage", features=["testsuite"]}
 quickwit-index-config = { version = "0.1.0", path = "../quickwit-index-config", features=["testsuite"] }
 tempfile = '3'

--- a/quickwit-proto/Cargo.toml
+++ b/quickwit-proto/Cargo.toml
@@ -10,10 +10,10 @@ homepage = "https://quickwit.io/"
 documentation = "https://quickwit.io/docs/"
 
 [dependencies]
-tonic = '0.5.2'
-prost = { version = "0.8", default-features = false, features = ["prost-derive"] }
+tonic = "0.6"
+prost = { version = "0.9", default-features = false, features = ["prost-derive"] }
 serde = { version = "1.0", features = ["derive"] }
 
 [build-dependencies]
-tonic-build = '0.5.2'
-prost-build = '0.8.0'
+tonic-build = "0.6"
+prost-build = "0.9"

--- a/quickwit-proto/src/cluster.rs
+++ b/quickwit-proto/src/cluster.rs
@@ -55,7 +55,7 @@ pub mod cluster_service_client {
     impl<T> ClusterServiceClient<T>
     where
         T: tonic::client::GrpcService<tonic::body::BoxBody>,
-        T::ResponseBody: Body + Send + Sync + 'static,
+        T::ResponseBody: Body + Send + 'static,
         T::Error: Into<StdError>,
         <T::ResponseBody as Body>::Error: Into<StdError> + Send,
     {
@@ -172,7 +172,7 @@ pub mod cluster_service_server {
     impl<T, B> tonic::codegen::Service<http::Request<B>> for ClusterServiceServer<T>
     where
         T: ClusterService,
-        B: Body + Send + Sync + 'static,
+        B: Body + Send + 'static,
         B::Error: Into<StdError> + Send + 'static,
     {
         type Response = http::Response<tonic::body::BoxBody>;

--- a/quickwit-proto/src/quickwit.rs
+++ b/quickwit-proto/src/quickwit.rs
@@ -267,13 +267,13 @@ pub enum SortOrder {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum OutputFormat {
-    //// Comma Separated Values format (https://datatracker.ietf.org/doc/html/rfc4180).
+    //// Comma Separated Values format (<https://datatracker.ietf.org/doc/html/rfc4180>).
     //// The delimiter is `,`.
     ///
     ///< This will be the default value
     Csv = 0,
     //// Format data by row in ClickHouse binary format.
-    //// https://clickhouse.tech/docs/en/interfaces/formats/#rowbinary
+    //// <https://clickhouse.tech/docs/en/interfaces/formats/#rowbinary>
     ClickHouseRowBinary = 1,
 }
 #[doc = r" Generated client implementations."]
@@ -298,7 +298,7 @@ pub mod search_service_client {
     impl<T> SearchServiceClient<T>
     where
         T: tonic::client::GrpcService<tonic::body::BoxBody>,
-        T::ResponseBody: Body + Send + Sync + 'static,
+        T::ResponseBody: Body + Send + 'static,
         T::Error: Into<StdError>,
         <T::ResponseBody as Body>::Error: Into<StdError> + Send,
     {
@@ -451,7 +451,6 @@ pub mod search_service_server {
         #[doc = "Server streaming response type for the LeafSearchStream method."]
         type LeafSearchStreamStream: futures_core::Stream<Item = Result<super::LeafSearchStreamResponse, tonic::Status>>
             + Send
-            + Sync
             + 'static;
         #[doc = " Perform a leaf stream on a given set of splits."]
         async fn leaf_search_stream(
@@ -486,7 +485,7 @@ pub mod search_service_server {
     impl<T, B> tonic::codegen::Service<http::Request<B>> for SearchServiceServer<T>
     where
         T: SearchService,
-        B: Body + Send + Sync + 'static,
+        B: Body + Send + 'static,
         B::Error: Into<StdError> + Send + 'static,
     {
         type Response = http::Response<tonic::body::BoxBody>;

--- a/quickwit-search/Cargo.toml
+++ b/quickwit-search/Cargo.toml
@@ -16,11 +16,11 @@ async-trait = "0.1"
 base64 = '0.13'
 futures = '0.3'
 http = "0.2"
-mockall = "0.9"
+mockall = "0.11"
 itertools = '0.10'
 thiserror = "1"
-tonic = '0.5.2'
-tokio-stream = '0.1.6'
+tonic = "0.6"
+tokio-stream = "0.1"
 tracing = "0.1"
 tracing-futures = "0.2.5"
 serde_json = "1"
@@ -28,7 +28,7 @@ serde = { version = "1.0", features = ["derive"] }
 hyper = { version = "0.14", features = ["stream", "server", "http1", "http2", "tcp", "client"] }
 bytes = "1"
 quickwit-common = {path="../quickwit-common"}
-lru = "0.6.6"
+lru = "0.7"
 once_cell = "1"
 opentelemetry = "0.16"
 tracing-opentelemetry = "0.15"

--- a/quickwit-search/src/client.rs
+++ b/quickwit-search/src/client.rs
@@ -241,7 +241,7 @@ pub async fn create_search_service_client(
         .path_and_query("/")
         .build()?;
     // Create a channel with connect_lazy to automatically reconnect to the node.
-    let channel = Endpoint::from(uri).connect_lazy()?;
+    let channel = Endpoint::from(uri).connect_lazy();
     let client = SearchServiceClient::from_grpc_client(
         quickwit_proto::search_service_client::SearchServiceClient::new(channel),
         grpc_addr,

--- a/quickwit-serve/Cargo.toml
+++ b/quickwit-serve/Cargo.toml
@@ -26,19 +26,19 @@ quickwit-metastore = {path="../quickwit-metastore"}
 quickwit-telemetry = {path="../quickwit-telemetry"}
 quickwit-directories = {path="../quickwit-directories"}
 thiserror = "1"
-tonic = "0.5.2"
+tonic = "0.6"
 async-trait = "0.1"
 termcolor = "1"
 bytes = "1"
 tokio = { version = "1.7", features = [ "full" ] }
-tokio-stream = "0.1.6"
+tokio-stream = "0.1"
 opentelemetry = "0.16"
 tracing-opentelemetry = "0.15"
 prometheus = "0.13"
 once_cell = '1'
 
 [dev-dependencies]
-mockall = "0.10"
+mockall = "0.11"
 assert-json-diff = "2.0.1"
 tokio = { version = "1", features = ["full"] }
 quickwit-storage = { version = "0.1.0", path = "../quickwit-storage", features=["testsuite"]}

--- a/quickwit-storage/Cargo.toml
+++ b/quickwit-storage/Cargo.toml
@@ -24,7 +24,7 @@ once_cell = '1'
 regex = '1'
 thiserror = '1'
 rand = '0.8'
-lru = "0.6"
+lru = "0.7"
 serde = { version = "1.0", features = ["derive"] }
 ec2_instance_metadata = "0.3"
 tempfile = '3'
@@ -48,12 +48,12 @@ version = '0.6'
 features = ['full']
 
 [dependencies.mockall]
-version = "0.9"
+version = "0.11"
 optional = true
 
 [dev-dependencies]
 tracing-subscriber = '0.2'
-mockall = '0.9'
+mockall = "0.11"
 
 [features]
 testsuite = ["mockall"]

--- a/quickwit-swim/Cargo.toml
+++ b/quickwit-swim/Cargo.toml
@@ -15,7 +15,7 @@ serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.56"
 uuid = { version = "0.8.1", features = ["serde", "v4"] }
 rand = "0.8"
-mio = { version = "0.7.0", features = ["os-poll", "udp"] }
+mio = { version = "0.7", features = ["os-poll", "net"] }
 futures = "0.3.5"
 tracing = "0.1"
 tokio = { version = "1.7", features = [ "full" ]}


### PR DESCRIPTION
Updating various deps.

    
- mio is not updated to avoid a redundant dep
- tracing-* is not updated because the new version does not allow to limit the subseconds precision.
