### PR TITLE
Improve serialization format of `quickwit.json` file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2422,6 +2422,7 @@ dependencies = [
  "diesel_migrations",
  "dotenv",
  "futures",
+ "itertools",
  "mockall",
  "once_cell",
  "openssl",

--- a/quickwit-backward-compat/test-data/file-backed-index/v0-cd9b0bf64dbb7af9e92bfed8a569c890.expected.json
+++ b/quickwit-backward-compat/test-data/file-backed-index/v0-cd9b0bf64dbb7af9e92bfed8a569c890.expected.json
@@ -1,0 +1,107 @@
+{
+  "index": {
+    "checkpoint": {
+      "0000000000": "0000000042"
+    },
+    "create_timestamp": 1789,
+    "doc_mapping": {
+      "field_mappings": [
+        {
+          "fast": true,
+          "indexed": true,
+          "name": "tenant_id",
+          "stored": true,
+          "type": "u64"
+        },
+        {
+          "fast": true,
+          "indexed": true,
+          "name": "timestamp",
+          "stored": true,
+          "type": "i64"
+        },
+        {
+          "fast": false,
+          "name": "log_level",
+          "record": "basic",
+          "stored": true,
+          "tokenizer": "raw",
+          "type": "text"
+        },
+        {
+          "fast": false,
+          "name": "message",
+          "record": "position",
+          "stored": true,
+          "tokenizer": "default",
+          "type": "text"
+        }
+      ],
+      "store_source": true,
+      "tag_fields": [
+        "log_level",
+        "tenant_id"
+      ]
+    },
+    "index_id": "my-index",
+    "index_uri": "s3://quickwit-indexes/my-index",
+    "indexing_settings": {
+      "commit_timeout_secs": 301,
+      "demux_enabled": true,
+      "demux_field": "tenant_id",
+      "merge_enabled": true,
+      "merge_policy": {
+        "demux_factor": 7,
+        "max_merge_factor": 11,
+        "merge_factor": 9
+      },
+      "resources": {
+        "heap_size": 3,
+        "num_threads": 3
+      },
+      "sort_field": "timestamp",
+      "sort_order": "asc",
+      "split_num_docs_target": 10000001,
+      "timestamp_field": "timestamp"
+    },
+    "search_settings": {
+      "default_search_fields": [
+        "message"
+      ]
+    },
+    "sources": [
+      {
+        "params": {},
+        "source_id": "kafka-source",
+        "source_type": "kafka"
+      }
+    ],
+    "update_timestamp": 1789,
+    "version": "0"
+  },
+  "splits": [
+    {
+      "create_timestamp": 3,
+      "demux_num_ops": 1,
+      "footer_offsets": {
+        "end": 2000,
+        "start": 1000
+      },
+      "num_docs": 12303,
+      "size_in_bytes": 234234,
+      "split_id": "split",
+      "split_state": "Published",
+      "tags": [
+        "234",
+        "aaa"
+      ],
+      "time_range": {
+        "end": 130198,
+        "start": 121000
+      },
+      "update_timestamp": 1789,
+      "version": "1"
+    }
+  ],
+  "version": "0"
+}

--- a/quickwit-backward-compat/test-data/file-backed-index/v0-cd9b0bf64dbb7af9e92bfed8a569c890.json
+++ b/quickwit-backward-compat/test-data/file-backed-index/v0-cd9b0bf64dbb7af9e92bfed8a569c890.json
@@ -1,0 +1,107 @@
+{
+  "index": {
+    "checkpoint": {
+      "0000000000": "0000000042"
+    },
+    "create_timestamp": 1789,
+    "doc_mapping": {
+      "field_mappings": [
+        {
+          "fast": true,
+          "indexed": true,
+          "name": "tenant_id",
+          "stored": true,
+          "type": "u64"
+        },
+        {
+          "fast": true,
+          "indexed": true,
+          "name": "timestamp",
+          "stored": true,
+          "type": "i64"
+        },
+        {
+          "fast": false,
+          "name": "log_level",
+          "record": "basic",
+          "stored": true,
+          "tokenizer": "raw",
+          "type": "text"
+        },
+        {
+          "fast": false,
+          "name": "message",
+          "record": "position",
+          "stored": true,
+          "tokenizer": "default",
+          "type": "text"
+        }
+      ],
+      "store_source": true,
+      "tag_fields": [
+        "log_level",
+        "tenant_id"
+      ]
+    },
+    "index_id": "my-index",
+    "index_uri": "s3://quickwit-indexes/my-index",
+    "indexing_settings": {
+      "commit_timeout_secs": 301,
+      "demux_enabled": true,
+      "demux_field": "tenant_id",
+      "merge_enabled": true,
+      "merge_policy": {
+        "demux_factor": 7,
+        "max_merge_factor": 11,
+        "merge_factor": 9
+      },
+      "resources": {
+        "heap_size": 3,
+        "num_threads": 3
+      },
+      "sort_field": "timestamp",
+      "sort_order": "asc",
+      "split_num_docs_target": 10000001,
+      "timestamp_field": "timestamp"
+    },
+    "search_settings": {
+      "default_search_fields": [
+        "message"
+      ]
+    },
+    "sources": [
+      {
+        "params": {},
+        "source_id": "kafka-source",
+        "source_type": "kafka"
+      }
+    ],
+    "update_timestamp": 1789,
+    "version": "0"
+  },
+  "splits": [
+    {
+      "create_timestamp": 3,
+      "demux_num_ops": 1,
+      "footer_offsets": {
+        "end": 2000,
+        "start": 1000
+      },
+      "num_docs": 12303,
+      "size_in_bytes": 234234,
+      "split_id": "split",
+      "split_state": "Published",
+      "tags": [
+        "234",
+        "aaa"
+      ],
+      "time_range": {
+        "end": 130198,
+        "start": 121000
+      },
+      "update_timestamp": 1789,
+      "version": "1"
+    }
+  ],
+  "version": "0"
+}

--- a/quickwit-cli/Cargo.toml
+++ b/quickwit-cli/Cargo.toml
@@ -46,7 +46,7 @@ tempfile = "3"
 chrono = "0.4"
 humansize = "1.1.1"
 openssl-probe = { version = "0.1.4", optional = true }
-itertools = "0.10.1"
+itertools = "0.10"
 colored = "2.0.0"
 futures = "0.3"
 regex = "1.5.4"

--- a/quickwit-cli/Cargo.toml
+++ b/quickwit-cli/Cargo.toml
@@ -46,7 +46,7 @@ tempfile = "3"
 chrono = "0.4"
 humansize = "1.1.1"
 openssl-probe = { version = "0.1.4", optional = true }
-itertools = "0.10"
+itertools = "0.10.3"
 colored = "2.0.0"
 futures = "0.3"
 regex = "1.5.4"

--- a/quickwit-indexing/Cargo.toml
+++ b/quickwit-indexing/Cargo.toml
@@ -17,7 +17,7 @@ byte-unit = { version = "4", default-features = false, features = ["serde"] }
 fail = "0.5"
 flume = "0.10"
 futures = "0.3"
-itertools = "0.10"
+itertools = "0.10.3"
 once_cell = "1"
 quickwit-actors = {path = "../quickwit-actors" }
 quickwit-common = {path = "../quickwit-common" }

--- a/quickwit-metastore/Cargo.toml
+++ b/quickwit-metastore/Cargo.toml
@@ -18,7 +18,7 @@ chrono = "0.4"
 diesel = { version = "1.4", features = ["postgres", "chrono", "extras"], optional = true }
 diesel_migrations =  { version = "1.4", optional = true }
 futures = "0.3.17"
-itertools = "0.10"
+itertools = "0.10.3"
 once_cell = "1"
 openssl = { version = "0.10.36", optional = true }
 regex = "1"

--- a/quickwit-metastore/Cargo.toml
+++ b/quickwit-metastore/Cargo.toml
@@ -18,9 +18,10 @@ chrono = "0.4"
 diesel = { version = "1.4", features = ["postgres", "chrono", "extras"], optional = true }
 diesel_migrations =  { version = "1.4", optional = true }
 futures = "0.3.17"
+itertools = "0.10"
+once_cell = "1"
 openssl = { version = "0.10.36", optional = true }
 regex = "1"
-once_cell = "1"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 thiserror = "1.0"

--- a/quickwit-metastore/src/lib.rs
+++ b/quickwit-metastore/src/lib.rs
@@ -52,12 +52,12 @@ mod metastore_resolver;
 pub mod postgresql;
 
 pub use error::{MetastoreError, MetastoreResolverError, MetastoreResult};
-pub use metastore::file_backed_metastore::FileBackedMetastore;
+pub use metastore::file_backed_metastore::{FileBackedIndex, FileBackedMetastore};
 #[cfg(feature = "postgres")]
 pub use metastore::postgresql_metastore::PostgresqlMetastore;
 #[cfg(feature = "testsuite")]
 pub use metastore::MockMetastore;
-pub use metastore::{IndexMetadata, Metastore};
+pub use metastore::{file_backed_metastore, IndexMetadata, Metastore};
 pub use metastore_resolver::{
     quickwit_metastore_uri_resolver, MetastoreFactory, MetastoreUriResolver,
 };

--- a/quickwit-metastore/src/metastore/file_backed_metastore/mod.rs
+++ b/quickwit-metastore/src/metastore/file_backed_metastore/mod.rs
@@ -17,8 +17,12 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+//! Module for [`FileBackedMetastore`]. It is public so that the crate `quickwit-backward-compat`
+//! can import [`FiledBackedIndex`] and run backward-compatibility tests. You should not have to
+//! import anything from here directly.
+
+pub mod file_backed_index;
 mod file_backed_metastore_factory;
-mod index;
 mod store_operations;
 
 use std::collections::HashMap;
@@ -32,8 +36,8 @@ use quickwit_storage::Storage;
 use tokio::sync::{Mutex, OwnedMutexGuard, RwLock};
 use tracing::error;
 
+pub use self::file_backed_index::FileBackedIndex;
 pub use self::file_backed_metastore_factory::FileBackedMetastoreFactory;
-use self::index::Index;
 use self::store_operations::{delete_index, fetch_index, index_exists, put_index};
 use crate::checkpoint::CheckpointDelta;
 use crate::{
@@ -44,11 +48,15 @@ use crate::{
 /// into as many files.
 pub struct FileBackedMetastore {
     storage: Arc<dyn Storage>,
-    per_index_metastores: RwLock<HashMap<String, Arc<Mutex<Index>>>>,
+    per_index_metastores: RwLock<HashMap<String, Arc<Mutex<FileBackedIndex>>>>,
     polling_interval_opt: Option<Duration>,
 }
 
-async fn poll_metastore_once(storage: &dyn Storage, index_id: &str, metadata_mutex: &Mutex<Index>) {
+async fn poll_metastore_once(
+    storage: &dyn Storage,
+    index_id: &str,
+    metadata_mutex: &Mutex<FileBackedIndex>,
+) {
     let index_fetch_res = fetch_index(&*storage, index_id).await;
     match index_fetch_res {
         Ok(index) => {
@@ -63,7 +71,7 @@ async fn poll_metastore_once(storage: &dyn Storage, index_id: &str, metadata_mut
 fn spawn_metastore_polling_task(
     storage: Arc<dyn Storage>,
     index_id: String,
-    metastore_weak: Weak<Mutex<Index>>,
+    metastore_weak: Weak<Mutex<FileBackedIndex>>,
     polling_interval: Duration,
 ) {
     tokio::task::spawn(async move {
@@ -108,7 +116,7 @@ impl FileBackedMetastore {
     async fn mutate(
         &self,
         index_id: &str,
-        mutation: impl FnOnce(&mut Index) -> crate::MetastoreResult<bool>,
+        mutation: impl FnOnce(&mut FileBackedIndex) -> crate::MetastoreResult<bool>,
     ) -> MetastoreResult<()> {
         let mut locked_index = self.get_locked_index(index_id).await?;
 
@@ -141,7 +149,7 @@ impl FileBackedMetastore {
     }
 
     async fn read<T, F>(&self, index_id: &str, view: F) -> MetastoreResult<T>
-    where F: FnOnce(&Index) -> MetastoreResult<T> {
+    where F: FnOnce(&FileBackedIndex) -> MetastoreResult<T> {
         let locked_index = self.get_locked_index(index_id).await?;
         view(&*locked_index)
     }
@@ -150,7 +158,10 @@ impl FileBackedMetastore {
     ///
     /// This function guarantees that the metadataset has not been
     /// marked as discarded.
-    async fn get_locked_index(&self, index_id: &str) -> MetastoreResult<OwnedMutexGuard<Index>> {
+    async fn get_locked_index(
+        &self,
+        index_id: &str,
+    ) -> MetastoreResult<OwnedMutexGuard<FileBackedIndex>> {
         loop {
             let index_mutex = self.index(index_id).await?;
             let index_lock = index_mutex.lock_owned().await;
@@ -167,7 +178,7 @@ impl FileBackedMetastore {
     /// and might trigger an error.
     ///
     /// For a given index_id, only copies of the same index_view are returned.
-    async fn index(&self, index_id: &str) -> MetastoreResult<Arc<Mutex<Index>>> {
+    async fn index(&self, index_id: &str) -> MetastoreResult<Arc<Mutex<FileBackedIndex>>> {
         {
             // Happy path!
             // If the object is already in our cache then we just return a copy
@@ -213,7 +224,7 @@ impl FileBackedMetastore {
 
     // Helper used for testing to obtain the data associated with the given index.
     #[cfg(test)]
-    async fn get_index(&self, index_id: &str) -> MetastoreResult<Index> {
+    async fn get_index(&self, index_id: &str) -> MetastoreResult<FileBackedIndex> {
         self.read(index_id, |index| Ok(index.clone())).await
     }
 
@@ -241,7 +252,7 @@ impl Metastore for FileBackedMetastore {
             });
         }
 
-        let index = Index::from(index_metadata);
+        let index = FileBackedIndex::from(index_metadata);
 
         put_index(&*self.storage, &index).await?;
 
@@ -355,7 +366,7 @@ impl Metastore for FileBackedMetastore {
     }
 
     async fn index_metadata(&self, index_id: &str) -> MetastoreResult<IndexMetadata> {
-        self.read(index_id, |index| Ok(index.index_metadata().clone()))
+        self.read(index_id, |index| Ok(index.metadata().clone()))
             .await
     }
 
@@ -393,7 +404,7 @@ mod tests {
     use tokio::time::Duration;
 
     use super::store_operations::put_index_given_index_id;
-    use super::Index;
+    use super::FileBackedIndex;
     use crate::checkpoint::CheckpointDelta;
     use crate::{
         FileBackedMetastore, IndexMetadata, Metastore, MetastoreError, SplitMetadata, SplitState,
@@ -449,10 +460,7 @@ mod tests {
             // Open index and check its metadata
             let created_index = metastore.get_index(index_id).await.unwrap();
             assert_eq!(created_index.index_id(), index_metadata.index_id);
-            assert_eq!(
-                created_index.index_metadata().index_uri,
-                index_metadata.index_uri
-            );
+            assert_eq!(created_index.metadata().index_uri, index_metadata.index_uri);
             // Open a non-existent index.
             let metastore_error = metastore.get_index("non-existent-index").await.unwrap_err();
             assert!(matches!(
@@ -546,7 +554,7 @@ mod tests {
             IndexMetadata::for_test("my-inconsistent-index", "ram://indexes/my-index");
 
         // Put inconsistent index into storage.
-        let index = Index::from(index_metadata);
+        let index = FileBackedIndex::from(index_metadata);
 
         put_index_given_index_id(&*storage, &index, index_id).await?;
 

--- a/quickwit-metastore/src/metastore/file_backed_metastore/store_operations.rs
+++ b/quickwit-metastore/src/metastore/file_backed_metastore/store_operations.rs
@@ -21,7 +21,7 @@ use std::path::{Path, PathBuf};
 
 use quickwit_storage::{Storage, StorageError, StorageErrorKind};
 
-use crate::metastore::file_backed_metastore::index::Index;
+use crate::metastore::file_backed_metastore::file_backed_index::FileBackedIndex;
 use crate::{MetastoreError, MetastoreResult};
 
 /// Metadata file managed by [`FileBackedMetastore`].
@@ -47,14 +47,17 @@ fn convert_error(index_id: &str, storage_err: StorageError) -> MetastoreError {
     }
 }
 
-pub(crate) async fn fetch_index(storage: &dyn Storage, index_id: &str) -> MetastoreResult<Index> {
+pub(crate) async fn fetch_index(
+    storage: &dyn Storage,
+    index_id: &str,
+) -> MetastoreResult<FileBackedIndex> {
     let metadata_path = meta_path(index_id);
     let content = storage
         .get_all(&metadata_path)
         .await
         .map_err(|storage_err| convert_error(index_id, storage_err))?;
 
-    let index: Index = serde_json::from_slice(&content[..])
+    let index: FileBackedIndex = serde_json::from_slice(&content[..])
         .map_err(|serde_err| MetastoreError::InvalidManifest { cause: serde_err })?;
 
     if index.index_id() != index_id {
@@ -85,7 +88,7 @@ pub(crate) async fn index_exists(storage: &dyn Storage, index_id: &str) -> Metas
 /// The point of having two methods here is just to make it usable in a unit test.
 pub(crate) async fn put_index_given_index_id(
     storage: &dyn Storage,
-    index: &Index,
+    index: &FileBackedIndex,
     index_id: &str,
 ) -> MetastoreResult<()> {
     // Serialize Index.
@@ -104,7 +107,10 @@ pub(crate) async fn put_index_given_index_id(
     Ok(())
 }
 /// Serializes the `Index` object and stores the data on the storage.
-pub(crate) async fn put_index(storage: &dyn Storage, index: &Index) -> MetastoreResult<()> {
+pub(crate) async fn put_index(
+    storage: &dyn Storage,
+    index: &FileBackedIndex,
+) -> MetastoreResult<()> {
     put_index_given_index_id(storage, index, index.index_id()).await
 }
 

--- a/quickwit-metastore/src/split_metadata.rs
+++ b/quickwit-metastore/src/split_metadata.rs
@@ -37,6 +37,7 @@ pub struct Split {
     pub update_timestamp: i64,
 
     /// Immutable part of the split.
+    #[serde(flatten)]
     pub split_metadata: SplitMetadata,
 }
 


### PR DESCRIPTION
### Description
Improve serialization format of `quickwit.json` file. Fixes #266.
```json
{
  "index": {},
  "splits": [{}, {}],
  "version": 0
}
```
### How was this PR tested?
- Added backward-compatibility tests
- Ran `make test-all` command
