### PR TITLE
Peer-seed port story (Issue/901)

### DIFF
--- a/docs/reference/index-config.md
+++ b/docs/reference/index-config.md
@@ -3,7 +3,7 @@ title: Index configuration
 position: 2
 ---
 
-The index config letsk you define four things:
+The index config lets you define four things:
 - the doc mapping, that is how a document, and the fields it contains are stored and indexed for a given index. A document is a collection of named fields, each having its own data type (text, binary, date, i64, f64)
 - the timestamp field `timestamp_field` used for [sharding documents in splits](../overview/architecture.md#splits). This is very useful when querying as Quickwit will be able to prune splits based on time range and make search way faster. The timestamp field must be an `i64`. When you define a timestamp field, note that documents will be ordered by default in descending order related to this field
 - the default search fields `default_search_fields`: if no field name is specified in your query, these fields will be used for search

--- a/docs/reference/ports.md
+++ b/docs/reference/ports.md
@@ -1,0 +1,34 @@
+--
+title: Quickwit's hosts and ports
+--
+
+When starting a quickwit search server, one important parameter that can be configured is
+the `rest_listen_port` (defaults to :7280).
+
+Internally, quickwit will in fact use 3 sockets. The port of these three sockets
+cannot be configured independently at the moment.
+The port used computed relatively to the `rest_listen_port` port, as follows.
+
+
+| Service                       | Port used                 | Protocol |  Default  |
+|-------------------------------|---------------------------|----------|-----------|
+| Http server with the rest api | `${rest_listen_port}`     |   TCP    | 7280      |
+| Cluster membership            | `${rest_listen_port}`     |   UDP    | 7280      |
+| GRPC service                  | `${rest_listen_port} + 1` |   TCP    | 7281      |
+
+It is not possible for the moment to configure these ports independently.
+
+
+In order to form a cluster, you will also need to define a `peer_seeds` parameter.
+The following address are valid peer seed addresses:
+
+| Type | Example without port | Example with port         |
+|--------------|--------------|---------------------------|
+| IPv4         | 172.1.0.12   | 172.1.0.12:7180           |
+| IPv6         | 2001:0db8:85a3:0000:0000:8a2e:0370:7334  | [2001:0db8:85a3:0000:0000:8a2e:0370:7334:7180]:7280 |
+| hostname     | node3        | node3:7180                |
+
+If no port is specified in a peer node address, a Quickwit node will assume the peer is using the same
+port as themselves.
+
+

--- a/docs/reference/ports.md
+++ b/docs/reference/ports.md
@@ -5,9 +5,9 @@ title: Quickwit's hosts and ports
 When starting a quickwit search server, one important parameter that can be configured is
 the `rest_listen_port` (defaults to :7280).
 
-Internally, quickwit will in fact use 3 sockets. The port of these three sockets
+Internally, Quickwit will, in fact, use three sockets. The ports of these three sockets
 cannot be configured independently at the moment.
-The port used computed relatively to the `rest_listen_port` port, as follows.
+The ports used are computed relative to the `rest_listen_port` port, as follows.
 
 
 | Service                       | Port used                 | Protocol |  Default  |
@@ -20,7 +20,7 @@ It is not possible for the moment to configure these ports independently.
 
 
 In order to form a cluster, you will also need to define a `peer_seeds` parameter.
-The following address are valid peer seed addresses:
+The following addresses are valid peer seed addresses:
 
 | Type | Example without port | Example with port         |
 |--------------|--------------|---------------------------|
@@ -29,6 +29,6 @@ The following address are valid peer seed addresses:
 | hostname     | node3        | node3:7180                |
 
 If no port is specified in a peer node address, a Quickwit node will assume the peer is using the same
-port as themselves.
+port as itself.
 
 

--- a/quickwit-common/src/net.rs
+++ b/quickwit-common/src/net.rs
@@ -49,10 +49,10 @@ fn contains_port(addr: &str) -> bool {
     false
 }
 
-/// Attempts parse a `socket_addr`.
-/// If no port, is defined, just accept the address and use the given default port.
+/// Attempts to parse a `socket_addr`.
+/// If no port is defined, it just accepts the address and uses the given default port.
 ///
-/// This function support
+/// This function supports
 /// - IPv4
 /// - IPv4:port
 /// - IPv6
@@ -62,7 +62,7 @@ fn contains_port(addr: &str) -> bool {
 /// with or without a port.
 ///
 /// Note that this function returns a SocketAddr, so that if a hostname
-/// is given DNS resolution will happen once and for all.
+/// is given, DNS resolution will happen once and for all.
 pub fn parse_socket_addr_with_default_port(
     addr: &str,
     default_port: u16,

--- a/quickwit-common/src/net.rs
+++ b/quickwit-common/src/net.rs
@@ -27,10 +27,101 @@ pub fn find_available_port() -> anyhow::Result<u16> {
     Ok(port)
 }
 
-/// Converts this string to a resolved `SocketAddr`.
-pub fn socket_addr_from_str<S: AsRef<str>>(addr: S) -> anyhow::Result<SocketAddr> {
-    addr.as_ref()
-        .to_socket_addrs()?
+/// Converts an object into a resolved `SocketAddr`.
+pub fn get_socket_addr<T: ToSocketAddrs + std::fmt::Debug>(addr: &T) -> anyhow::Result<SocketAddr> {
+    addr.to_socket_addrs()?
         .next()
-        .ok_or_else(|| anyhow::anyhow!("Failed to resolve address `{}`.", addr.as_ref()))
+        .ok_or_else(|| anyhow::anyhow!("Failed to resolve address `{:?}`.", addr))
+}
+
+/// Returns true if the socket addr is a valid socket address containing a port.
+///
+/// If the socket adddress looks invalid to begin with, we may return false or true.
+fn contains_port(addr: &str) -> bool {
+    // [IPv6]:port
+    if let Some((_, colon_port)) = addr[1..].rsplit_once(']') {
+        return colon_port.starts_with(':');
+    }
+    if let Some((host, _port)) = addr[1..].rsplit_once(':') {
+        // if host contains a ":" then is thi is probably a IPv6 address.
+        return !host.contains(':');
+    }
+    false
+}
+
+/// Attempts parse a `socket_addr`.
+/// If no port, is defined, just accept the address and use the given default port.
+///
+/// This function support
+/// - IPv4
+/// - IPv4:port
+/// - IPv6
+/// - [IPv6]:port -- IpV6 contains colon. It is customary to require bracket for this reason.
+/// - hostname
+/// - hostname:port
+/// with or without a port.
+///
+/// Note that this function returns a SocketAddr, so that if a hostname
+/// is given DNS resolution will happen once and for all.
+pub fn parse_socket_addr_with_default_port(
+    addr: &str,
+    default_port: u16,
+) -> anyhow::Result<SocketAddr> {
+    if contains_port(addr) {
+        get_socket_addr(&addr)
+    } else {
+        get_socket_addr(&(addr, default_port))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_parse_socket_addr_helper(addr: &str, expected_opt: Option<&str>) {
+        let socket_addr_res = parse_socket_addr_with_default_port(addr, 1337);
+        if let Some(expected) = expected_opt {
+            assert!(
+                socket_addr_res.is_ok(),
+                "Parsing `{}` was expected to succeed",
+                addr
+            );
+            let socket_addr = socket_addr_res.unwrap();
+            let expected_socket_addr: SocketAddr = expected.parse().unwrap();
+            assert_eq!(socket_addr, expected_socket_addr);
+        } else {
+            assert!(
+                socket_addr_res.is_err(),
+                "Parsing `{}` was expected to fail",
+                addr
+            );
+        }
+    }
+
+    #[test]
+    fn test_parse_socket_addr_with_ips() {
+        test_parse_socket_addr_helper("127.0.0.1", Some("127.0.0.1:1337"));
+        test_parse_socket_addr_helper("127.0.0.1:100", Some("127.0.0.1:100"));
+        test_parse_socket_addr_helper("127.0.0.:100", None);
+        test_parse_socket_addr_helper(
+            "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+            Some("[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:1337"),
+        );
+        test_parse_socket_addr_helper("2001:0db8:85a3:0000:0000:8a2e:0370:7334:1000", None);
+        test_parse_socket_addr_helper(
+            "[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:1000",
+            Some("[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:1000"),
+        );
+        test_parse_socket_addr_helper("[2001:0db8:1000", None);
+        test_parse_socket_addr_helper("2001:0db8:85a3:0000:0000:8a2e:0370:7334]:1000", None);
+    }
+
+    // This test require DNS.
+    #[test]
+    fn test_parse_socket_addr_with_resolution() {
+        let socket_addr = parse_socket_addr_with_default_port("google.com:1000", 1337).unwrap();
+        assert_eq!(socket_addr.port(), 1000);
+        let socket_addr = parse_socket_addr_with_default_port("google.com", 1337).unwrap();
+        assert_eq!(socket_addr.port(), 1337);
+    }
 }

--- a/quickwit-config/src/server_config.rs
+++ b/quickwit-config/src/server_config.rs
@@ -152,11 +152,12 @@ impl SearcherConfig {
         ))
     }
 
-    pub fn discovery_socket_addr(&self) -> anyhow::Result<SocketAddr> {
+    /// We use the same port number as the rest port but this is UDP
+    pub fn gossip_socket_addr(&self) -> anyhow::Result<SocketAddr> {
         socket_addr_from_str(format!(
             "{}:{}",
             self.rest_listen_address,
-            self.rest_listen_port + 2
+            self.rest_listen_port
         ))
     }
 
@@ -393,7 +394,7 @@ mod tests {
             let server_config_yaml = r#"
             version: 0
             metastore_uri: postgres://username:password@host:port/db
- 
+
             indexer:
               data_dir_path: /opt/quickwit/data
 

--- a/quickwit-config/src/server_config.rs
+++ b/quickwit-config/src/server_config.rs
@@ -24,7 +24,7 @@ use std::path::{Path, PathBuf};
 use anyhow::{bail, Context};
 use byte_unit::Byte;
 use json_comments::StripComments;
-use quickwit_common::net::socket_addr_from_str;
+use quickwit_common::net::{get_socket_addr, parse_socket_addr_with_default_port};
 use quickwit_storage::load_file;
 use serde::{Deserialize, Serialize};
 use tracing::warn;
@@ -138,38 +138,28 @@ impl SearcherConfig {
     }
 
     pub fn rest_socket_addr(&self) -> anyhow::Result<SocketAddr> {
-        socket_addr_from_str(format!(
-            "{}:{}",
-            self.rest_listen_address, self.rest_listen_port
-        ))
+        get_socket_addr(&(self.rest_listen_address.as_str(), self.rest_listen_port))
     }
 
     pub fn grpc_socket_addr(&self) -> anyhow::Result<SocketAddr> {
-        socket_addr_from_str(format!(
-            "{}:{}",
-            self.rest_listen_address,
-            self.rest_listen_port + 1
-        ))
+        get_socket_addr(&(self.rest_listen_address.as_str(), self.rest_listen_port + 1))
     }
 
-    /// We use the same port number as the rest port but this is UDP
     pub fn gossip_socket_addr(&self) -> anyhow::Result<SocketAddr> {
-        socket_addr_from_str(format!(
-            "{}:{}",
-            self.rest_listen_address,
-            self.rest_listen_port
-        ))
+        // We use the same port number as the rest port but this is UDP
+        get_socket_addr(&(self.rest_listen_address.as_str(), self.rest_listen_port))
     }
 
     pub fn peer_socket_addrs(&self) -> anyhow::Result<Vec<SocketAddr>> {
+        // If no port is given, we assume a peer is using the same port as ourself.
+        let default_gossip_port = self.gossip_socket_addr()?.port();
         let peer_socket_addrs: Vec<SocketAddr> = self
             .peer_seeds
             .iter()
             .flat_map(|peer_seed| {
-                socket_addr_from_str(format!("{}:{}", peer_seed, self.rest_listen_port + 2))
-                    .map_err(
-                        |_| warn!(address = %peer_seed, "Failed to resolve peer seed address."),
-                    )
+                parse_socket_addr_with_default_port(peer_seed, default_gossip_port).map_err(
+                    |_| warn!(address = %peer_seed, "Failed to resolve peer seed address."),
+                )
             })
             .collect();
 
@@ -498,7 +488,7 @@ mod tests {
             };
             assert_eq!(
                 searcher_config.peer_socket_addrs().unwrap(),
-                vec!["127.0.0.1:1791".parse().unwrap()]
+                vec!["127.0.0.1:1789".parse().unwrap()]
             );
         }
     }

--- a/quickwit-search/src/lib.rs
+++ b/quickwit-search/src/lib.rs
@@ -65,22 +65,10 @@ pub use crate::search_stream::root_search_stream;
 pub use crate::service::{MockSearchService, SearchService, SearchServiceImpl};
 use crate::thread_pool::run_cpu_intensive;
 
-/// Compute the gRPC port from the HTTP port.
-/// Add 1 to the HTTP port to get the gRPC port.
-pub fn http_addr_to_grpc_addr(http_addr: SocketAddr) -> SocketAddr {
-    SocketAddr::new(http_addr.ip(), http_addr.port() + 1)
-}
-
-/// Compute the SWIM port from the HTTP port.
-/// Add 2 to the HTTP port to get the SWIM port.
-pub fn http_addr_to_swim_addr(http_addr: SocketAddr) -> SocketAddr {
-    SocketAddr::new(http_addr.ip(), http_addr.port() + 2)
-}
-
 /// Compute the gRPC port from the SWIM port.
-/// Subtract 1 to the SWIM port to get the gRPC port.
+/// Add 1 to the SWIM port to get the gRPC port.
 pub fn swim_addr_to_grpc_addr(swim_addr: SocketAddr) -> SocketAddr {
-    SocketAddr::new(swim_addr.ip(), swim_addr.port() - 1)
+    SocketAddr::new(swim_addr.ip(), swim_addr.port() + 1)
 }
 
 /// GlobalDocAddress serves as a hit address.

--- a/quickwit-serve/src/lib.rs
+++ b/quickwit-serve/src/lib.rs
@@ -94,7 +94,7 @@ pub async fn run_searcher(
     let host_key = read_or_create_host_key(&searcher_config.host_key_path)?;
     let cluster = Arc::new(Cluster::new(
         host_key,
-        searcher_config.discovery_socket_addr()?,
+        searcher_config.gossip_socket_addr()?,
     )?);
     for peer_socket_addr in searcher_config.peer_socket_addrs()? {
         // If the peer address is specified,


### PR DESCRIPTION
Closes #901
    
    - people can optionally pass a port when defining their peer nodes.
    
    Making it possible to run several node on the same computer.
    
    Previously all nodes were assumed to share the same SWIM
    listen port, preventing running several quickwit instance
    on the same node.
    
    - peer node address can now be IPv6
    
    IPv6 was broken due to the parsing of format!("{}:{}") idiom.
    
    - Change in the base port -> service port logic.
    
    In addition this PR change the base port -> service
    port logic.
    
    Before:
    Rest port (TCP) = Base port
    GRPC port (TCP) = Base port + 1
    SWIM port (UDP) = Base port + 2
    
    After:
    Rest port (TCP) = Base port
    GRPC port (TCP) = Base port + 1
    SWIM port (UDP) = Base port
    
    The reason for this is that in the configuration,
    the user needs to know about the rest port and the SWIM
    port.
    
    To make it less confusing for the user who did not
    read the manual, we use the same base port for SWIM and Rest.
    
    Let's see how it helps by looking at what the user needs
    to configure.

    -- Before:
    
    Node 1
    - rest_listen_address: "localhost"
    - rest_listen_port: 10000
    - peer_seeds: ["localhost:20002"]
    Node 2
    - rest_listen_address: "localhost"
    - rest_listen_port: 20000
    - peer_seeds: ["localhost:10002"]
    
    --- After:
    Node 1
    - rest_listen_address: "localhost"
    - rest_listen_port: 10000
    - peer_seeds: ["localhost:20000"]
    Node 2
    - rest_listen_address: "localhost"
    - rest_listen_port: 20000
    - peer_seeds: ["localhost:10000"]


# Tested

Via unit test and by running a two node cluster locally.
Cluster formation and gRPC works correctly. Leaf node are executed by the two nodes.