### PR TITLE
Add errors attributes to rest search response.

### DIFF
--- a/quickwit-cli/src/index.rs
+++ b/quickwit-cli/src/index.rs
@@ -41,7 +41,7 @@ use quickwit_indexing::{index_data, STD_IN_SOURCE_ID};
 use quickwit_metastore::checkpoint::Checkpoint;
 use quickwit_metastore::{quickwit_metastore_uri_resolver, IndexMetadata, Split, SplitState};
 use quickwit_proto::{SearchRequest, SearchResponse};
-use quickwit_search::single_node_search;
+use quickwit_search::{single_node_search, SearchResponseRest};
 use quickwit_storage::{load_file, quickwit_storage_uri_resolver};
 use quickwit_telemetry::payload::TelemetryEvent;
 use serde_json::json;
@@ -742,7 +742,8 @@ pub async fn search_index(args: SearchIndexArgs) -> anyhow::Result<SearchRespons
 
 pub async fn search_index_cli(args: SearchIndexArgs) -> anyhow::Result<()> {
     let search_response: SearchResponse = search_index(args).await?;
-    let search_response_json = serde_json::to_string_pretty(&search_response)?;
+    let search_response_rest = SearchResponseRest::try_from(search_response)?;
+    let search_response_json = serde_json::to_string_pretty(&search_response_rest)?;
     println!("{}", search_response_json);
     Ok(())
 }

--- a/quickwit-search/src/search_response_rest.rs
+++ b/quickwit-search/src/search_response_rest.rs
@@ -34,6 +34,8 @@ pub struct SearchResponseRest {
     pub hits: Vec<serde_json::Value>,
     /// Elapsed time.
     pub elapsed_time_micros: u64,
+    /// Search errors.
+    pub errors: Vec<String>,
 }
 
 impl TryFrom<quickwit_proto::SearchResponse> for SearchResponseRest {
@@ -56,6 +58,7 @@ impl TryFrom<quickwit_proto::SearchResponse> for SearchResponseRest {
             num_hits: search_response.num_hits,
             hits,
             elapsed_time_micros: search_response.elapsed_time_micros,
+            errors: search_response.errors,
         })
     }
 }

--- a/quickwit-serve/src/rest.rs
+++ b/quickwit-serve/src/rest.rs
@@ -411,6 +411,7 @@ mod tests {
             num_hits: 55,
             hits: Vec::new(),
             elapsed_time_micros: 0u64,
+            errors: Vec::new(),
         };
         let search_response_json: serde_json::Value = serde_json::to_value(&search_response)?;
         let expected_search_response_json: serde_json::Value = json!({


### PR DESCRIPTION
I removed from the search CLI command the conversion of a search response into a rest search response because it didn't show the errors. However, this was a bad choice as when you print the `SearchResponse` it's quite ugly... see at the end the example.

This PR reintroduces the use of `SearchResponseRest` and add a new attribute `errors` to show errors.

```
{
      "json": "{\"_source\":[\"{\\\"id\\\":19162108755,\\\"event_type\\\":\\\"IssueCommentEvent\\\",\\\"actor_login\\\":\\\"fulmicoton\\\",\\\"repo_name\\\":\\\"quickwit-inc/quickwit\\\",\\\"created_at\\\":1638497795000,\\\"action\\\":\\\"created\\\",\\\"number\\\":831,\\\"title\\\":\\\"Missing allocation in LZ4 compression buffer.\\\",\\\"labels\\\":[\\\"bug\\\"],\\\"ref\\\":null,\\\"additions\\\":null,\\\"deletions\\\":null,\\\"commit_id\\\":null,\\\"body\\\":\\\"closing. It is in shipped in tantivy https://github.com/quickwit-inc/tantivy/pull/1226\\\"}\\n\"],\"body\":[\"closing. It is in shipped in tantivy https://github.com/quickwit-inc/tantivy/pull/1226\"],\"created_at\":[1638497795000],\"event_type\":[\"IssueCommentEvent\"],\"id\":[19162108755],\"title\":[\"Missing allocation in LZ4 compression buffer.\"]}",
      "partialHit": {
        "sortingFieldValue": 0,
        "splitId": "01FQSTE78XRMXM0W5ZHAETA0DK",
        "segmentOrd": 0,
        "docId": 1388550
      }
    }
```