### PR TITLE
Singletonning the file backed metastore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2425,6 +2425,7 @@ dependencies = [
  "mockall",
  "once_cell",
  "openssl",
+ "quickwit-common",
  "quickwit-config",
  "quickwit-index-config",
  "quickwit-storage",

--- a/quickwit-cli/src/index.rs
+++ b/quickwit-cli/src/index.rs
@@ -39,7 +39,7 @@ use quickwit_indexing::models::IndexingStatistics;
 use quickwit_indexing::source::FileSourceParams;
 use quickwit_indexing::{index_data, STD_IN_SOURCE_ID};
 use quickwit_metastore::checkpoint::Checkpoint;
-use quickwit_metastore::{IndexMetadata, MetastoreUriResolver, Split, SplitState};
+use quickwit_metastore::{quickwit_metastore_uri_resolver, IndexMetadata, Split, SplitState};
 use quickwit_proto::{SearchRequest, SearchResponse};
 use quickwit_search::single_node_search;
 use quickwit_storage::quickwit_storage_uri_resolver;
@@ -365,7 +365,7 @@ impl IndexCliCommand {
 
 pub async fn describe_index_cli(args: DescribeIndexArgs) -> anyhow::Result<()> {
     debug!(args = ?args, "describe");
-    let metastore_uri_resolver = MetastoreUriResolver::default();
+    let metastore_uri_resolver = quickwit_metastore_uri_resolver();
     let metastore = metastore_uri_resolver.resolve(&args.metastore_uri).await?;
     let index_metadata = metastore.index_metadata(&args.index_id).await?;
     let splits = metastore
@@ -626,7 +626,7 @@ pub async fn ingest_docs_cli(args: IngestDocsArgs) -> anyhow::Result<()> {
         params,
     };
     run_index_checklist(&args.metastore_uri, &args.index_id, Some(&source_config)).await?;
-    let metastore_uri_resolver = MetastoreUriResolver::default();
+    let metastore_uri_resolver = quickwit_metastore_uri_resolver();
     let metastore = metastore_uri_resolver.resolve(&args.metastore_uri).await?;
     let mut index_metadata = metastore.index_metadata(&args.index_id).await?;
     let storage_uri_resolver = quickwit_storage_uri_resolver();
@@ -689,7 +689,7 @@ pub async fn ingest_docs_cli(args: IngestDocsArgs) -> anyhow::Result<()> {
 pub async fn search_index(args: SearchIndexArgs) -> anyhow::Result<SearchResponse> {
     debug!(args = ?args, "search-index");
     let storage_uri_resolver = quickwit_storage_uri_resolver();
-    let metastore_uri_resolver = MetastoreUriResolver::default();
+    let metastore_uri_resolver = quickwit_metastore_uri_resolver();
     let metastore = metastore_uri_resolver.resolve(&args.metastore_uri).await?;
     let search_request = SearchRequest {
         index_id: args.index_id,
@@ -726,7 +726,7 @@ pub async fn merge_or_demux_cli(
         params: json!(null),
     };
     run_index_checklist(&args.metastore_uri, &args.index_id, Some(&source_config)).await?;
-    let metastore_uri_resolver = MetastoreUriResolver::default();
+    let metastore_uri_resolver = quickwit_metastore_uri_resolver();
     let metastore = metastore_uri_resolver.resolve(&args.metastore_uri).await?;
     let mut index_metadata = metastore.index_metadata(&args.index_id).await?;
     let storage_uri_resolver = quickwit_storage_uri_resolver();

--- a/quickwit-cli/src/lib.rs
+++ b/quickwit-cli/src/lib.rs
@@ -24,7 +24,7 @@ use once_cell::sync::Lazy;
 use quickwit_common::run_checklist;
 use quickwit_config::SourceConfig;
 use quickwit_indexing::check_source_connectivity;
-use quickwit_metastore::MetastoreUriResolver;
+use quickwit_metastore::quickwit_metastore_uri_resolver;
 use quickwit_storage::quickwit_storage_uri_resolver;
 use regex::Regex;
 
@@ -74,7 +74,7 @@ pub async fn run_index_checklist(
     source_to_check: Option<&SourceConfig>,
 ) -> anyhow::Result<()> {
     let mut checks: Vec<(&str, anyhow::Result<()>)> = Vec::new();
-    let metastore_uri_resolver = MetastoreUriResolver::default();
+    let metastore_uri_resolver = quickwit_metastore_uri_resolver();
     let metastore = metastore_uri_resolver.resolve(metastore_uri).await?;
     checks.push(("metastore", metastore.check_connectivity().await));
 

--- a/quickwit-cli/src/service.rs
+++ b/quickwit-cli/src/service.rs
@@ -23,7 +23,7 @@ use quickwit_common::run_checklist;
 use quickwit_common::uri::Uri;
 use quickwit_config::ServerConfig;
 use quickwit_indexing::index_data;
-use quickwit_metastore::MetastoreUriResolver;
+use quickwit_metastore::quickwit_metastore_uri_resolver;
 use quickwit_serve::run_searcher;
 use quickwit_storage::quickwit_storage_uri_resolver;
 use quickwit_telemetry::payload::TelemetryEvent;
@@ -117,7 +117,7 @@ async fn run_indexer_cli(args: RunIndexerArgs) -> anyhow::Result<()> {
     let indexer_config = server_config
         .indexer_config
         .context("Indexer config is empty.")?;
-    let metastore_uri_resolver = MetastoreUriResolver::default();
+    let metastore_uri_resolver = quickwit_metastore_uri_resolver();
     let metastore = metastore_uri_resolver
         .resolve(&server_config.metastore_uri)
         .await?;
@@ -137,7 +137,7 @@ async fn run_searcher_cli(args: RunSearcherArgs) -> anyhow::Result<()> {
     let searcher_config = server_config
         .searcher_config
         .context("Searcher config is empty.")?;
-    let metastore_uri_resolver = MetastoreUriResolver::default();
+    let metastore_uri_resolver = quickwit_metastore_uri_resolver();
     let metastore = metastore_uri_resolver
         .resolve(&server_config.metastore_uri)
         .await?;

--- a/quickwit-cli/src/source.rs
+++ b/quickwit-cli/src/source.rs
@@ -23,7 +23,7 @@ use itertools::Itertools;
 use quickwit_common::uri::Uri;
 use quickwit_config::SourceConfig;
 use quickwit_metastore::checkpoint::Checkpoint;
-use quickwit_metastore::{IndexMetadata, MetastoreUriResolver};
+use quickwit_metastore::{quickwit_metastore_uri_resolver, IndexMetadata};
 use serde_json::Value;
 use tabled::{Alignment, Header, Modify, Row, Style, Table, Tabled};
 
@@ -231,7 +231,7 @@ fn make_table<T: Tabled>(header: &str, rows: impl IntoIterator<Item = T>) -> Tab
 }
 
 async fn resolve_index(metastore_uri: &str, index_id: &str) -> anyhow::Result<IndexMetadata> {
-    let metastore_uri_resolver = MetastoreUriResolver::default();
+    let metastore_uri_resolver = quickwit_metastore_uri_resolver();
     let metastore = metastore_uri_resolver.resolve(metastore_uri).await?;
     let index_metadata = metastore.index_metadata(index_id).await?;
     Ok(index_metadata)

--- a/quickwit-cli/src/split.rs
+++ b/quickwit-cli/src/split.rs
@@ -26,7 +26,7 @@ use quickwit_common::uri::Uri;
 use quickwit_directories::{
     get_hotcache_from_split, read_split_footer, BundleDirectory, HotDirectory,
 };
-use quickwit_metastore::MetastoreUriResolver;
+use quickwit_metastore::quickwit_metastore_uri_resolver;
 use quickwit_storage::{quickwit_storage_uri_resolver, BundleStorage, Storage};
 use tracing::debug;
 
@@ -131,7 +131,7 @@ pub async fn describe_split_cli(args: DescribeSplitArgs) -> anyhow::Result<()> {
     debug!(args = ?args, "describe-split");
 
     let storage_uri_resolver = quickwit_storage_uri_resolver();
-    let metastore_uri_resolver = MetastoreUriResolver::default();
+    let metastore_uri_resolver = quickwit_metastore_uri_resolver();
     let metastore = metastore_uri_resolver.resolve(&args.metastore_uri).await?;
     let index_metadata = metastore.index_metadata(&args.index_id).await?;
     let index_storage = storage_uri_resolver.resolve(&index_metadata.index_uri)?;
@@ -158,7 +158,7 @@ pub async fn extract_split_cli(args: ExtractSplitArgs) -> anyhow::Result<()> {
     debug!(args = ?args, "extract-split");
 
     let storage_uri_resolver = quickwit_storage_uri_resolver();
-    let metastore_uri_resolver = MetastoreUriResolver::default();
+    let metastore_uri_resolver = quickwit_metastore_uri_resolver();
     let metastore = metastore_uri_resolver.resolve(&args.metastore_uri).await?;
     let index_metadata = metastore.index_metadata(&args.index_id).await?;
     let index_storage = storage_uri_resolver.resolve(&index_metadata.index_uri)?;

--- a/quickwit-cli/tests/cli.rs
+++ b/quickwit-cli/tests/cli.rs
@@ -30,7 +30,7 @@ use helpers::{TestEnv, TestStorageType};
 use predicates::prelude::*;
 use quickwit_cli::index::{create_index_cli, CreateIndexArgs};
 use quickwit_common::rand::append_random_suffix;
-use quickwit_metastore::{Metastore, MetastoreUriResolver};
+use quickwit_metastore::{quickwit_metastore_uri_resolver, Metastore};
 use serde_json::{Number, Value};
 use serial_test::serial;
 use tokio::time::{sleep, Duration};
@@ -366,7 +366,7 @@ async fn test_cmd_garbage_collect_no_grace() -> Result<()> {
         test_env.data_dir_path.as_path(),
     );
 
-    let metastore = MetastoreUriResolver::default()
+    let metastore = quickwit_metastore_uri_resolver()
         .resolve(&test_env.metastore_uri)
         .await?;
     let splits = metastore.list_all_splits(&test_env.index_id).await?;
@@ -431,7 +431,7 @@ async fn test_cmd_garbage_collect_no_grace() -> Result<()> {
         assert_eq!(split_filepath.exists(), false);
     }
 
-    let metastore = MetastoreUriResolver::default()
+    let metastore = quickwit_metastore_uri_resolver()
         .resolve(&test_env.metastore_uri)
         .await?;
     assert_eq!(

--- a/quickwit-common/src/uri.rs
+++ b/quickwit-common/src/uri.rs
@@ -29,7 +29,7 @@ const FILE_PROTOCOL: &str = "file";
 const PROTOCOL_SEPARATOR: &str = "://";
 
 /// Encapsulates the URI type.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Hash)]
 pub struct Uri {
     uri: String,
     protocol_idx: usize,

--- a/quickwit-core/src/index.rs
+++ b/quickwit-core/src/index.rs
@@ -24,7 +24,7 @@ use quickwit_indexing::{
     delete_splits_with_files, run_garbage_collect, FileEntry, IndexingSplitStore,
 };
 use quickwit_metastore::{
-    IndexMetadata, Metastore, MetastoreUriResolver, SplitMetadata, SplitState,
+    quickwit_metastore_uri_resolver, IndexMetadata, Metastore, SplitMetadata, SplitState,
 };
 use quickwit_storage::{quickwit_storage_uri_resolver, Storage};
 use tracing::error;
@@ -38,7 +38,7 @@ pub async fn create_index(
     metastore_uri: &str,
     index_metadata: IndexMetadata,
 ) -> anyhow::Result<()> {
-    let metastore = MetastoreUriResolver::default()
+    let metastore = quickwit_metastore_uri_resolver()
         .resolve(metastore_uri)
         .await?;
     metastore.create_index(index_metadata).await?;
@@ -57,7 +57,7 @@ pub async fn delete_index(
     index_id: &str,
     dry_run: bool,
 ) -> anyhow::Result<Vec<FileEntry>> {
-    let metastore = MetastoreUriResolver::default()
+    let metastore = quickwit_metastore_uri_resolver()
         .resolve(metastore_uri)
         .await?;
     let storage_resolver = quickwit_storage_uri_resolver();
@@ -126,7 +126,7 @@ pub async fn garbage_collect_index(
     grace_period: Duration,
     dry_run: bool,
 ) -> anyhow::Result<Vec<FileEntry>> {
-    let metastore = MetastoreUriResolver::default()
+    let metastore = quickwit_metastore_uri_resolver()
         .resolve(metastore_uri)
         .await?;
     let storage_resolver = quickwit_storage_uri_resolver();

--- a/quickwit-indexing/src/test_utils.rs
+++ b/quickwit-indexing/src/test_utils.rs
@@ -23,7 +23,7 @@ use std::sync::Arc;
 use quickwit_config::{IndexerConfig, SourceConfig};
 use quickwit_index_config::IndexConfig as DocMapper;
 use quickwit_metastore::{
-    IndexMetadata, Metastore, MetastoreUriResolver, Split, SplitMetadata, SplitState,
+    quickwit_metastore_uri_resolver, IndexMetadata, Metastore, Split, SplitMetadata, SplitState,
 };
 use quickwit_storage::{Storage, StorageUriResolver};
 
@@ -71,7 +71,7 @@ impl TestSandbox {
             .collect();
         let doc_mapper = index_meta.build_doc_mapper()?;
         let (indexer_config, _temp_dir) = IndexerConfig::for_test()?;
-        let metastore_uri_resolver = MetastoreUriResolver::default();
+        let metastore_uri_resolver = quickwit_metastore_uri_resolver();
         let metastore = metastore_uri_resolver.resolve(METASTORE_URI).await?;
         metastore.create_index(index_meta.clone()).await?;
         let storage_uri_resolver = StorageUriResolver::for_test();

--- a/quickwit-metastore/Cargo.toml
+++ b/quickwit-metastore/Cargo.toml
@@ -27,6 +27,7 @@ thiserror = "1.0"
 tokio = { version = "1.6", features = ["full"]}
 tracing = "0.1.29"
 
+quickwit-common = { version = "0.1.0", path = "../quickwit-common" }
 quickwit-config = { version = "0.1.0", path = "../quickwit-config" }
 quickwit-index-config = { version = "0.1.0", path = "../quickwit-index-config" }
 quickwit-storage = { version = "0.1.0", path = "../quickwit-storage" }

--- a/quickwit-metastore/src/lib.rs
+++ b/quickwit-metastore/src/lib.rs
@@ -58,6 +58,8 @@ pub use metastore::postgresql_metastore::PostgresqlMetastore;
 #[cfg(feature = "testsuite")]
 pub use metastore::MockMetastore;
 pub use metastore::{IndexMetadata, Metastore};
-pub use metastore_resolver::{MetastoreFactory, MetastoreUriResolver};
+pub use metastore_resolver::{
+    quickwit_metastore_uri_resolver, MetastoreFactory, MetastoreUriResolver,
+};
 pub use split_metadata::{Split, SplitMetadata, SplitState};
 pub(crate) use split_metadata_version::VersionedSplitMetadataDeserializeHelper;

--- a/quickwit-metastore/src/metastore/file_backed_metastore/file_backed_metastore_factory.rs
+++ b/quickwit-metastore/src/metastore/file_backed_metastore/file_backed_metastore_factory.rs
@@ -77,12 +77,12 @@ fn extract_polling_interval_from_uri(uri: &str) -> (String, Option<Duration>) {
 impl FileBackedMetastoreFactory {
     async fn get_from_cache(&self, uri: &Uri) -> Option<Arc<dyn Metastore>> {
         let mut cache_lock = self.cache.lock().await;
-        let metastore_weak: &Weak<dyn Metastore> = cache_lock.get(&uri)?;
+        let metastore_weak: &Weak<dyn Metastore> = cache_lock.get(uri)?;
         if let Some(metastore_arc) = metastore_weak.upgrade() {
             Some(metastore_arc.clone())
         } else {
             // It does not hurt to do a bit of garbage collecting.
-            cache_lock.remove(&uri);
+            cache_lock.remove(uri);
             None
         }
     }

--- a/quickwit-metastore/src/metastore_resolver.rs
+++ b/quickwit-metastore/src/metastore_resolver.rs
@@ -21,6 +21,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use once_cell::sync::OnceCell;
 
 use crate::metastore::file_backed_metastore::FileBackedMetastoreFactory;
 #[cfg(feature = "postgres")]
@@ -60,8 +61,12 @@ pub struct MetastoreUriResolver {
     per_protocol_resolver: Arc<HashMap<String, Arc<dyn MetastoreFactory>>>,
 }
 
-impl Default for MetastoreUriResolver {
-    fn default() -> Self {
+/// Quickwit supported storage resolvers.
+///
+/// The returned metastore uri resolver is a Singleton.
+pub fn quickwit_metastore_uri_resolver() -> &'static MetastoreUriResolver {
+    static METASTORE_URI_RESOLVER: OnceCell<MetastoreUriResolver> = OnceCell::new();
+    METASTORE_URI_RESOLVER.get_or_init(|| {
         #[allow(unused_mut)]
         let mut builder = MetastoreUriResolver::builder()
             .register("ram", FileBackedMetastoreFactory::default())
@@ -74,7 +79,7 @@ impl Default for MetastoreUriResolver {
         }
 
         builder.build()
-    }
+    })
 }
 
 impl MetastoreUriResolver {
@@ -104,12 +109,12 @@ impl MetastoreUriResolver {
 
 #[cfg(test)]
 mod tests {
-    use crate::MetastoreUriResolver;
+    use crate::quickwit_metastore_uri_resolver;
 
     #[tokio::test]
     async fn test_metastore_resolver_should_not_raise_errors_on_file_and_s3() -> anyhow::Result<()>
     {
-        let metastore_resolver = MetastoreUriResolver::default();
+        let metastore_resolver = quickwit_metastore_uri_resolver();
         metastore_resolver.resolve("file://").await?;
         metastore_resolver
             .resolve("s3://bucket/path/to/object")
@@ -120,7 +125,7 @@ mod tests {
     #[tokio::test]
     #[should_panic(expected = "ProtocolUnsupported(\"s4\")")]
     async fn test_metastore_resolver_should_raise_error_on_storage_error() {
-        let metastore_resolver = MetastoreUriResolver::default();
+        let metastore_resolver = quickwit_metastore_uri_resolver();
         metastore_resolver
             .resolve("s4://bucket/path/to/object")
             .await


### PR DESCRIPTION
It is necessary to be able to run several
sources targetting the same index for instance.

The metastore uri resolver is a singleton now too.

Closes #926
