### PR TITLE
Ease quickwit configuration

### DIFF
--- a/config/quickwit.yaml
+++ b/config/quickwit.yaml
@@ -1,0 +1,58 @@
+# ============================ Quickwit Configuration ==============================
+#
+# Website: https://quickwit.io
+# Docs: https://quickwit.io/docs/
+#
+# -------------------------------- General settings --------------------------------
+#
+# Config file version.
+#
+version: 0
+#
+# Node ID must be unique in your cluster. If not set, a random ID is given at each boot.
+#
+#node_id: node-1
+#
+# Path to directory where data is persisted. Default to `./qwdata`.
+#
+#data_dir: /path/to/data
+#
+# Metastore URI. Default to `data_dir/indexes` which is a file backed metastore
+# and mostly convenient for testing. A cluster would require a metastore backed by S3 or
+# postgreqsl.
+#
+#metastore_uri: s3://your-bucket/indexes
+#metastore_uri: postgres://username:password@host:port/db
+#
+# Default index root URI which define the location where index data (splits) is stored
+# following the scheme `{default_index_root_uri}/{index-id}`. Default to `data_dir/indexes`.
+#
+#default_index_root_uri: s3://your-bucket/indexes
+#
+#
+
+#
+# -------------------------------- Indexer settings --------------------------------
+#
+# By default an indexer is only accessible on localhost on http port 7280.
+#
+#indexer:
+#  rest_listen_address: 127.0.0.1
+#  rest_listen_port: 7280
+#  split_store_max_num_bytes: 200G
+#  split_store_max_num_splits: 10000
+#
+# -------------------------------- Searcher settings --------------------------------
+#
+# By default a searcher is only accessible on localhost on http port 7280.
+#
+#searcher:
+#  rest_listen_address: 127.0.0.1
+#  rest_listen_port: 7280
+#  peer_seeds:
+#    - quickwit-searcher-0.local
+#    - quickwit-searcher-1.local
+#  fast_field_cache_capacity: 10G
+#  split_footer_cache_capacity: 1G
+#
+

--- a/config/tutorials/gh-archive/index-config.yaml
+++ b/config/tutorials/gh-archive/index-config.yaml
@@ -1,0 +1,30 @@
+#
+# Index config file for gh-archive dataset.
+#
+version: 0
+
+doc_mapping:
+  field_mappings:
+    - name: id
+      type: u64
+      fast: true
+    - name: created_at
+      type: i64
+      fast: true
+    - name: event_type
+      type: text
+      tokenizer: raw
+    - name: title
+      type: text
+      tokenizer: default
+      record: position
+    - name: body
+      type: text
+      tokenizer: default
+      record: position
+
+indexing_settings:
+  timestamp_field: created_at
+
+search_settings:
+  default_search_fields: [title, body]

--- a/config/tutorials/hdfs-logs/index-config.yaml
+++ b/config/tutorials/hdfs-logs/index-config.yaml
@@ -1,3 +1,7 @@
+#
+# Index config file for hdfs-logs dataset.
+#
+
 version: 0
 
 doc_mapping:
@@ -25,31 +29,7 @@ doc_mapping:
   store_source: true
 
 indexing_settings:
-  demux_field: tenant_id
   timestamp_field: timestamp
-  sort_field: timestamp
-  sort_order: asc
-  commit_timeout_secs: 61
-  split_num_docs_target: 10000001
-  merge_policy:
-    demux_factor: 7
-    merge_factor: 9
-    max_merge_factor: 11
-  resources:
-    num_threads: 3
-    heap_size: 3G
 
 search_settings:
   default_search_fields: [severity_text, body]
-
-sources:
-  - source_id: hdfs-logs-kafka-source
-    source_type: kafka
-    params:
-      bootstrap.servers: host:9092
-      topic: cloudera-cluster-logs
-
-  - source_id: hdfs-logs-kinesis-source
-    source_type: kinesis
-    params:
-      stream_name: emr-cluster-logs

--- a/config/tutorials/hdfs-logs/searcher-1.yaml
+++ b/config/tutorials/hdfs-logs/searcher-1.yaml
@@ -1,0 +1,7 @@
+version: 0
+node_id: searcher-1
+searcher:
+  rest_listen_address: 127.0.0.1
+  rest_listen_port: 7280
+  peer_seeds:
+     - 127.0.0.1:7290 # searcher-2

--- a/config/tutorials/hdfs-logs/searcher-2.yaml
+++ b/config/tutorials/hdfs-logs/searcher-2.yaml
@@ -1,0 +1,6 @@
+version: 0
+node_id: searcher-2
+searcher:
+  rest_listen_address: 127.0.0.1
+  rest_listen_port: 7290
+

--- a/config/tutorials/wikipedia/index-config.yaml
+++ b/config/tutorials/wikipedia/index-config.yaml
@@ -1,0 +1,25 @@
+#
+# Index config file for wikipedia dataset.
+#
+
+version: 0
+
+doc_mapping:
+  field_mappings:
+    - name: title
+      type: text
+      tokenizer: default
+      record: position
+      stored: true
+    - name: body
+      type: text
+      tokenizer: default
+      record: position
+      stored: true
+    - name: url
+      type: text
+      tokenizer: raw
+      stored: true
+
+search_settings:
+  default_search_fields: [title, body]

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -72,7 +72,7 @@ Now we can create the index with the command:
 
 ```bash
 
-./quickwit new --index-uri file:///your-path-to-your-index/wikipedia --index-config-path ./wikipedia_index_config.json --index-id wikipedia --metastore-uri file:///path-to-your-metastore
+./quickwit new --index-uri file:///your-path-to-your-index/wikipedia --index-config-path ./wikipedia_index_config.json --index wikipedia --metastore-uri file:///path-to-your-metastore
 ```
 
 The metastore is like a directory of indexes that has it's own storage and some meta information about the indexes.
