### PR TITLE
Fix integration test suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ fmt:
 # `make test-all` starts the Docker services and runs all the tests.
 # `make -k test-all docker-compose-down`, tears down the Docker services after running all the tests.
 test-all: docker-compose-up
-	QUICKWIT_ENV=local cargo test --all-features
+	QUICKWIT_ENV=local AWS_ACCESS_KEY_ID=ignored AWS_SECRET_ACCESS_KEY=ignored cargo test --all-features
 
 # This will build and push all custom cross images for cross-compilation.
 # You will need to login into Docker Hub with the `quickwit` account.

--- a/quickwit-cli/tests/cli.rs
+++ b/quickwit-cli/tests/cli.rs
@@ -654,15 +654,15 @@ async fn test_all_local_index() -> Result<()> {
     .unwrap();
     // TODO: wait until port server accepts incoming connections and remove sleep.
     sleep(Duration::from_secs(2)).await;
-    let mut process_output_str = String::new();
+    let mut process_stdout_output = String::new();
     let _ = server_process
         .stdout
         .as_mut()
-        .expect("Failed to get server process output")
+        .expect("Failed to capture process stdout.")
         .take(800)
-        .read_to_string(&mut process_output_str)
-        .expect("Cannot read output");
-    assert!(process_output_str.contains("http://127.0.0.1:"));
+        .read_to_string(&mut process_stdout_output)
+        .expect("Failed to read 800 bytes from process stdout.");
+    assert!(process_stdout_output.contains("http://127.0.0.1:"));
 
     let query_response = reqwest::get(format!(
         "http://127.0.0.1:{}/api/v1/{}/search?query=level:info",
@@ -764,14 +764,16 @@ async fn test_all_with_s3_localstack_cli() -> Result<()> {
     .unwrap();
     // TODO: ditto.
     sleep(Duration::from_secs(2)).await;
-    let mut data = vec![0; 600];
-    server_process
+    let mut process_stdout_output = String::new();
+    let _ = server_process
         .stdout
         .as_mut()
-        .expect("Failed to get server process output")
-        .read_exact(&mut data)
-        .expect("Cannot read output");
-    let process_output_str = String::from_utf8(data).unwrap();
+        .expect("Failed to capture process stdout.")
+        .take(800)
+        .read_to_string(&mut process_stdout_output)
+        .expect("Failed to read 800 bytes from process stdout.");
+    assert!(process_stdout_output.contains("http://127.0.0.1:"));
+
     let query_response = reqwest::get(format!(
         "http://127.0.0.1:{}/api/v1/{}/search?query=level:info",
         test_env.searcher_rest_listen_port, test_env.index_id,
@@ -779,12 +781,12 @@ async fn test_all_with_s3_localstack_cli() -> Result<()> {
     .await?
     .text()
     .await?;
-    server_process.kill().unwrap();
 
-    assert!(process_output_str.contains("http://127.0.0.1:"));
     let result: Value =
         serde_json::from_str(&query_response).expect("Couldn't deserialize response.");
     assert_eq!(result["numHits"], Value::Number(Number::from(2i64)));
+
+    server_process.kill().unwrap();
 
     make_command(
         format!(
@@ -861,14 +863,16 @@ async fn test_all_with_s3_localstack_internal_api() -> Result<()> {
     .unwrap();
     // TODO: ditto.
     sleep(Duration::from_secs(2)).await;
-    let mut data = vec![0; 600];
-    server_process
+    let mut process_stdout_output = String::new();
+    let _ = server_process
         .stdout
         .as_mut()
-        .expect("Failed to get server process output")
-        .read_exact(&mut data)
-        .expect("Cannot read output");
-    let process_output_str = String::from_utf8(data).unwrap();
+        .expect("Failed to capture process stdout.")
+        .take(800)
+        .read_to_string(&mut process_stdout_output)
+        .expect("Failed to read 800 bytes from process stdout.");
+    assert!(process_stdout_output.contains("http://127.0.0.1:"));
+
     let query_response = reqwest::get(format!(
         "http://127.0.0.1:{}/api/v1/{}/search?query=level:info",
         test_env.searcher_rest_listen_port, test_env.index_id,
@@ -876,12 +880,11 @@ async fn test_all_with_s3_localstack_internal_api() -> Result<()> {
     .await?
     .text()
     .await?;
-    server_process.kill().unwrap();
-
-    assert!(process_output_str.contains("http://127.0.0.1:"));
     let result: Value =
         serde_json::from_str(&query_response).expect("Couldn't deserialize response.");
     assert_eq!(result["numHits"], Value::Number(Number::from(2i64)));
+
+    server_process.kill().unwrap();
 
     make_command(
         format!(


### PR DESCRIPTION
### Description
- Add placeholders for AWS keys, it's necessary if you don't have an `~/.aws/config`. That's my case on my fresh laptop setup.
- Fix process stdout capture. Honestly, I don't why the current way does not work T_t

### How was this PR tested?
Ran `make test-all` locally