### PR TITLE
Rename `quickwit.json` to `metastore.json`

### DIFF
--- a/quickwit-cli/tests/cli.rs
+++ b/quickwit-cli/tests/cli.rs
@@ -653,7 +653,7 @@ async fn test_all_local_index() -> Result<()> {
 
     let metadata_file_exists = test_env
         .storage
-        .exists(&Path::new(&test_env.index_id).join("quickwit.json"))
+        .exists(&Path::new(&test_env.index_id).join("metastore.json"))
         .await?;
     assert_eq!(metadata_file_exists, true);
 

--- a/quickwit-metastore/src/metastore/file_backed_metastore/mod.rs
+++ b/quickwit-metastore/src/metastore/file_backed_metastore/mod.rs
@@ -394,7 +394,6 @@ metastore_test_suite!(crate::FileBackedMetastore);
 #[cfg(test)]
 mod tests {
     use std::ops::RangeInclusive;
-    use std::path::Path;
     use std::sync::Arc;
 
     use chrono::Utc;
@@ -403,7 +402,7 @@ mod tests {
     use rand::Rng;
     use tokio::time::Duration;
 
-    use super::store_operations::put_index_given_index_id;
+    use super::store_operations::{meta_path, put_index_given_index_id};
     use super::FileBackedIndex;
     use crate::checkpoint::CheckpointDelta;
     use crate::{
@@ -487,7 +486,7 @@ mod tests {
             .expect_put()
             .times(2)
             .returning(move |path, put_payload| {
-                assert_eq!(path, Path::new("my-index/quickwit.json"));
+                assert_eq!(path, meta_path("my-index"));
                 block_on(ram_storage_clone.put(path, put_payload))
             });
         mock_storage

--- a/quickwit-metastore/src/metastore/file_backed_metastore/store_operations.rs
+++ b/quickwit-metastore/src/metastore/file_backed_metastore/store_operations.rs
@@ -25,11 +25,11 @@ use crate::metastore::file_backed_metastore::file_backed_index::FileBackedIndex;
 use crate::{MetastoreError, MetastoreResult};
 
 /// Metadata file managed by [`FileBackedMetastore`].
-const META_FILENAME: &str = "quickwit.json";
+const META_FILENAME: &str = "metastore.json";
 
 /// Path to the metadata file from the given index ID.
 pub(crate) fn meta_path(index_id: &str) -> PathBuf {
-    Path::new(index_id).join(Path::new(META_FILENAME))
+    Path::new(index_id).join(META_FILENAME)
 }
 
 fn convert_error(index_id: &str, storage_err: StorageError) -> MetastoreError {


### PR DESCRIPTION
### Description
Rename `quickwit.json` to `metastore.json`. Something we discussed with @fmassot. WDYT @fulmicoton?