### PR TITLE
Avoid panic and log a warning when a node join the cluster with an id…

### DIFF
--- a/config/tutorials/hdfs-logs/searcher-1.yaml
+++ b/config/tutorials/hdfs-logs/searcher-1.yaml
@@ -4,4 +4,5 @@ searcher:
   rest_listen_address: 127.0.0.1
   rest_listen_port: 7280
   peer_seeds:
-     - 127.0.0.1:7290 # searcher-2
+    - 127.0.0.1:7290 # searcher-2
+    - 127.0.0.1:7300 # searcher-3

--- a/config/tutorials/hdfs-logs/searcher-3.yaml
+++ b/config/tutorials/hdfs-logs/searcher-3.yaml
@@ -1,8 +1,9 @@
 version: 0
-node_id: searcher-2
+node_id: searcher-3
 searcher:
   rest_listen_address: 127.0.0.1
-  rest_listen_port: 7290
+  rest_listen_port: 7300
   peer_seeds:
     - 127.0.0.1:7280 # searcher-1
-    - 127.0.0.1:7300 # searcher-3
+    - 127.0.0.1:7290 # searcher-2
+

--- a/quickwit-swim/src/member.rs
+++ b/quickwit-swim/src/member.rs
@@ -43,13 +43,13 @@ pub struct ArtilleryStateChange {
 
 impl ArtilleryMember {
     pub fn new(
-        host_id: String,
+        node_id: String,
         remote_host: SocketAddr,
         incarnation_number: u64,
         known_state: ArtilleryMemberState,
     ) -> Self {
         ArtilleryMember {
-            node_id: host_id,
+            node_id,
             remote_host: Some(remote_host),
             incarnation_number,
             member_state: known_state,

--- a/quickwit-swim/src/membership.rs
+++ b/quickwit-swim/src/membership.rs
@@ -35,13 +35,21 @@ impl ArtilleryMemberList {
             .collect()
     }
 
+    pub fn current_node_id(&self) -> String {
+        for member in self.members.iter() {
+            if member.is_current() {
+                return member.node_id();
+            }
+        }
+        panic!("Could not find current node as registered member");
+    }
+
     fn mut_myself(&mut self) -> &mut ArtilleryMember {
         for member in &mut self.members {
             if member.is_current() {
                 return member;
             }
         }
-
         panic!("Could not find this instance as registered member");
     }
 
@@ -135,13 +143,13 @@ impl ArtilleryMemberList {
         let mut changed_nodes = Vec::new();
         let mut new_nodes = Vec::new();
 
-        let my_host_key = self.mut_myself().node_id();
+        let my_node_id = self.mut_myself().node_id();
 
         for state_change in state_changes {
             let new_member_data = state_change.member();
             let old_member_data = current_members.entry(new_member_data.node_id());
 
-            if new_member_data.node_id() == my_host_key {
+            if new_member_data.node_id() == my_node_id {
                 if new_member_data.state() != ArtilleryMemberState::Alive {
                     let myself = self.reincarnate_self();
                     changed_nodes.push(myself.clone());

--- a/quickwit-swim/src/state.rs
+++ b/quickwit-swim/src/state.rs
@@ -329,6 +329,13 @@ impl ArtilleryEpidemic {
         use Request::*;
 
         if message.cluster_key == self.config.cluster_key {
+            // We want to abort if a new member has the same node_id of an existing member.  
+            // A new member is detected according to its socket address.
+            if !self.members.has_member(&src_addr) && self.members.get_member(&message.sender).is_some() {
+                error!("Cannot add a member with a node-id `{}` already present in the cluster.", message.sender);
+                return;
+            }
+
             self.apply_state_changes(message.state_changes, src_addr);
             remove_potential_seed(&mut self.seed_queue, src_addr);
 


### PR DESCRIPTION
… already taken by a member.

Fix #962

It's tested locally but clearly it's hard to know what is really happening.....

### How was this PR tested?
I tested it locally with 3 searcher nodes. Two with same node id and one with a different. No panic and it show logs like this:

```
2021-12-23T18:04:22.615Z  INFO quickwit_cluster::cluster: Create new cluster. node_id="searcher-1" listen_addr=127.0.0.1:7280
2021-12-23T18:04:22.615Z  INFO quickwit_cluster::cluster: Adding peer node. self_addr=127.0.0.1:7280 peer_addr=127.0.0.1:7290
2021-12-23T18:04:22.616Z  INFO quickwit_serve: Searcher ready to accept requests at http://127.0.0.1:7280/
2021-12-23T18:04:22.616Z  INFO quickwit_serve::rest: Starting REST service. rest_addr=127.0.0.1:7280
2021-12-23T18:04:22.616Z  INFO quickwit_serve::grpc: Start gRPC service. grpc_addr=127.0.0.1:7281
2021-12-23T18:04:25.626Z  WARN quickwit_swim::state: Cannot add a member with a node-id `searcher-1` already present in the cluster.
2021-12-23T18:05:41.876Z  INFO quickwit_cluster::cluster: Joined. node_id="searcher-3" remote_host=Some(127.0.0.1:7300)
```