@@ -80,7 +80,7 @@ The metastore is like a directory of indexes that has it's own storage and some 
 To simplify our command, we now assume that the index and metastore are to be created in the current directory and use the `pwd` command to specify the index uri:
 
 ```bash
-./quickwit new --index-uri file://$(pwd)/wikipedia --index-config-path ./wikipedia_index_config.json --index-id wikipedia --metastore-uri file://$(pwd)/metastore/
+./quickwit new --index-uri file://$(pwd)/wikipedia --index-config-path ./wikipedia_index_config.json --index wikipedia --metastore-uri file://$(pwd)/metastore/
 ```
 
 Check that an empty directory `$(pwd)/wikipedia` has been created, Quickwit will write index files here and a `quickwit.json` which contains the [index metadata](../overview/architecture.md#index-metadata).
@@ -103,13 +103,13 @@ Let's download [a bunch of wikipedia articles (10 000)](https://quickwit-dataset
 curl -o wiki-articles-10000.json https://quickwit-datasets-public.s3.amazonaws.com/wiki-articles-10000.json
 
 # Index our 10k documents.
-./quickwit index --index-id wikipedia --data-dir-path ./wikipedia --metastore-uri file://$(pwd)/metastore --input-path wiki-articles-10000.json
+./quickwit index --index wikipedia --data-dir-path ./wikipedia --metastore-uri file://$(pwd)/metastore --input-path wiki-articles-10000.json
 ```
 
 Wait one second or two and check if it worked by using `search` command:
 
 ```bash
-./quickwit search --index-id wikipedia --metastore-uri file://$(pwd)/metastore --query "barack AND obama"
+./quickwit search --index wikipedia --metastore-uri file://$(pwd)/metastore --query "barack AND obama"
 ```
 
 It should return 10 hits. Now you're ready to serve our search API.
@@ -151,7 +151,7 @@ Don't forget to encode correctly the query params to avoid bad request (status 4
 Let's do some cleanup by deleting the index:
 
 ```bash
-./quickwit delete --index-id wikipedia --metastore-uri file:///$(pwd)/metastore
+./quickwit delete --index wikipedia --metastore-uri file:///$(pwd)/metastore
 ```
 
 Congrats! You can level up with the following tutorials to discover all Quickwit features.
@@ -161,11 +161,11 @@ Congrats! You can level up with the following tutorials to discover all Quickwit
 
 ```bash
 curl -o wikipedia_index_config.json https://raw.githubusercontent.com/quickwit-inc/quickwit/main/examples/index_configs/wikipedia_index_config.json
-./quickwit new --index-uri file://$(pwd)/wikipedia --index-config-path ./wikipedia_index_config.json --index-id wikipedia --metastore-uri file://$(pwd)/metastore/
+./quickwit new --index-uri file://$(pwd)/wikipedia --index-config-path ./wikipedia_index_config.json --index wikipedia --metastore-uri file://$(pwd)/metastore/
 curl -o wiki-articles-10000.json https://quickwit-datasets-public.s3.amazonaws.com/wiki-articles-10000.json
-./quickwit index --index-id wikipedia --data-dir-path ./wikipedia --metastore-uri file://$(pwd)/metastore --input-path wiki-articles-10000.json
-./quickwit search --index-id wikipedia --metastore-uri file://$(pwd)/metastore --query "barack AND obama"
-./quickwit delete --index-id wikipedia --metastore-uri file:///$(pwd)/metastore
+./quickwit index --index wikipedia --data-dir-path ./wikipedia --metastore-uri file://$(pwd)/metastore --input-path wiki-articles-10000.json
+./quickwit search --index wikipedia --metastore-uri file://$(pwd)/metastore --query "barack AND obama"
+./quickwit delete --index wikipedia --metastore-uri file:///$(pwd)/metastore
 ```
 
 

--- a/quickwit-cli/src/cli.yaml
+++ b/quickwit-cli/src/cli.yaml
@@ -12,17 +12,31 @@ subcommands:
                 about: Creates an index.
                 display_order: 1
                 args:
-                    - metastore-uri:
-                        about: Location of the metastore.
-                        long: metastore-uri
-                        value_name: METASTORE URI
+                    - index:
+                        about: ID of the target index.
+                        long: index
+                        value_name: INDEX
                         required: true
-                        env: QUICKWIT_METASTORE_URI
-                    - index-config-uri:
+                    - index-config:
                         about: Location of the index config file.
-                        long: index-config-uri
-                        value_name: INDEX CONFIG URI
+                        long: index-config
+                        value_name: INDEX CONFIG
                         required: true
+                    - index-uri:
+                        about: Index data (or splits) storage URI.
+                        long: index-uri
+                        value_name: INDEX URI
+                    - config:
+                        about: Quickwit config file.
+                        long: config
+                        value_name: CONFIG
+                        env: QW_CONFIG
+                        required: true
+                    - data-dir:
+                        about: Where data is persisted. Override data-dir defined in config file, default is `./qwdata`.
+                        long: data-dir
+                        value_name: DATA DIR
+                        env: QW_DATA_DIR
                     - overwrite:
                         about: Overwrites pre-existing index.
                         long: overwrite
@@ -30,26 +44,26 @@ subcommands:
                 display_order: 2
                 about: Indexes JSON documents read from a file or streamed from stdin.
                 args:
-                    - index-id:
+                    - index:
                         about: ID of the target index.
-                        long: index-id
-                        value_name: INDEX ID
+                        long: index
+                        value_name: INDEX
                         required: true
-                    - metastore-uri:
-                        about: Location of the metastore.
-                        long: metastore-uri
-                        value_name: METASTORE URI
+                    - config:
+                        about: Quickwit config file.
+                        long: config
+                        value_name: CONFIG
+                        env: QW_CONFIG
                         required: true
-                        env: QUICKWIT_METASTORE_URI
+                    - data-dir:
+                        about: Where data is persisted. Override data-dir defined in config file, default is `./qwdata`.
+                        long: data-dir
+                        value_name: DATA DIR
+                        env: QW_DATA_DIR
                     - input-path:
                         about: Location of the input file.
                         long: input-path
                         value_name: INPUT PATH
-                    - data-dir-path:
-                        about: Creates cached and intermediate data structures in this local directory.
-                        long: data-dir-path
-                        value_name: DATA DIR PATH
-                        required: true
                     - overwrite:
                         about: Overwrites pre-existing index.
                         long: overwrite
@@ -57,32 +71,42 @@ subcommands:
                 display_order: 3
                 about: Display descriptive statistics about the index.
                 args:
-                    - index-id:
+                    - index:
                         about: ID of the target index.
-                        long: index-id
-                        value_name: INDEX ID
+                        long: index
+                        value_name: INDEX
                         required: true
-                    - metastore-uri:
-                        about: Location of the metastore.
-                        long: metastore-uri
-                        value_name: METASTORE URI
+                    - config:
+                        about: Quickwit config file.
+                        long: config
+                        value_name: CONFIG
+                        env: QW_CONFIG
                         required: true
-                        env: QUICKWIT_METASTORE_URI
+                    - data-dir:
+                        about: Where data is persisted. Override data-dir defined in config file, default is `./qwdata`.
+                        long: data-dir
+                        value_name: DATA DIR
+                        env: QW_DATA_DIR
             - search:
                 display_order: 4
                 about: Searches an index.
                 args:
-                    - index-id:
+                    - index:
                         about: id of the target index.
-                        long: index-id
-                        value_name: INDEX ID
+                        long: index
+                        value_name: INDEX
                         required: true
-                    - metastore-uri:
-                        about: Location of the metastore.
-                        long: metastore-uri
-                        value_name: METASTORE URI
+                    - config:
+                        about: Quickwit config file.
+                        long: config
+                        value_name: CONFIG
+                        env: QW_CONFIG
                         required: true
-                        env: QUICKWIT_METASTORE_URI
+                    - data-dir:
+                        about: Where data is persisted. Override data-dir defined in config file, default is `./qwdata`.
+                        long: data-dir
+                        value_name: DATA DIR
+                        env: QW_DATA_DIR
                     - query:
                         about: Query expressed in Tantivy syntax.
                         long: query
@@ -115,57 +139,62 @@ subcommands:
                 display_order: 4
                 about: Merges an index.
                 args:
-                    - index-id:
-                        about: Index ID.
-                        long: index-id
-                        value_name: INDEX ID
+                    - index:
+                        about: INDEX.
+                        long: index
+                        value_name: INDEX
                         required: true
-                    - metastore-uri:
-                        about: Location of the metastore.
-                        long: metastore-uri
-                        value_name: METASTORE URI
+                    - config:
+                        about: Quickwit config file.
+                        long: config
+                        value_name: CONFIG
+                        env: QW_CONFIG
                         required: true
-                        env: QUICKWIT_METASTORE_URI
-                    - data-dir-path:
-                        about: Creates indexing directories in this local directory.
-                        long: data-dir-path
-                        value_name: DATA DIR PATH
-                        required: true
+                    - data-dir:
+                        about: Where data is persisted. Override data-dir defined in config file, default is `./qwdata`.
+                        long: data-dir
+                        value_name: DATA DIR
+                        env: QW_DATA_DIR
             - demux:
                 display_order: 5
                 about: Demuxes an index.
                 args:
-                    - index-id:
+                    - index:
                         about: ID of the target index.
-                        long: index-id
-                        value_name: INDEX ID
+                        long: index
+                        value_name: INDEX
                         required: true
-                    - metastore-uri:
-                        about: Location of the metastore.
-                        long: metastore-uri
-                        value_name: METASTORE URI
+                    - config:
+                        about: Quickwit config file.
+                        long: config
+                        value_name: CONFIG
+                        env: QW_CONFIG
                         required: true
-                        env: QUICKWIT_METASTORE_URI
-                    - data-dir-path:
-                        about: Creates indexing directories in this local directory.
-                        long: data-dir-path
-                        value_name: DATA DIR PATH
-                        required: true
+                    - data-dir:
+                        about: Where data is persisted. Override data-dir defined in config file, default is `./qwdata`.
+                        long: data-dir
+                        value_name: DATA DIR
+                        env: QW_DATA_DIR
             - gc:
                 display_order: 6
                 about: Garbage collects stale staged splits and splits marked for deletion.
                 args:
-                    - index-id:
+                    - index:
                         about: ID of the target index.
-                        long: index-id
-                        value_name: INDEX ID
+                        long: index
+                        value_name: INDEX
                         required: true
-                    - metastore-uri:
-                        about: Location of the metastore.
-                        long: metastore-uri
-                        value_name: METASTORE URI
+                    - config:
+                        about: Quickwit config file.
+                        long: config
+                        value_name: CONFIG
+                        env: QW_CONFIG
                         required: true
-                        env: QUICKWIT_METASTORE_URI
+                    - data-dir:
+                        about: Where data is persisted. Override data-dir defined in config file, default is `./qwdata`.
+                        long: data-dir
+                        value_name: DATA DIR
+                        env: QW_DATA_DIR
                     - grace-period:
                         about: Threshold period after which stale staged splits are garbage collected.
                         long: grace-period
@@ -178,17 +207,22 @@ subcommands:
                 display_order: 7
                 about: Delete an index.
                 args:
-                    - index-id:
+                    - index:
                         about: ID of the target index.
-                        long: index-id
-                        value_name: INDEX ID
+                        long: index
+                        value_name: INDEX
                         required: true
-                    - metastore-uri:
-                        about: Location of the metastore.
-                        long: metastore-uri
-                        value_name: METASTORE URI
+                    - config:
+                        about: Quickwit config file.
+                        long: config
+                        value_name: CONFIG
+                        env: QW_CONFIG
                         required: true
-                        env: QUICKWIT_METASTORE_URI
+                    - data-dir:
+                        about: Where data is persisted. Override data-dir defined in config file, default is `./qwdata`.
+                        long: data-dir
+                        value_name: DATA DIR
+                        env: QW_DATA_DIR
                     - dry-run:
                         about: Executes the command in dry run mode and only displays the list of splits candidate for deletion.
                         long: dry-run
@@ -201,16 +235,10 @@ subcommands:
             - list:
                 about: Lists the splits of an index.
                 args:
-                    - metastore-uri:
-                        about: Location of the metastore.
-                        long: metastore-uri
-                        value_name: METASTORE URI
-                        required: true
-                        env: QUICKWIT_METASTORE_URI
-                    - index-id:
+                    - index:
                         about: ID of the target index.
-                        long: index-id
-                        value_name: INDEX ID
+                        long: index
+                        value_name: INDEX
                         required: true
                     - states:
                         about: |
@@ -234,25 +262,41 @@ subcommands:
                         value_name: TAGS
                         multiple_occurrences: true
                         use_delimiter: true
+                    - config:
+                        about: Quickwit config file.
+                        long: config
+                        value_name: CONFIG
+                        env: QW_CONFIG
+                        required: true
+                    - data-dir:
+                        about: Where data is persisted. Override data-dir defined in config file, default is `./qwdata`.
+                        long: data-dir
+                        value_name: DATA DIR
+                        env: QW_DATA_DIR
             - extract:
                 about: Downloads and extracts a split to a directory.
                 args:
-                    - index-id:
+                    - index:
                         about: ID of the target index.
-                        long: index-id
-                        value_name: INDEX ID
+                        long: index
+                        value_name: INDEX
                         required: true
-                    - split-id:
+                    - split:
                         about: ID of the target split.
-                        long: split-id
-                        value_name: SPLIT ID
+                        long: split
+                        value_name: SPLIT
                         required: true
-                    - metastore-uri:
-                        about: Location of the metastore.
-                        long: metastore-uri
-                        value_name: METASTORE URI
+                    - config:
+                        about: Quickwit config file.
+                        long: config
+                        value_name: CONFIG
+                        env: QW_CONFIG
                         required: true
-                        env: QUICKWIT_METASTORE_URI
+                    - data-dir:
+                        about: Where data is persisted. Override data-dir defined in config file, default is `./qwdata`.
+                        long: data-dir
+                        value_name: DATA DIR
+                        env: QW_DATA_DIR
                     - target-dir:
                         about: Directory to extract the split to.
                         long: target-dir
@@ -261,22 +305,27 @@ subcommands:
             - describe:
                 about: Displays metadata about the split.
                 args:
-                    - index-id:
+                    - index:
                         about: ID of the target index.
-                        long: index-id
-                        value_name: INDEX ID
+                        long: index
+                        value_name: INDEX
                         required: true
-                    - split-id:
+                    - split:
                         about: ID of the target split.
-                        long: split-id
-                        value_name: SPLIT ID
+                        long: split
+                        value_name: SPLIT
                         required: true
-                    - metastore-uri:
-                        about: Location of the metastore.
-                        long: metastore-uri
-                        value_name: METASTORE URI
+                    - config:
+                        about: Quickwit config file.
+                        long: config
+                        value_name: CONFIG
+                        env: QW_CONFIG
                         required: true
-                        env: QUICKWIT_METASTORE_URI
+                    - data-dir:
+                        about: Where data is persisted. Override data-dir defined in config file, default is `./qwdata`.
+                        long: data-dir
+                        value_name: DATA DIR
+                        env: QW_DATA_DIR
                     - verbose:
                         about: Displays additional metadata about the hotcache.
                         long: verbose
@@ -293,23 +342,35 @@ subcommands:
                     - searcher:
                         about: Starts a search node, aka a `searcher`
                         args:
-                            - server-config-uri:
-                                about: Location of the server config.
-                                long: server-config-uri
-                                value_name: SERVER CONFIG URI
+                            - config:
+                                about: Quickwit config file.
+                                long: config
+                                value_name: CONFIG
+                                env: QW_CONFIG
                                 required: true
+                            - data-dir:
+                                about: Where data is persisted. Override data-dir defined in config file, default is `./qwdata`.
+                                long: data-dir
+                                value_name: DATA DIR
+                                env: QW_DATA_DIR
                     - indexer:
                         about: Start an indexing server, aka an `indexer`
                         args:
-                            - server-config-uri:
-                                about: Location of the server config.
-                                long: server-config-uri
-                                value_name: SERVER CONFIG URI
+                            - config:
+                                about: Quickwit config file.
+                                long: config
+                                value_name: CONFIG
+                                env: QW_CONFIG
                                 required: true
-                            - index-id:
+                            - data-dir:
+                                about: Where data is persisted. Override data-dir defined in config file, default is `./qwdata`.
+                                long: data-dir
+                                value_name: DATA DIR
+                                env: QW_DATA_DIR
+                            - index:
                                 about: ID of the index to run the indexer for.
-                                long: index-id
-                                value_name: INDEX ID
+                                long: index
+                                value_name: INDEX
                                 required: true
     - source:
         about: Manages sources.
@@ -320,33 +381,43 @@ subcommands:
             - describe:
                 about: Describes a source.
                 args:
-                    - index-id:
+                    - index:
                         about: ID of the target index.
-                        long: index-id
-                        value_name: INDEX ID
+                        long: index
+                        value_name: INDEX
                         required: true
-                    - source-id:
+                    - source:
                         about: ID of the target source.
-                        long: source-id
-                        value_name: SOURCE ID
+                        long: source
+                        value_name: SOURCE
                         required: true
-                    - metastore-uri:
-                        about: Location of the metastore.
-                        long: metastore-uri
-                        value_name: METASTORE URI
+                    - config:
+                        about: Quickwit config file.
+                        long: config
+                        value_name: CONFIG
+                        env: QW_CONFIG
                         required: true
-                        env: QUICKWIT_METASTORE_URI
+                    - data-dir:
+                        about: Where data is persisted. Override data-dir defined in config file, default is `./qwdata`.
+                        long: data-dir
+                        value_name: DATA DIR
+                        env: QW_DATA_DIR
             - list:
                 about: Lists the sources of an index.
                 args:
-                    - index-id:
+                    - index:
                         about: ID of the target index.
-                        long: index-id
-                        value_name: INDEX ID
+                        long: index
+                        value_name: INDEX
                         required: true
-                    - metastore-uri:
-                        about: Location of the metastore.
-                        long: metastore-uri
-                        value_name: METASTORE URI
+                    - config:
+                        about: Quickwit config file.
+                        long: config
+                        value_name: CONFIG
+                        env: QW_CONFIG
                         required: true
-                        env: QUICKWIT_METASTORE_URI
+                    - data-dir:
+                        about: Where data is persisted. Override data-dir defined in config file, default is `./qwdata`.
+                        long: data-dir
+                        value_name: DATA DIR
+                        env: QW_DATA_DIR

--- a/quickwit-cli/tests/cli.rs
+++ b/quickwit-cli/tests/cli.rs
@@ -30,6 +30,7 @@ use helpers::{TestEnv, TestStorageType};
 use predicates::prelude::*;
 use quickwit_cli::index::{create_index_cli, CreateIndexArgs};
 use quickwit_common::rand::append_random_suffix;
+use quickwit_common::uri::Uri;
 use quickwit_metastore::{quickwit_metastore_uri_resolver, Metastore};
 use serde_json::{Number, Value};
 use serial_test::serial;
@@ -40,9 +41,11 @@ use crate::helpers::{create_test_env, make_command, spawn_command};
 fn create_logs_index(test_env: &TestEnv) {
     make_command(
         format!(
-            "index create --index-config-uri {} --metastore-uri {}",
+            "index create --index {} --index-uri {} --index-config {} --config {}",
+            test_env.index_id,
+            test_env.index_uri(),
             test_env.resource_files["index_config"].display(),
-            test_env.metastore_uri,
+            test_env.resource_files["config"].display(),
         )
         .as_str(),
     )
@@ -50,14 +53,13 @@ fn create_logs_index(test_env: &TestEnv) {
     .success();
 }
 
-fn ingest_docs(index_id: &str, input_path: &Path, metastore_uri: &str, data_dir_path: &Path) {
+fn ingest_docs(input_path: &Path, test_env: &TestEnv) {
     make_command(
         format!(
-            "index ingest --index-id {} --input-path {} --metastore-uri {} --data-dir-path {}",
-            index_id,
+            "index ingest --index {} --input-path {} --config {}",
+            test_env.index_id,
             input_path.display(),
-            metastore_uri,
-            data_dir_path.display(),
+            test_env.resource_files["config"].display(),
         )
         .as_str(),
     )
@@ -80,7 +82,7 @@ fn test_cmd_help() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
-async fn test_cmd_create_fail() -> Result<()> {
+async fn test_cmd_create() -> Result<()> {
     let index_id = append_random_suffix("test-create-cmd");
     let test_env = create_test_env(index_id, TestStorageType::LocalFileSystem)?;
     create_logs_index(&test_env);
@@ -91,13 +93,38 @@ async fn test_cmd_create_fail() -> Result<()> {
         .unwrap();
     assert_eq!(index_metadata.index_id, test_env.index_id);
 
+    // Create without giving `index-uri`.
+    let index_id = append_random_suffix("test-create-cmd-no-index-uri");
+    let test_env = create_test_env(index_id, TestStorageType::LocalFileSystem)?;
+    make_command(
+        format!(
+            "index create --index {} --index-config {} --config {}",
+            test_env.index_id,
+            test_env.resource_files["index_config"].display(),
+            test_env.resource_files["config"].display(),
+        )
+        .as_str(),
+    )
+    .assert()
+    .success();
+    let index_metadata = test_env
+        .metastore()
+        .index_metadata(&test_env.index_id)
+        .await
+        .unwrap();
+    assert_eq!(index_metadata.index_id, test_env.index_id);
+    assert_eq!(
+        index_metadata.index_uri,
+        Uri::try_new(&format!("./qwdata/indexes/{}", test_env.index_id))
+            .unwrap()
+            .as_ref()
+    );
+
     // Attempt to create with ill-formed new command.
     make_command("index create")
         .assert()
         .failure()
-        .stderr(predicate::str::contains(
-            "--index-config-uri <INDEX CONFIG URI>",
-        ));
+        .stderr(predicate::str::contains("--index-config <INDEX CONFIG>"));
     Ok(())
 }
 
@@ -109,9 +136,10 @@ fn test_cmd_create_on_existing_index() -> Result<()> {
 
     make_command(
         format!(
-            "index create --index-config-uri {} --metastore-uri {}",
+            "index create --index {} --index-config {} --config {}",
+            test_env.index_id,
             test_env.resource_files["index_config"].display(),
-            test_env.metastore_uri,
+            test_env.resource_files["config"].display(),
         )
         .as_str(),
     )
@@ -128,11 +156,10 @@ fn test_cmd_ingest_on_non_existing_index() -> Result<()> {
     let test_env = create_test_env(index_id, TestStorageType::LocalFileSystem)?;
     make_command(
         format!(
-            "index ingest --index-id {} --input-path {} --metastore-uri {} --data-dir-path {}",
+            "index ingest --index {} --input-path {} --config {}",
             "index-does-no-exist",
             test_env.resource_files["logs"].display(),
-            test_env.metastore_uri,
-            test_env.data_dir_path.display()
+            test_env.resource_files["config"].display(),
         )
         .as_str(),
     )
@@ -152,14 +179,13 @@ fn test_cmd_ingest_on_non_existing_file() -> Result<()> {
     create_logs_index(&test_env);
     make_command(
         format!(
-            "index ingest --index-id {} --input-path {} --metastore-uri {} --data-dir-path {}",
+            "index ingest --index {} --input-path {} --config {}",
             test_env.index_id,
             test_env
                 .data_dir_path
                 .join("file-does-not-exist.json")
                 .display(),
-            &test_env.metastore_uri,
-            test_env.data_dir_path.display()
+            &test_env.resource_files["config"].display(),
         )
         .as_str(),
     )
@@ -175,21 +201,15 @@ fn test_cmd_ingest_simple() -> Result<()> {
     let test_env = create_test_env(index_id, TestStorageType::LocalFileSystem)?;
     create_logs_index(&test_env);
 
-    ingest_docs(
-        &test_env.index_id,
-        test_env.resource_files["logs"].as_path(),
-        &test_env.metastore_uri,
-        test_env.data_dir_path.as_path(),
-    );
+    ingest_docs(test_env.resource_files["logs"].as_path(), &test_env);
 
     // Using piped input
     let log_path = test_env.resource_files["logs"].clone();
     make_command(
         format!(
-            "index ingest --index-id {} --metastore-uri {} --data-dir-path {}",
+            "index ingest --index {} --config {}",
             test_env.index_id,
-            test_env.metastore_uri,
-            test_env.data_dir_path.display()
+            test_env.resource_files["config"].display(),
         )
         .as_str(),
     )
@@ -208,17 +228,13 @@ fn test_cmd_search() -> Result<()> {
     let test_env = create_test_env(index_id, TestStorageType::LocalFileSystem)?;
     create_logs_index(&test_env);
 
-    ingest_docs(
-        &test_env.index_id,
-        test_env.resource_files["logs"].as_path(),
-        &test_env.metastore_uri,
-        test_env.data_dir_path.as_path(),
-    );
+    ingest_docs(test_env.resource_files["logs"].as_path(), &test_env);
 
     make_command(
         format!(
-            "index search --index-id {} --metastore-uri {} --query level:info",
-            test_env.index_id, test_env.metastore_uri,
+            "index search --index {} --config {} --query level:info",
+            test_env.index_id,
+            test_env.resource_files["config"].display(),
         )
         .as_str(),
     )
@@ -234,10 +250,10 @@ fn test_cmd_search() -> Result<()> {
     crate::helpers::make_command_with_list_of_args(&[
         "index",
         "search",
-        "--index-id",
+        "--index",
         &test_env.index_id,
-        "--metastore-uri",
-        &test_env.metastore_uri,
+        "--config",
+        &test_env.resource_files["config"].display().to_string(),
         "--query",
         "+level:info +city:paris",
     ])
@@ -252,10 +268,10 @@ fn test_cmd_search() -> Result<()> {
     crate::helpers::make_command_with_list_of_args(&[
         "index",
         "search",
-        "--index-id",
+        "--index",
         &test_env.index_id,
-        "--metastore-uri",
-        &test_env.metastore_uri,
+        "--config",
+        &test_env.resource_files["config"].display().to_string(),
         "--query",
         "level:info AND city:conakry",
     ])
@@ -278,8 +294,9 @@ fn test_cmd_delete_index_dry_run() -> Result<()> {
     // Empty index.
     make_command(
         format!(
-            "index delete --index-id {} --metastore-uri {} --dry-run",
-            test_env.index_id, test_env.metastore_uri
+            "index delete --index {} --config {} --dry-run",
+            test_env.index_id,
+            test_env.resource_files["config"].display(),
         )
         .as_str(),
     )
@@ -287,18 +304,14 @@ fn test_cmd_delete_index_dry_run() -> Result<()> {
     .success()
     .stdout(predicate::str::contains("Only the index will be deleted"));
 
-    ingest_docs(
-        &test_env.index_id,
-        test_env.resource_files["logs"].as_path(),
-        &test_env.metastore_uri,
-        test_env.data_dir_path.as_path(),
-    );
+    ingest_docs(test_env.resource_files["logs"].as_path(), &test_env);
 
     // Non-empty index
     make_command(
         format!(
-            "index delete --index-id {} --metastore-uri {} --dry-run",
-            test_env.index_id, test_env.metastore_uri
+            "index delete --index {} --config {} --dry-run",
+            test_env.index_id,
+            test_env.resource_files["config"].display(),
         )
         .as_str(),
     )
@@ -318,16 +331,12 @@ async fn test_cmd_delete() -> Result<()> {
     let test_env = create_test_env(index_id, TestStorageType::LocalFileSystem)?;
     create_logs_index(&test_env);
 
-    ingest_docs(
-        &test_env.index_id,
-        test_env.resource_files["logs"].as_path(),
-        &test_env.metastore_uri,
-        test_env.data_dir_path.as_path(),
-    );
+    ingest_docs(test_env.resource_files["logs"].as_path(), &test_env);
     make_command(
         format!(
-            "index gc --index-id {} --metastore-uri {}",
-            test_env.index_id, test_env.metastore_uri
+            "index gc --index {} --config {}",
+            test_env.index_id,
+            test_env.resource_files["config"].display()
         )
         .as_str(),
     )
@@ -339,8 +348,9 @@ async fn test_cmd_delete() -> Result<()> {
 
     make_command(
         format!(
-            "index delete --index-id {} --metastore-uri {}",
-            test_env.index_id, test_env.metastore_uri
+            "index delete --index {} --config {}",
+            test_env.index_id,
+            test_env.resource_files["config"].display(),
         )
         .as_str(),
     )
@@ -359,12 +369,7 @@ async fn test_cmd_garbage_collect_no_grace() -> Result<()> {
     let index_id = append_random_suffix("test-gc-cmd--no-grace-period");
     let test_env = create_test_env(index_id, TestStorageType::LocalFileSystem)?;
     create_logs_index(&test_env);
-    ingest_docs(
-        &test_env.index_id,
-        test_env.resource_files["logs"].as_path(),
-        &test_env.metastore_uri,
-        test_env.data_dir_path.as_path(),
-    );
+    ingest_docs(test_env.resource_files["logs"].as_path(), &test_env);
 
     let metastore = quickwit_metastore_uri_resolver()
         .resolve(&test_env.metastore_uri)
@@ -384,8 +389,9 @@ async fn test_cmd_garbage_collect_no_grace() -> Result<()> {
     assert_eq!(splits.len(), 1);
     make_command(
         format!(
-            "index gc --index-id {} --metastore-uri {}",
-            test_env.index_id, test_env.metastore_uri
+            "index gc --index {} --config {}",
+            test_env.index_id,
+            test_env.resource_files["config"].display(),
         )
         .as_str(),
     )
@@ -406,8 +412,9 @@ async fn test_cmd_garbage_collect_no_grace() -> Result<()> {
 
     make_command(
         format!(
-            "index gc --index-id {} --metastore-uri {} --dry-run --grace-period 10m",
-            test_env.index_id, test_env.metastore_uri,
+            "index gc --index {} --config {} --dry-run --grace-period 10m",
+            test_env.index_id,
+            test_env.resource_files["config"].display(),
         )
         .as_str(),
     )
@@ -426,8 +433,9 @@ async fn test_cmd_garbage_collect_no_grace() -> Result<()> {
 
     make_command(
         format!(
-            "index gc --index-id {} --metastore-uri {} --grace-period 10m",
-            test_env.index_id, test_env.metastore_uri
+            "index gc --index {} --config {} --grace-period 10m",
+            test_env.index_id,
+            test_env.resource_files["config"].display(),
         )
         .as_str(),
     )
@@ -452,8 +460,9 @@ async fn test_cmd_garbage_collect_no_grace() -> Result<()> {
 
     make_command(
         format!(
-            "index delete --index-id {} --metastore-uri {}",
-            test_env.index_id, test_env.metastore_uri
+            "index delete --index {} --config {}",
+            test_env.index_id,
+            test_env.resource_files["config"].display(),
         )
         .as_str(),
     )
@@ -468,20 +477,16 @@ async fn test_cmd_garbage_collect_spares_files_within_grace_period() -> Result<(
     let index_id = append_random_suffix("test-gc-cmd");
     let test_env = create_test_env(index_id, TestStorageType::LocalFileSystem)?;
     create_logs_index(&test_env);
-    ingest_docs(
-        &test_env.index_id,
-        test_env.resource_files["logs"].as_path(),
-        &test_env.metastore_uri,
-        test_env.data_dir_path.as_path(),
-    );
+    ingest_docs(test_env.resource_files["logs"].as_path(), &test_env);
 
     let metastore = test_env.metastore();
     let splits = metastore.list_all_splits(&test_env.index_id).await?;
     assert_eq!(splits.len(), 1);
     make_command(
         format!(
-            "index gc --index-id {} --metastore-uri {}",
-            test_env.index_id, test_env.metastore_uri
+            "index gc --index {} --config {}",
+            test_env.index_id,
+            test_env.resource_files["config"].display(),
         )
         .as_str(),
     )
@@ -513,8 +518,9 @@ async fn test_cmd_garbage_collect_spares_files_within_grace_period() -> Result<(
 
     make_command(
         format!(
-            "index gc --index-id {} --metastore-uri {} --grace-period 2s",
-            test_env.index_id, test_env.metastore_uri
+            "index gc --index {} --config {} --grace-period 2s",
+            test_env.index_id,
+            test_env.resource_files["config"].display(),
         )
         .as_str(),
     )
@@ -530,8 +536,9 @@ async fn test_cmd_garbage_collect_spares_files_within_grace_period() -> Result<(
     sleep(Duration::from_secs(3)).await;
     make_command(
         format!(
-            "index gc --index-id {} --metastore-uri {} --dry-run --grace-period 2s",
-            test_env.index_id, test_env.metastore_uri,
+            "index gc --index {} --config {} --dry-run --grace-period 2s",
+            test_env.index_id,
+            test_env.resource_files["config"].display(),
         )
         .as_str(),
     )
@@ -545,8 +552,9 @@ async fn test_cmd_garbage_collect_spares_files_within_grace_period() -> Result<(
 
     make_command(
         format!(
-            "index gc --index-id {} --metastore-uri {} --grace-period 2s",
-            test_env.index_id, test_env.metastore_uri
+            "index gc --index {} --config {} --grace-period 2s",
+            test_env.index_id,
+            test_env.resource_files["config"].display(),
         )
         .as_str(),
     )
@@ -568,8 +576,10 @@ async fn test_cmd_dry_run_delete_on_s3_localstack() -> Result<()> {
     let test_env = create_test_env(index_id, TestStorageType::S3)?;
     make_command(
         format!(
-            "index create --metastore-uri {} --index-config-uri {}",
-            test_env.metastore_uri,
+            "index create --index {} --index-uri {} --config {} --index-config {}",
+            test_env.index_id,
+            test_env.index_uri(),
+            test_env.resource_files["config"].display(),
             test_env.resource_files["index_config"].display()
         )
         .as_str(),
@@ -577,17 +587,13 @@ async fn test_cmd_dry_run_delete_on_s3_localstack() -> Result<()> {
     .assert()
     .success();
 
-    ingest_docs(
-        &test_env.index_id,
-        test_env.resource_files["logs"].as_path(),
-        &test_env.metastore_uri,
-        test_env.data_dir_path.as_path(),
-    );
+    ingest_docs(test_env.resource_files["logs"].as_path(), &test_env);
 
     make_command(
         format!(
-            "index gc --index-id {} --metastore-uri {}",
-            test_env.index_id, test_env.metastore_uri
+            "index gc --index {} --config {}",
+            test_env.index_id,
+            test_env.resource_files["config"].display(),
         )
         .as_str(),
     )
@@ -599,8 +605,9 @@ async fn test_cmd_dry_run_delete_on_s3_localstack() -> Result<()> {
 
     make_command(
         format!(
-            "index delete --index-id {} --metastore-uri {} --dry-run",
-            test_env.index_id, test_env.metastore_uri
+            "index delete --index {} --config {} --dry-run",
+            test_env.index_id,
+            test_env.resource_files["config"].display(),
         )
         .as_str(),
     )
@@ -613,8 +620,9 @@ async fn test_cmd_dry_run_delete_on_s3_localstack() -> Result<()> {
 
     make_command(
         format!(
-            "index delete --index-id {} --metastore-uri {}",
-            test_env.index_id, test_env.metastore_uri
+            "index delete --index {} --config {}",
+            test_env.index_id,
+            test_env.resource_files["config"].display(),
         )
         .as_str(),
     )
@@ -632,9 +640,11 @@ async fn test_all_local_index() -> Result<()> {
     let test_env = create_test_env(index_id, TestStorageType::LocalFileSystem)?;
     make_command(
         format!(
-            "index create --metastore-uri {} --index-config-uri {}",
-            test_env.metastore_uri,
-            test_env.resource_files["index_config"].display()
+            "index create --index {} --index-uri {} --index-config {} --config {}",
+            test_env.index_id,
+            test_env.index_uri(),
+            test_env.resource_files["index_config"].display(),
+            test_env.resource_files["config"].display()
         )
         .as_str(),
     )
@@ -647,18 +657,13 @@ async fn test_all_local_index() -> Result<()> {
         .await?;
     assert_eq!(metadata_file_exists, true);
 
-    ingest_docs(
-        &test_env.index_id,
-        test_env.resource_files["logs"].as_path(),
-        &test_env.metastore_uri,
-        test_env.data_dir_path.as_path(),
-    );
+    ingest_docs(test_env.resource_files["logs"].as_path(), &test_env);
 
     // serve & api-search
     let mut server_process = spawn_command(
         format!(
-            "service run searcher --server-config-uri {}",
-            test_env.resource_files["server_config"].display(),
+            "service run searcher --config {}",
+            test_env.resource_files["config"].display(),
         )
         .as_str(),
     )
@@ -673,7 +678,8 @@ async fn test_all_local_index() -> Result<()> {
         .take(800)
         .read_to_string(&mut process_stdout_output)
         .expect("Failed to read 800 bytes from process stdout.");
-    assert!(process_stdout_output.contains("http://127.0.0.1:"));
+    println!("{}", process_stdout_output);
+    assert!(process_stdout_output.contains("Searcher ready to accept"));
 
     let query_response = reqwest::get(format!(
         "http://127.0.0.1:{}/api/v1/{}/search?query=level:info",
@@ -701,8 +707,9 @@ async fn test_all_local_index() -> Result<()> {
 
     make_command(
         format!(
-            "index delete --index-id {} --metastore-uri {}",
-            test_env.index_id, test_env.metastore_uri
+            "index delete --index {} --config {}",
+            test_env.index_id,
+            test_env.resource_files["config"].display()
         )
         .as_str(),
     )
@@ -726,9 +733,11 @@ async fn test_all_with_s3_localstack_cli() -> Result<()> {
     let test_env = create_test_env(index_id, TestStorageType::S3)?;
     make_command(
         format!(
-            "index create --metastore-uri {} --index-config-uri {}",
-            test_env.metastore_uri,
-            test_env.resource_files["index_config"].display()
+            "index create --index {} --index-uri {} --index-config {} --config {}",
+            test_env.index_id,
+            test_env.index_uri(),
+            test_env.resource_files["index_config"].display(),
+            test_env.resource_files["config"].display()
         )
         .as_str(),
     )
@@ -741,18 +750,14 @@ async fn test_all_with_s3_localstack_cli() -> Result<()> {
         .await;
     assert_eq!(index_metadata.is_ok(), true);
 
-    ingest_docs(
-        &test_env.index_id,
-        test_env.resource_files["logs"].as_path(),
-        &test_env.metastore_uri,
-        test_env.data_dir_path.as_path(),
-    );
+    ingest_docs(test_env.resource_files["logs"].as_path(), &test_env);
 
     // cli search
     make_command(
         format!(
-            "index search --index-id {} --metastore-uri {} --query level:info",
-            test_env.index_id, test_env.metastore_uri,
+            "index search --index {} --query level:info --config {}",
+            test_env.index_id,
+            test_env.resource_files["config"].display(),
         )
         .as_str(),
     )
@@ -767,8 +772,8 @@ async fn test_all_with_s3_localstack_cli() -> Result<()> {
     // TODO: ditto.
     let mut server_process = spawn_command(
         format!(
-            "service run searcher --server-config-uri {}",
-            test_env.resource_files["server_config"].display(),
+            "service run searcher --config {}",
+            test_env.resource_files["config"].display(),
         )
         .as_str(),
     )
@@ -783,7 +788,7 @@ async fn test_all_with_s3_localstack_cli() -> Result<()> {
         .take(800)
         .read_to_string(&mut process_stdout_output)
         .expect("Failed to read 800 bytes from process stdout.");
-    assert!(process_stdout_output.contains("http://127.0.0.1:"));
+    assert!(process_stdout_output.contains("Searcher ready to accept"));
 
     let query_response = reqwest::get(format!(
         "http://127.0.0.1:{}/api/v1/{}/search?query=level:info",
@@ -792,7 +797,6 @@ async fn test_all_with_s3_localstack_cli() -> Result<()> {
     .await?
     .text()
     .await?;
-
     let result: Value =
         serde_json::from_str(&query_response).expect("Couldn't deserialize response.");
     assert_eq!(result["numHits"], Value::Number(Number::from(2i64)));
@@ -801,8 +805,9 @@ async fn test_all_with_s3_localstack_cli() -> Result<()> {
 
     make_command(
         format!(
-            "index delete --index-id {} --metastore-uri {}",
-            test_env.index_id, test_env.metastore_uri
+            "index delete --index {} --config {}",
+            test_env.index_id,
+            test_env.resource_files["config"].display()
         )
         .as_str(),
     )
@@ -827,12 +832,13 @@ async fn test_all_with_s3_localstack_internal_api() -> Result<()> {
     let index_id = append_random_suffix("test-all--cli-API");
     let test_env = create_test_env(index_id, TestStorageType::S3)?;
     let args = CreateIndexArgs {
-        metastore_uri: test_env.metastore_uri.clone(),
-        index_config_uri: test_env.resource_files["index_config"]
-            .to_str()
-            .unwrap()
-            .to_string(),
+        index_id: test_env.index_id.clone(),
+        index_uri: Some(test_env.index_uri()),
+        index_config_uri: Uri::try_new(test_env.resource_files["index_config"].to_str().unwrap())
+            .unwrap(),
+        config_uri: Uri::try_new(&test_env.resource_files["config"].display().to_string()).unwrap(),
         overwrite: false,
+        data_dir: None,
     };
     create_index_cli(args).await?;
     let index_metadata = test_env
@@ -840,18 +846,14 @@ async fn test_all_with_s3_localstack_internal_api() -> Result<()> {
         .index_metadata(&test_env.index_id)
         .await;
     assert_eq!(index_metadata.is_ok(), true);
-    ingest_docs(
-        &test_env.index_id,
-        test_env.resource_files["logs"].as_path(),
-        &test_env.metastore_uri,
-        test_env.data_dir_path.as_path(),
-    );
+    ingest_docs(test_env.resource_files["logs"].as_path(), &test_env);
 
     // cli search
     make_command(
         format!(
-            "index search --index-id {} --metastore-uri {} --query level:info",
-            test_env.index_id, test_env.metastore_uri,
+            "index search --index {} --query level:info --config {}",
+            test_env.index_id,
+            test_env.resource_files["config"].display(),
         )
         .as_str(),
     )
@@ -866,8 +868,8 @@ async fn test_all_with_s3_localstack_internal_api() -> Result<()> {
     // TODO: ditto.
     let mut server_process = spawn_command(
         format!(
-            "service run searcher --server-config-uri {}",
-            test_env.resource_files["server_config"].display(),
+            "service run searcher --config {}",
+            test_env.resource_files["config"].display(),
         )
         .as_str(),
     )
@@ -882,8 +884,6 @@ async fn test_all_with_s3_localstack_internal_api() -> Result<()> {
         .take(800)
         .read_to_string(&mut process_stdout_output)
         .expect("Failed to read 800 bytes from process stdout.");
-    assert!(process_stdout_output.contains("http://127.0.0.1:"));
-
     let query_response = reqwest::get(format!(
         "http://127.0.0.1:{}/api/v1/{}/search?query=level:info",
         test_env.searcher_rest_listen_port, test_env.index_id,
@@ -891,16 +891,17 @@ async fn test_all_with_s3_localstack_internal_api() -> Result<()> {
     .await?
     .text()
     .await?;
+    server_process.kill().unwrap();
+    assert!(process_stdout_output.contains("Searcher ready to accept"));
     let result: Value =
         serde_json::from_str(&query_response).expect("Couldn't deserialize response.");
     assert_eq!(result["numHits"], Value::Number(Number::from(2i64)));
 
-    server_process.kill().unwrap();
-
     make_command(
         format!(
-            "index delete --index-id {} --metastore-uri {}",
-            test_env.index_id, test_env.metastore_uri
+            "index delete --index {} --config {}",
+            test_env.index_id,
+            test_env.resource_files["config"].display(),
         )
         .as_str(),
     )

--- a/quickwit-cli/tests/helpers.rs
+++ b/quickwit-cli/tests/helpers.rs
@@ -27,6 +27,7 @@ use assert_cmd::cargo::cargo_bin;
 use assert_cmd::Command;
 use predicates::str;
 use quickwit_common::net::find_available_port;
+use quickwit_common::uri::Uri;
 use quickwit_metastore::FileBackedMetastore;
 use quickwit_storage::{LocalFileStorage, RegionProvider, S3CompatibleObjectStorage, Storage};
 use tempfile::{tempdir, TempDir};
@@ -69,19 +70,17 @@ const DEFAULT_INDEX_CONFIG: &str = r#"
       default_search_fields: [event]
 "#;
 
-const DEFAULT_SERVER_CONFIG: &str = r#"
+const DEFAULT_QUICKWIT_CONFIG: &str = r#"
     version: 0
     metastore_uri: #metastore_uri
+    data_dir_path: #data_dir_path
 
     indexer:
-      data_dir_path: #data_dir_path
       rest_listen_port: #indexer.rest_listen_port
       grpc_listen_port: #indexer.grpc_listen_port
       discovery_listen_port: #indexer.discovery_listen_port
 
     searcher:
-      data_dir_path: #data_dir_path
-      host_key_path: #data_dir_path/host_key
       rest_listen_port: #searcher.rest_listen_port
       grpc_listen_port: #searcher.grpc_listen_port
       discovery_listen_port: #searcher.discovery_listen_port
@@ -162,6 +161,10 @@ impl TestEnv {
     pub fn metastore(&self) -> FileBackedMetastore {
         FileBackedMetastore::new(self.storage.clone())
     }
+
+    pub fn index_uri(&self) -> Uri {
+        Uri::try_new(&format!("{}/{}", self.metastore_uri, self.index_id)).unwrap()
+    }
 }
 
 pub enum TestStorageType {
@@ -206,16 +209,16 @@ pub fn create_test_env(index_id: String, storage_type: TestStorageType) -> anyho
             .replace("#index_id", &index_id)
             .replace("#index_uri", &index_uri),
     )?;
-    let server_config_path = resources_dir_path.join("server_config.yaml");
+    let quickwit_config_path = resources_dir_path.join("config.yaml");
     let init_listen_port = find_available_port()?;
     let listen_ports = (0..6)
         .map(|i| init_listen_port + i)
         .map(|port| port.to_string())
         .collect::<Vec<String>>();
     fs::write(
-        &server_config_path,
+        &quickwit_config_path,
         // A poor's man templating engine reloaded...
-        DEFAULT_SERVER_CONFIG
+        DEFAULT_QUICKWIT_CONFIG
             .replace("#metastore_uri", &metastore_uri)
             .replace(
                 "#data_dir_path",
@@ -234,8 +237,8 @@ pub fn create_test_env(index_id: String, storage_type: TestStorageType) -> anyho
     fs::write(&wikipedia_docs_path, WIKI_JSON_DOCS)?;
 
     let mut resource_files = HashMap::new();
+    resource_files.insert("config", quickwit_config_path);
     resource_files.insert("index_config", index_config_path);
-    resource_files.insert("server_config", server_config_path);
     resource_files.insert("logs", log_docs_path);
     resource_files.insert("wiki", wikipedia_docs_path);
 

--- a/quickwit-cluster/src/cluster.rs
+++ b/quickwit-cluster/src/cluster.rs
@@ -17,9 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use std::fs;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
@@ -42,56 +40,11 @@ const CLUSTER_ID: &str = "quickwit-cluster";
 
 const CLUSTER_EVENT_TIMEOUT: Duration = Duration::from_millis(200);
 
-/// Reads the key that makes a node unique from the given file.
-/// If the file does not exist, it generates an ID and writes it to the file
-/// so that it can be reused on reboot.
-pub fn read_or_create_host_key(host_key_path: &Path) -> ClusterResult<Uuid> {
-    let host_key;
-
-    if host_key_path.exists() {
-        let host_key_contents =
-            fs::read(host_key_path).map_err(|err| ClusterError::ReadHostKeyError {
-                message: err.to_string(),
-            })?;
-        host_key = Uuid::from_slice(host_key_contents.as_slice()).map_err(|err| {
-            ClusterError::ReadHostKeyError {
-                message: err.to_string(),
-            }
-        })?;
-        info!(host_key=?host_key, host_key_path=?host_key_path, "Read existing host key.");
-    } else {
-        if let Some(dir) = host_key_path.parent() {
-            if !dir.exists() {
-                fs::create_dir_all(dir).map_err(|err| ClusterError::WriteHostKeyError {
-                    message: format!(
-                        "Directory `{}` does not exists. Failed to create it with err={:?}",
-                        dir.display(),
-                        err
-                    ),
-                })?;
-            }
-        }
-        host_key = Uuid::new_v4();
-        fs::write(host_key_path, host_key.as_bytes()).map_err(|err| {
-            ClusterError::WriteHostKeyError {
-                message: format!(
-                    "IO Error upon writing into `{}`: {:?}.",
-                    host_key_path.display(),
-                    err
-                ),
-            }
-        })?;
-        info!(host_key=?host_key, host_key_path=?host_key_path, "Create new host key.");
-    }
-
-    Ok(host_key)
-}
-
 /// A member information.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Member {
     /// An ID that makes a member unique.
-    pub host_key: Uuid,
+    pub node_id: String,
 
     /// Listen address.
     pub listen_addr: SocketAddr,
@@ -122,23 +75,25 @@ impl Cluster {
     /// Create a cluster given a host key and a listen address.
     /// When a cluster is created, the thread that monitors cluster events
     /// will be started at the same time.
-    pub fn new(host_key: Uuid, listen_addr: SocketAddr) -> ClusterResult<Self> {
-        info!( host_key=?host_key, listen_addr=?listen_addr, "Create new cluster.");
+    pub fn new(node_id: String, listen_addr: SocketAddr) -> ClusterResult<Self> {
+        info!( node_id=?node_id, listen_addr=?listen_addr, "Create new cluster.");
         let config = ArtilleryClusterConfig {
             cluster_key: CLUSTER_ID.as_bytes().to_vec(),
             listen_addr,
             ..Default::default()
         };
         let (artillery_cluster, swim_event_rx) =
-            ArtilleryCluster::create_and_start(host_key, config).map_err(|err| match err {
-                ArtilleryError::Io(io_err) => ClusterError::UDPPortBindingError {
-                    port: listen_addr.port(),
-                    message: io_err.to_string(),
+            ArtilleryCluster::create_and_start(node_id.clone(), config).map_err(
+                |err| match err {
+                    ArtilleryError::Io(io_err) => ClusterError::UDPPortBindingError {
+                        port: listen_addr.port(),
+                        message: io_err.to_string(),
+                    },
+                    _ => ClusterError::CreateClusterError {
+                        message: err.to_string(),
+                    },
                 },
-                _ => ClusterError::CreateClusterError {
-                    message: err.to_string(),
-                },
-            })?;
+            )?;
 
         let (members_sender, members_receiver) = watch::channel(Vec::new());
 
@@ -152,7 +107,7 @@ impl Cluster {
 
         // Add itself as the initial member of the cluster.
         let member = Member {
-            host_key,
+            node_id,
             listen_addr,
             is_self: true,
         };
@@ -258,7 +213,7 @@ fn convert_member(member: ArtilleryMember, self_listen_addr: SocketAddr) -> Memb
     };
 
     Member {
-        host_key: member.host_key(),
+        node_id: member.node_id(),
         listen_addr,
         is_self: member.is_current(),
     }
@@ -268,29 +223,29 @@ fn convert_member(member: ArtilleryMember, self_listen_addr: SocketAddr) -> Memb
 fn log_artillery_event(artillery_member_event: ArtilleryMemberEvent) {
     match artillery_member_event {
         ArtilleryMemberEvent::Joined(artillery_member) => {
-            info!(host_key=?artillery_member.host_key(), remote_host=?artillery_member.remote_host(), "Joined.");
+            info!(node_id=?artillery_member.node_id(), remote_host=?artillery_member.remote_host(), "Joined.");
         }
         ArtilleryMemberEvent::WentUp(artillery_member) => {
-            info!(host_key=?artillery_member.host_key(), remote_host=?artillery_member.remote_host(), "Went up.");
+            info!(node_id=?artillery_member.node_id(), remote_host=?artillery_member.remote_host(), "Went up.");
         }
         ArtilleryMemberEvent::SuspectedDown(artillery_member) => {
-            warn!(host_key=?artillery_member.host_key(), remote_host=?artillery_member.remote_host(), "Suspected down.");
+            warn!(node_id=?artillery_member.node_id(), remote_host=?artillery_member.remote_host(), "Suspected down.");
         }
         ArtilleryMemberEvent::WentDown(artillery_member) => {
-            error!(host_key=?artillery_member.host_key(), remote_host=?artillery_member.remote_host(), "Went down.");
+            error!(node_id=?artillery_member.node_id(), remote_host=?artillery_member.remote_host(), "Went down.");
         }
         ArtilleryMemberEvent::Left(artillery_member) => {
-            info!(host_key=?artillery_member.host_key(), remote_host=?artillery_member.remote_host(), "Left.");
+            info!(node_id=?artillery_member.node_id(), remote_host=?artillery_member.remote_host(), "Left.");
         }
         ArtilleryMemberEvent::Payload(artillery_member, message) => {
-            info!(host_key=?artillery_member.host_key(), remote_host=?artillery_member.remote_host(), message=?message, "Payload.");
+            info!(node_id=?artillery_member.node_id(), remote_host=?artillery_member.remote_host(), message=?message, "Payload.");
         }
     };
 }
 
 /// Creates a local cluster listening on a random port.
 pub fn create_cluster_for_test() -> anyhow::Result<Cluster> {
-    let peer_uuid = Uuid::new_v4();
+    let peer_uuid = Uuid::new_v4().to_string();
     let port = quickwit_common::net::find_available_port()?;
     let peer_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), port);
     let cluster = Cluster::new(peer_uuid, peer_addr)?;
@@ -306,45 +261,29 @@ mod tests {
     use quickwit_swim::prelude::{ArtilleryMember, ArtilleryMemberState};
 
     use super::*;
-    use crate::cluster::{convert_member, read_or_create_host_key, Member};
-
-    #[tokio::test]
-    async fn test_cluster_read_host_key() {
-        let tmp_dir = tempfile::tempdir().unwrap();
-        let host_key_path = tmp_dir.path().join("host_key");
-
-        // Since the directory does not exist, generate UUID on the specified host_key_path.
-        let host_key1 = read_or_create_host_key(host_key_path.as_path()).unwrap();
-
-        // Read the generated UUID.
-        let host_key2 = read_or_create_host_key(host_key_path.as_path()).unwrap();
-
-        assert_eq!(host_key1, host_key2);
-    }
+    use crate::cluster::{convert_member, Member};
 
     #[tokio::test]
     async fn test_cluster_convert_member() {
-        let tmp_dir = tempfile::tempdir().unwrap();
-        let host_key_path = tmp_dir.path().join("host_key");
-        let host_key = read_or_create_host_key(host_key_path.as_path()).unwrap();
+        let node_id = Uuid::new_v4().to_string();
         let remote_host = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0);
         {
             let artillery_member =
-                ArtilleryMember::new(host_key, remote_host, 0, ArtilleryMemberState::Alive);
+                ArtilleryMember::new(node_id.clone(), remote_host, 0, ArtilleryMemberState::Alive);
 
             let member = convert_member(artillery_member, remote_host);
             let expected_member = Member {
-                host_key,
+                node_id: node_id.clone(),
                 listen_addr: remote_host,
                 is_self: false,
             };
             assert_eq!(member, expected_member);
         }
         {
-            let artillery_member = ArtilleryMember::current(host_key);
+            let artillery_member = ArtilleryMember::current(node_id.clone());
             let member = convert_member(artillery_member, remote_host);
             let expected_member = Member {
-                host_key,
+                node_id,
                 listen_addr: remote_host,
                 is_self: true,
             };

--- a/quickwit-cluster/src/error.rs
+++ b/quickwit-cluster/src/error.rs
@@ -39,16 +39,16 @@ pub enum ClusterError {
         message: String,
     },
 
-    /// Read host key error.
-    #[error("Failed to read host key: `{message}`")]
-    ReadHostKeyError {
+    /// Read host ID error.
+    #[error("Failed to read host ID: `{message}`")]
+    ReadHostIdError {
         /// Underlying error message.
         message: String,
     },
 
-    /// Write host key error.
-    #[error("Failed to write host key: `{message}`")]
-    WriteHostKeyError {
+    /// Write host ID error.
+    #[error("Failed to write host ID: `{message}`")]
+    WriteHostIdError {
         /// Underlying error message.
         message: String,
     },
@@ -59,8 +59,8 @@ impl From<ClusterError> for tonic::Status {
         let code = match error {
             ClusterError::CreateClusterError { .. } => tonic::Code::Internal,
             ClusterError::UDPPortBindingError { .. } => tonic::Code::PermissionDenied,
-            ClusterError::ReadHostKeyError { .. } => tonic::Code::Internal,
-            ClusterError::WriteHostKeyError { .. } => tonic::Code::Internal,
+            ClusterError::ReadHostIdError { .. } => tonic::Code::Internal,
+            ClusterError::WriteHostIdError { .. } => tonic::Code::Internal,
         };
         let message = error.to_string();
         tonic::Status::new(code, message)

--- a/quickwit-cluster/src/service.rs
+++ b/quickwit-cluster/src/service.rs
@@ -32,7 +32,7 @@ use crate::error::ClusterError;
 impl From<Member> for PMember {
     fn from(member: Member) -> Self {
         PMember {
-            id: member.host_key.to_string(),
+            id: member.node_id.to_string(),
             listen_address: member.listen_addr.to_string(),
             is_self: member.is_self,
         }
@@ -101,12 +101,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_cluster_convert_proto_member() {
-        let host_key = Uuid::new_v4();
+        let host_id = Uuid::new_v4().to_string();
         let listen_addr = "localhost:12345".to_socket_addrs().unwrap().next().unwrap();
         let is_self = true;
 
         let member = Member {
-            host_key,
+            node_id: host_id.clone(),
             listen_addr,
             is_self,
         };
@@ -116,7 +116,7 @@ mod tests {
         println!("proto_member={:?}", proto_member);
 
         let expected = PMember {
-            id: host_key.to_string(),
+            id: host_id,
             listen_address: listen_addr.to_string(),
             is_self,
         };

--- a/quickwit-common/src/uri.rs
+++ b/quickwit-common/src/uri.rs
@@ -29,7 +29,7 @@ const FILE_PROTOCOL: &str = "file";
 const PROTOCOL_SEPARATOR: &str = "://";
 
 /// Encapsulates the URI type.
-#[derive(Debug, PartialEq, Eq, Hash)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct Uri {
     uri: String,
     protocol_idx: usize,

--- a/quickwit-config/resources/tests/config/quickwit.json
+++ b/quickwit-config/resources/tests/config/quickwit.json
@@ -1,17 +1,16 @@
 # Comments are supported.
 {
     "version": 0,
+    "node_id": "my-unique-node-id",
     "metastore_uri": "postgres://username:password@host:port/db",
+    "data_dir_path": "/opt/quickwit/data",
     "indexer": {
-        "data_dir_path": "/opt/quickwit/data",
         "rest_listen_address": "0.0.0.0",
         "rest_listen_port": 1111,
         "split_store_max_num_bytes": "1T",
         "split_store_max_num_splits": 10000
     },
     "searcher": {
-        "data_dir_path": "/opt/quickwit/data",
-        "host_key_path": "/opt/quickwit/host_key",
         "rest_listen_address": "0.0.0.0",
         "rest_listen_port": 11111,
         "peer_seeds": [

--- a/quickwit-config/resources/tests/config/quickwit.toml
+++ b/quickwit-config/resources/tests/config/quickwit.toml
@@ -1,16 +1,15 @@
 version = 0
+node_id = "my-unique-node-id"
 metastore_uri = "postgres://username:password@host:port/db"
+data_dir_path = "/opt/quickwit/data"
 
 [indexer]
-data_dir_path = "/opt/quickwit/data"
 rest_listen_address = "0.0.0.0"
 rest_listen_port = 1111
 split_store_max_num_bytes = "1T"
 split_store_max_num_splits = 10_000
 
 [searcher]
-data_dir_path = "/opt/quickwit/data"
-host_key_path = "/opt/quickwit/host_key"
 rest_listen_address = "0.0.0.0"
 rest_listen_port = 11111
 peer_seeds = [ "quickwit-searcher-0.local", "quickwit-searcher-1.local" ]

--- a/quickwit-config/resources/tests/config/quickwit.yaml
+++ b/quickwit-config/resources/tests/config/quickwit.yaml
@@ -1,14 +1,13 @@
 version: 0
+node_id: my-unique-node-id
 metastore_uri: postgres://username:password@host:port/db
+data_dir_path: /opt/quickwit/data
 indexer:
-  data_dir_path: /opt/quickwit/data
   rest_listen_address: 0.0.0.0
   rest_listen_port: 1111
   split_store_max_num_bytes: 1T
   split_store_max_num_splits: 10000
 searcher:
-  data_dir_path: /opt/quickwit/data
-  host_key_path: /opt/quickwit/host_key
   rest_listen_address: 0.0.0.0
   rest_listen_port: 11111
   peer_seeds:

--- a/quickwit-config/resources/tests/index_config/hdfs-logs-create-config.yaml
+++ b/quickwit-config/resources/tests/index_config/hdfs-logs-create-config.yaml
@@ -6,6 +6,7 @@ doc_mapping:
       type: text
       tokenizer: default
       record: position
+    - name: timestamp
+      type: i64
+      fast: true
 
-search_settings:
-  default_search_fields: [body]

--- a/quickwit-config/resources/tests/index_config/hdfs-logs.json
+++ b/quickwit-config/resources/tests/index_config/hdfs-logs.json
@@ -1,8 +1,6 @@
 # Comments are supported.
 {
     "version": 0,
-    "index_id": "hdfs-logs",
-    "index_uri": "s3://quickwit-indexes/hdfs-logs",
     "doc_mapping": {
         "field_mappings": [
             {

--- a/quickwit-config/resources/tests/index_config/hdfs-logs.toml
+++ b/quickwit-config/resources/tests/index_config/hdfs-logs.toml
@@ -1,6 +1,4 @@
 version = 0
-index_id = "hdfs-logs"
-index_uri = "s3://quickwit-indexes/hdfs-logs"
 
 [doc_mapping]
 field_mappings = [

--- a/quickwit-config/resources/tests/index_config/partial-hdfs-logs.yaml
+++ b/quickwit-config/resources/tests/index_config/partial-hdfs-logs.yaml
@@ -1,6 +1,4 @@
 version: 0
-index_id: hdfs-logs
-index_uri: s3://quickwit-indexes/hdfs-logs
 
 doc_mapping:
   field_mappings:

--- a/quickwit-config/src/lib.rs
+++ b/quickwit-config/src/lib.rs
@@ -17,11 +17,11 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+mod config;
 mod index_config;
-mod server_config;
 
+pub use config::{IndexerConfig, QuickwitConfig, SearcherConfig};
 pub use index_config::{
     DocMapping, IndexConfig, IndexingResources, IndexingSettings, MergePolicy, SearchSettings,
     SourceConfig,
 };
-pub use server_config::{IndexerConfig, SearcherConfig, ServerConfig};

--- a/quickwit-indexing/src/actors/indexing_pipeline.rs
+++ b/quickwit-indexing/src/actors/indexing_pipeline.rs
@@ -17,6 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -541,13 +542,14 @@ pub struct IndexingPipelineParams {
 
 impl IndexingPipelineParams {
     pub async fn try_new(
+        data_dir_path: &Path,
         index_metadata: IndexMetadata,
         indexer_config: IndexerConfig,
         metastore: Arc<dyn Metastore>,
         storage: Arc<dyn Storage>,
     ) -> anyhow::Result<Self> {
         let doc_mapper = index_metadata.build_doc_mapper()?;
-        let indexing_directory_path = indexer_config.data_dir_path.join(&index_metadata.index_id);
+        let indexing_directory_path = data_dir_path.join(&index_metadata.index_id);
         let indexing_directory = IndexingDirectory::create_in_dir(indexing_directory_path).await?;
         let source_config = index_metadata.source()?;
         Ok(Self {

--- a/quickwit-indexing/src/source/file_source.rs
+++ b/quickwit-indexing/src/source/file_source.rs
@@ -293,22 +293,16 @@ mod tests {
         let (mailbox, inbox) = create_test_mailbox();
         use tempfile::NamedTempFile;
         let mut temp_file = NamedTempFile::new()?;
-        let temp_path = temp_file.path().to_path_buf();
         for i in 0..100 {
             temp_file.write_all(format!("{}\n", i).as_bytes())?;
         }
         temp_file.flush()?;
+        let temp_file_path = temp_file.path().canonicalize()?;
         let params = FileSourceParams {
-            filepath: Some(temp_path.as_path().to_path_buf()),
+            filepath: Some(temp_file_path.clone()),
         };
         let mut checkpoint = Checkpoint::default();
-        let partition_id = PartitionId::from(
-            temp_file
-                .path()
-                .canonicalize()?
-                .to_string_lossy()
-                .to_string(),
-        );
+        let partition_id = PartitionId::from(temp_file_path.to_string_lossy().to_string());
         let checkpoint_delta = CheckpointDelta::from_partition_delta(
             partition_id,
             Position::from(0u64),

--- a/quickwit-indexing/src/test_utils.rs
+++ b/quickwit-indexing/src/test_utils.rs
@@ -114,6 +114,7 @@ impl TestSandbox {
         index_meta.sources = vec![source_config];
         self.add_docs_id.fetch_add(1, Ordering::SeqCst);
         let statistics = index_data(
+            self._temp_dir.path(),
             index_meta,
             self.indexer_config.clone(),
             self.metastore.clone(),

--- a/quickwit-metastore/src/checkpoint.rs
+++ b/quickwit-metastore/src/checkpoint.rs
@@ -275,7 +275,7 @@ impl Checkpoint {
     ///   |  (..a] (b..c] with b > a     | Compatible                  |
     ///   |  (..a] (b..c] with b < a     | Incompatible                |
     ///
-    /// If the delta is compatible, returns an error without modifying the original checkpoint.
+    /// If the delta is incompatible, returns an error without modifying the original checkpoint.
     pub fn try_apply_delta(
         &mut self,
         delta: CheckpointDelta,

--- a/quickwit-storage/src/lib.rs
+++ b/quickwit-storage/src/lib.rs
@@ -74,19 +74,18 @@ pub use crate::cache::{wrap_storage_with_long_term_cache, Cache, MemorySizedCach
 pub use crate::error::{StorageError, StorageErrorKind, StorageResolverError, StorageResult};
 
 /// Loads an entire local or remote file into memory.
-pub async fn load_file(raw_uri: &str) -> anyhow::Result<OwnedBytes> {
-    let uri = Uri::try_new(raw_uri)?;
+pub async fn load_file(uri: &Uri) -> anyhow::Result<OwnedBytes> {
     let path = Path::new(uri.as_ref());
     let parent_uri = path
         .parent()
-        .with_context(|| format!("`{}` is not a valid file URI.", raw_uri))?
+        .with_context(|| format!("`{}` is not a valid file URI.", uri))?
         .to_str()
-        .with_context(|| format!("Failed to convert URI `{}` to str.", raw_uri))?;
+        .with_context(|| format!("Failed to convert URI `{}` to str.", uri))?;
 
     let storage = quickwit_storage_uri_resolver().resolve(parent_uri)?;
     let file_name = path
         .file_name()
-        .with_context(|| format!("`{}` is not a valid file URI.", raw_uri))?;
+        .with_context(|| format!("`{}` is not a valid file URI.", uri))?;
     let bytes = storage.get_all(Path::new(file_name)).await?;
     Ok(bytes)
 }
@@ -99,7 +98,10 @@ mod tests {
     async fn test_load_file() {
         let expected_bytes = tokio::fs::read_to_string("Cargo.toml").await.unwrap();
         assert_eq!(
-            load_file("Cargo.toml").await.unwrap().as_slice(),
+            load_file(&Uri::try_new("Cargo.toml").unwrap())
+                .await
+                .unwrap()
+                .as_slice(),
             expected_bytes.as_bytes()
         );
     }

--- a/quickwit-swim/src/member.rs
+++ b/quickwit-swim/src/member.rs
@@ -5,7 +5,6 @@ use std::net::SocketAddr;
 use std::time::{Duration, Instant};
 
 use serde::*;
-use uuid::Uuid;
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialOrd, Ord, PartialEq, Eq, Copy)]
 pub enum ArtilleryMemberState {
@@ -26,7 +25,7 @@ pub enum ArtilleryMemberState {
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct ArtilleryMember {
     #[serde(rename = "h")]
-    host_key: Uuid,
+    node_id: String,
     #[serde(rename = "r")]
     remote_host: Option<SocketAddr>,
     #[serde(rename = "i")]
@@ -44,13 +43,13 @@ pub struct ArtilleryStateChange {
 
 impl ArtilleryMember {
     pub fn new(
-        host_key: Uuid,
+        host_id: String,
         remote_host: SocketAddr,
         incarnation_number: u64,
         known_state: ArtilleryMemberState,
     ) -> Self {
         ArtilleryMember {
-            host_key,
+            node_id: host_id,
             remote_host: Some(remote_host),
             incarnation_number,
             member_state: known_state,
@@ -58,9 +57,9 @@ impl ArtilleryMember {
         }
     }
 
-    pub fn current(host_key: Uuid) -> Self {
+    pub fn current(node_id: String) -> Self {
         ArtilleryMember {
-            host_key,
+            node_id,
             remote_host: None,
             incarnation_number: 0,
             member_state: ArtilleryMemberState::Alive,
@@ -68,8 +67,8 @@ impl ArtilleryMember {
         }
     }
 
-    pub fn host_key(&self) -> Uuid {
-        self.host_key
+    pub fn node_id(&self) -> String {
+        self.node_id.clone()
     }
 
     pub fn remote_host(&self) -> Option<SocketAddr> {
@@ -128,14 +127,14 @@ impl ArtilleryStateChange {
 impl PartialOrd for ArtilleryMember {
     fn partial_cmp(&self, rhs: &ArtilleryMember) -> Option<Ordering> {
         let t1 = (
-            self.host_key.as_bytes(),
+            self.node_id.as_bytes(),
             format!("{:?}", self.remote_host),
             self.incarnation_number,
             self.member_state,
         );
 
         let t2 = (
-            rhs.host_key.as_bytes(),
+            rhs.node_id.as_bytes(),
             format!("{:?}", rhs.remote_host),
             rhs.incarnation_number,
             rhs.member_state,
@@ -155,7 +154,7 @@ impl Debug for ArtilleryMember {
     fn fmt(&self, fmt: &mut Formatter) -> fmt::Result {
         fmt.debug_struct("ArtilleryMember")
             .field("incarnation_number", &self.incarnation_number)
-            .field("host", &self.host_key)
+            .field("host", &self.node_id)
             .field("state", &self.member_state)
             .field(
                 "drift_time_ms",
@@ -215,7 +214,7 @@ mod test {
     #[test]
     fn test_member_encode_decode() {
         let member = ArtilleryMember {
-            host_key: uuid::Uuid::new_v4(),
+            node_id: uuid::Uuid::new_v4().to_string(),
             remote_host: Some(FromStr::from_str("127.0.0.1:1337").unwrap()),
             incarnation_number: 123,
             member_state: ArtilleryMemberState::Alive,

--- a/quickwit-swim/src/membership.rs
+++ b/quickwit-swim/src/membership.rs
@@ -4,7 +4,6 @@ use std::net::SocketAddr;
 use std::time::Duration;
 
 use rand::prelude::SliceRandom;
-use uuid::Uuid;
 
 use crate::member::{self, ArtilleryMember, ArtilleryMemberState, ArtilleryStateChange};
 
@@ -29,10 +28,10 @@ impl ArtilleryMemberList {
             .collect()
     }
 
-    pub fn to_map(&self) -> HashMap<Uuid, ArtilleryMember> {
+    pub fn to_map(&self) -> HashMap<String, ArtilleryMember> {
         self.members
             .iter()
-            .map(|m| (m.host_key(), (*m).clone()))
+            .map(|m| (m.node_id(), (*m).clone()))
             .collect()
     }
 
@@ -136,13 +135,13 @@ impl ArtilleryMemberList {
         let mut changed_nodes = Vec::new();
         let mut new_nodes = Vec::new();
 
-        let my_host_key = self.mut_myself().host_key();
+        let my_host_key = self.mut_myself().node_id();
 
         for state_change in state_changes {
             let new_member_data = state_change.member();
-            let old_member_data = current_members.entry(new_member_data.host_key());
+            let old_member_data = current_members.entry(new_member_data.node_id());
 
-            if new_member_data.host_key() == my_host_key {
+            if new_member_data.node_id() == my_host_key {
                 if new_member_data.state() != ArtilleryMemberState::Alive {
                     let myself = self.reincarnate_self();
                     changed_nodes.push(myself.clone());
@@ -217,11 +216,11 @@ impl ArtilleryMemberList {
 
     /// `get_member` will return artillery member if the given uuid is matches with any of the
     /// member in the cluster.
-    pub fn get_member(&self, id: &Uuid) -> Option<ArtilleryMember> {
+    pub fn get_member(&self, id: &str) -> Option<ArtilleryMember> {
         let member: Vec<_> = self
             .members
             .iter()
-            .filter(|&m| m.host_key() == *id)
+            .filter(|&m| m.node_id() == *id)
             .collect();
 
         if member.is_empty() {


### PR DESCRIPTION
## Issues closed by this PR

- #915
- #896
- #932


## Description
The goal of this PR is to make quickwit configuration easy for a new user, it's very user-friendly oriented.



### 1. A quickwit config file for all commands

This PR introduces a quickwit config file that corresponds to the previous `server_config.yaml`. Its primary goal is to define the main variables used by all or almost commands:
- the `metastore_uri``
- the `data_dir_path`

I moved the `data_dir_path` as a global variable as I considered it useful for many commands.

The config file contains also the indexer/searcher config parameters if the user wants to start these services.

Moreover, to make it easy to start with quickwit (and similar to other big project config setup), the user can run the following commands:
```
quickwit service run searcher # <-- by default it will load the config file in ./config/quickwit.yaml
quickwit service run searcher --config-uri ./config/quickwit-node-1.yaml
QUICKWIT_CONFIG_URI=./config/quickwit-node-1.yaml quickwit service run searcher
``` 

### 2. A default `metastore_uri` and `index_root_uri` useful at index creation

When the user wants to create an index, it's good to have nice defaults AND to have a config independent from local environment.

The defaults are:
- `metastore_uri: CWD/metastore` 
- `default_index_root_uri: CWD/data/indexes`: I'm hesitating with this default, putting indexes dir at root level is also ok. I like having one data directory. I don't think this is a big issue as tutorial will end up putting indexes in dedicated directories on s3.

The create command in its simplest form is:
```
quickwit index create --index-id wikipedia
```

You can also specify the `index-uri` if needed.

### 3. Node id

As discussed here #916, I changed `host_key` into `node_id` specified in the config file. So don't need to save it in the data dir.

### 4. A conf file to start with.

The goal of this config file is to shipped in the `tar.gz`: https://github.com/quickwit-inc/quickwit/blob/7a9ab3a91ad3497b2a7cbecf6c650436dcf3662a/config/quickwit.yaml
 
