### PR TITLE
Rename `ScheduledForDeletion` to `MarkedForDeletion`

### DIFF
--- a/quickwit-core/src/index.rs
+++ b/quickwit-core/src/index.rs
@@ -95,7 +95,7 @@ pub async fn delete_index(
 
     // Select split to delete
     let splits_to_delete = metastore
-        .list_splits(index_id, SplitState::ScheduledForDeletion, None, None)
+        .list_splits(index_id, SplitState::MarkedForDeletion, None, None)
         .await?
         .into_iter()
         .map(|metadata| metadata.split_metadata)

--- a/quickwit-indexing/src/actors/garbage_collector.rs
+++ b/quickwit-indexing/src/actors/garbage_collector.rs
@@ -181,10 +181,10 @@ mod tests {
                 assert_eq!(index_id, "foo-index");
                 let splits = match split_state {
                     SplitState::Staged => make_splits(&["a"], SplitState::Staged),
-                    SplitState::ScheduledForDeletion => {
-                        make_splits(&["a", "b", "c"], SplitState::ScheduledForDeletion)
+                    SplitState::MarkedForDeletion => {
+                        make_splits(&["a", "b", "c"], SplitState::MarkedForDeletion)
                     }
-                    _ => panic!("only Staged and ScheduledForDeletion expected."),
+                    _ => panic!("only Staged and MarkedForDeletion expected."),
                 };
                 Ok(splits)
             },
@@ -237,10 +237,10 @@ mod tests {
                 assert_eq!(index_id, "foo-index");
                 let splits = match split_state {
                     SplitState::Staged => make_splits(&["a"], SplitState::Staged),
-                    SplitState::ScheduledForDeletion => {
-                        make_splits(&["a", "b"], SplitState::ScheduledForDeletion)
+                    SplitState::MarkedForDeletion => {
+                        make_splits(&["a", "b"], SplitState::MarkedForDeletion)
                     }
-                    _ => panic!("only Staged and ScheduledForDeletion expected."),
+                    _ => panic!("only Staged and MarkedForDeletion expected."),
                 };
                 Ok(splits)
             },

--- a/quickwit-indexing/src/garbage_collection.rs
+++ b/quickwit-indexing/src/garbage_collection.rs
@@ -97,15 +97,15 @@ pub async fn run_garbage_collect(
     }
 
     if dry_run {
-        let mut scheduled_for_delete_splits = metastore
-            .list_splits(index_id, SplitState::ScheduledForDeletion, None, None)
+        let mut splits_marked_for_deletion = metastore
+            .list_splits(index_id, SplitState::MarkedForDeletion, None, None)
             .await?
             .into_iter()
             .map(|meta| meta.split_metadata)
             .collect::<Vec<_>>();
-        scheduled_for_delete_splits.extend(deletable_staged_splits);
+        splits_marked_for_deletion.extend(deletable_staged_splits);
 
-        let candidate_entries: Vec<FileEntry> = scheduled_for_delete_splits
+        let candidate_entries: Vec<FileEntry> = splits_marked_for_deletion
             .iter()
             .map(FileEntry::from)
             .collect();
@@ -124,7 +124,7 @@ pub async fn run_garbage_collect(
     // We wait another 2 minutes until the split is actually deleted.
     let grace_period_deletion = Utc::now().timestamp() - deletion_grace_period.as_secs() as i64;
     let splits_to_delete = metastore
-        .list_splits(index_id, SplitState::ScheduledForDeletion, None, None)
+        .list_splits(index_id, SplitState::MarkedForDeletion, None, None)
         .await?
         .into_iter()
         // TODO: Update metastore API and push this filter down.

--- a/quickwit-metastore/src/metastore/file_backed_metastore/index.rs
+++ b/quickwit-metastore/src/metastore/file_backed_metastore/index.rs
@@ -135,12 +135,12 @@ impl Index {
                 }
             };
 
-            if metadata.split_state == SplitState::ScheduledForDeletion {
-                // If the split is already scheduled for deletion, This is fine, we just skip it.
+            if metadata.split_state == SplitState::MarkedForDeletion {
+                // If the split is already marked for deletion, This is fine, we just skip it.
                 continue;
             }
 
-            metadata.split_state = SplitState::ScheduledForDeletion;
+            metadata.split_state = SplitState::MarkedForDeletion;
             metadata.update_timestamp = now_timestamp;
             is_modified = true;
         }
@@ -257,7 +257,7 @@ impl Index {
             }
         };
         match metadata.split_state {
-            SplitState::ScheduledForDeletion | SplitState::Staged => {
+            SplitState::MarkedForDeletion | SplitState::Staged => {
                 // Only `ScheduledForDeletion` and `Staged` can be deleted
                 self.splits.remove(split_id);
                 DeleteSplitOutcome::Success

--- a/quickwit-metastore/src/metastore/mod.rs
+++ b/quickwit-metastore/src/metastore/mod.rs
@@ -342,14 +342,14 @@ impl<'de> Deserialize<'de> for IndexMetadata {
 ///   - Start uploading the split files.
 /// 3. `Published`
 ///   - Uploading the split files is complete and the split is searchable.
-/// 4. `ScheduledForDeletion`
+/// 4. `MarkedForDeletion`
 ///   - Mark the split for deletion.
 ///
 /// If a split has a file in the storage, it MUST be registered in the metastore,
 /// and its state can be as follows:
 /// - `Staged`: The split is almost ready. Some of its files may have been uploaded in the storage.
 /// - `Published`: The split is ready and published.
-/// - `ScheduledForDeletion`: The split is scheduled for deletion.
+/// - `MarkedForDeletion`: The split is marked for deletion.
 ///
 /// Before creating any file, we need to stage the split. If there is a failure, upon recovery, we
 /// schedule for deletion all the staged splits. A client may not necessarily remove files from
@@ -433,7 +433,7 @@ pub trait Metastore: Send + Sync + 'static {
     async fn list_all_splits(&self, index_id: &str) -> MetastoreResult<Vec<Split>>;
 
     /// Marks a list of splits for deletion.
-    /// This API will change the state to `ScheduledForDeletion` so that it is not referenced by the
+    /// This API will change the state to `MarkedForDeletion` so that it is not referenced by the
     /// client. It actually does not remove the split from storage.
     /// An error will occur if you specify an index or split that does not exist in the storage.
     async fn mark_splits_for_deletion<'a>(
@@ -443,7 +443,7 @@ pub trait Metastore: Send + Sync + 'static {
     ) -> MetastoreResult<()>;
 
     /// Deletes a list of splits.
-    /// This API only takes a split that is in `Staged` or `ScheduledForDeletion` state.
+    /// This API only takes splits that are in `Staged` or `MarkedForDeletion` state.
     /// This removes the split metadata from the metastore, but does not remove the split from
     /// storage. An error will occur if you specify an index or split that does not exist in the
     /// storage.

--- a/quickwit-metastore/src/metastore/postgresql_metastore.rs
+++ b/quickwit-metastore/src/metastore/postgresql_metastore.rs
@@ -241,7 +241,7 @@ impl PostgresqlMetastore {
                     .and(schema::splits::dsl::split_id.eq_any(split_ids)),
             ),
         )
-        .set((schema::splits::dsl::split_state.eq(SplitState::ScheduledForDeletion.to_string()),))
+        .set((schema::splits::dsl::split_state.eq(SplitState::MarkedForDeletion.to_string()),))
         .returning(schema::splits::dsl::split_id)
         .get_results(conn)?;
 
@@ -693,7 +693,7 @@ impl Metastore for PostgresqlMetastore {
         conn.transaction::<_, MetastoreError, _>(|| {
             let deletable_states = [
                 SplitState::Staged.to_string(),
-                SplitState::ScheduledForDeletion.to_string(),
+                SplitState::MarkedForDeletion.to_string(),
             ];
 
             let deleted_split_ids: Vec<String> = diesel::delete(

--- a/quickwit-metastore/src/split_metadata.rs
+++ b/quickwit-metastore/src/split_metadata.rs
@@ -123,21 +123,23 @@ pub enum SplitState {
     /// The split is ready and published.
     Published,
 
-    /// The split is scheduled for deletion.
-    ScheduledForDeletion,
+    /// The split is marked for deletion.
+    MarkedForDeletion,
 }
 
 impl FromStr for SplitState {
-    type Err = &'static str;
+    type Err = String;
 
     fn from_str(input: &str) -> Result<SplitState, Self::Err> {
-        match input {
-            "Staged" => Ok(SplitState::Staged),
-            "Published" => Ok(SplitState::Published),
-            "ScheduledForDeletion" => Ok(SplitState::ScheduledForDeletion),
-            "New" => Ok(SplitState::Staged), // Deprecated
-            _ => Err("Unknown split state"),
-        }
+        let split_state = match input {
+            "Staged" => SplitState::Staged,
+            "Published" => SplitState::Published,
+            "MarkedForDeletion" => SplitState::MarkedForDeletion,
+            "ScheduledForDeletion" => SplitState::MarkedForDeletion, // Deprecated
+            "New" => SplitState::Staged,                             // Deprecated
+            _ => return Err(format!("Unknown split state `{}`.", input)),
+        };
+        Ok(split_state)
     }
 }
 


### PR DESCRIPTION
### Description
I noticed that nobody uses the term "scheduled" for deletion. Instead, we all use "marked", so I figured I'd rename the enum. The metastore API is already named `mark_for_deletion`.

This change is backward compatible.
