### PR TITLE
Add and implement `add_source` and `delete_source` metastore APIs

### DIFF
--- a/quickwit-backward-compat/build.rs
+++ b/quickwit-backward-compat/build.rs
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashMap};
 
 use byte_unit::Byte;
 use quickwit_config::{
@@ -151,7 +151,8 @@ fn sample_index_metadata_for_regression() -> IndexMetadata {
         source_type: "kafka".to_string(),
         params: serde_json::json!({}),
     };
-    let sources = vec![kafka_source];
+    let mut sources = HashMap::new();
+    sources.insert(kafka_source.source_id.clone(), kafka_source);
 
     IndexMetadata {
         index_id: "my-index".to_string(),

--- a/quickwit-backward-compat/tests/test_backward_compatibility.rs
+++ b/quickwit-backward-compat/tests/test_backward_compatibility.rs
@@ -96,18 +96,7 @@ fn test_index_metadata_eq(index_metadata: &IndexMetadata, expected_index_metadat
         index_metadata.search_settings,
         expected_index_metadata.search_settings
     );
-    assert_eq!(
-        index_metadata
-            .sources
-            .iter()
-            .map(|source| &source.source_id)
-            .collect::<Vec<_>>(),
-        expected_index_metadata
-            .sources
-            .iter()
-            .map(|source| &source.source_id)
-            .collect::<Vec<_>>(),
-    );
+    assert_eq!(index_metadata.sources, expected_index_metadata.sources);
 }
 
 fn read_split_metadata(path: &Path) -> anyhow::Result<SplitMetadata> {

--- a/quickwit-cli/src/index.rs
+++ b/quickwit-cli/src/index.rs
@@ -607,10 +607,10 @@ pub async fn create_index_cli(args: CreateIndexArgs) -> anyhow::Result<()> {
         index_id: args.index_id.clone(),
         index_uri,
         checkpoint: Checkpoint::default(),
+        sources: index_config.sources(),
         doc_mapping: index_config.doc_mapping,
         indexing_settings: index_config.indexing_settings,
         search_settings: index_config.search_settings,
-        sources: index_config.sources,
         create_timestamp: Utc::now().timestamp(),
         update_timestamp: Utc::now().timestamp(),
     };
@@ -672,7 +672,9 @@ pub async fn ingest_docs_cli(args: IngestDocsArgs) -> anyhow::Result<()> {
         source_type,
         params,
     };
-    index_metadata.sources = vec![source_config.clone()];
+    index_metadata
+        .sources
+        .insert(source_config.source_id.clone(), source_config);
     let indexer_config = IndexerConfig {
         ..Default::default()
     };
@@ -773,7 +775,9 @@ pub async fn merge_or_demux_cli(
     let mut index_metadata = metastore.index_metadata(&args.index_id).await?;
     let storage_uri_resolver = quickwit_storage_uri_resolver();
     let storage = storage_uri_resolver.resolve(&index_metadata.index_uri)?;
-    index_metadata.sources = vec![source_config];
+    index_metadata
+        .sources
+        .insert(source_config.source_id.clone(), source_config);
     let indexer_config = IndexerConfig {
         ..Default::default()
     };

--- a/quickwit-cli/src/lib.rs
+++ b/quickwit-cli/src/lib.rs
@@ -101,7 +101,7 @@ pub async fn run_index_checklist(
             check_source_connectivity(source_config).await,
         ));
     } else {
-        for source_config in index_metadata.sources.iter() {
+        for source_config in index_metadata.sources.values() {
             checks.push((
                 source_config.source_id.as_str(),
                 check_source_connectivity(source_config).await,

--- a/quickwit-config/src/index_config.rs
+++ b/quickwit-config/src/index_config.rs
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashMap};
 use std::ffi::OsStr;
 use std::path::Path;
 use std::time::Duration;
@@ -194,7 +194,7 @@ pub struct SearchSettings {
     pub default_search_fields: Vec<String>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct SourceConfig {
     pub source_id: String,
     pub source_type: String,
@@ -255,7 +255,17 @@ impl IndexConfig {
         serde_yaml::from_slice(bytes).context("Failed to parse YAML index config file.")
     }
 
+    pub fn sources(&self) -> HashMap<String, SourceConfig> {
+        self.sources
+            .iter()
+            .map(|source| (source.source_id.clone(), source.clone()))
+            .collect()
+    }
+
     fn validate(&self) -> anyhow::Result<()> {
+        if self.sources.len() < self.sources().len() {
+            bail!("Index config contains duplicate sources.")
+        }
         Ok(())
     }
 }

--- a/quickwit-indexing/src/test_utils.rs
+++ b/quickwit-indexing/src/test_utils.rs
@@ -101,7 +101,7 @@ impl TestSandbox {
             .into_iter()
             .map(|doc_json| doc_json.to_string())
             .collect();
-        let source_config = SourceConfig {
+        let source = SourceConfig {
             source_id: self.index_meta.index_id.clone(),
             source_type: "vec".to_string(),
             params: serde_json::to_value(VecSourceParams {
@@ -111,7 +111,9 @@ impl TestSandbox {
             })?,
         };
         let mut index_meta = self.index_meta.clone();
-        index_meta.sources = vec![source_config];
+        index_meta.sources.clear();
+        index_meta.sources.insert(source.source_id.clone(), source);
+
         self.add_docs_id.fetch_add(1, Ordering::SeqCst);
         let statistics = index_data(
             self._temp_dir.path(),

--- a/quickwit-metastore/src/error.rs
+++ b/quickwit-metastore/src/error.rs
@@ -66,6 +66,12 @@ pub enum MetastoreError {
     #[error("Publish checkpoint delta overlaps with the current checkpoint: {0:?}.")]
     IncompatibleCheckpointDelta(#[from] IncompatibleCheckpointDelta),
 
+    #[error("Source `{source_id}` of type `{source_type}` already exists.")]
+    SourceAlreadyExists {
+        source_id: String,
+        source_type: String,
+    },
+
     #[cfg(feature = "postgres")]
     #[error("Database error: {0:?}.")]
     DbError(diesel::result::Error),

--- a/quickwit-metastore/src/error.rs
+++ b/quickwit-metastore/src/error.rs
@@ -72,6 +72,9 @@ pub enum MetastoreError {
         source_type: String,
     },
 
+    #[error("Source `{source_id}` does not exist.")]
+    SourceDoesNotExist { source_id: String },
+
     #[cfg(feature = "postgres")]
     #[error("Database error: {0:?}.")]
     DbError(diesel::result::Error),

--- a/quickwit-metastore/src/metastore/file_backed_metastore/file_backed_index.rs
+++ b/quickwit-metastore/src/metastore/file_backed_metastore/file_backed_index.rs
@@ -26,6 +26,7 @@ use std::ops::{Range, RangeInclusive};
 
 use chrono::Utc;
 use itertools::Itertools;
+use quickwit_config::SourceConfig;
 use quickwit_index_config::tag_pruning::TagFilterAst;
 use serde::{Deserialize, Serialize};
 
@@ -369,5 +370,9 @@ impl FileBackedIndex {
 
         self.metadata.update_timestamp = Utc::now().timestamp();
         Ok(())
+    }
+
+    pub(crate) fn add_source(&mut self, source: SourceConfig) -> MetastoreResult<bool> {
+        self.metadata.add_source(source)
     }
 }

--- a/quickwit-metastore/src/metastore/file_backed_metastore/file_backed_index.rs
+++ b/quickwit-metastore/src/metastore/file_backed_metastore/file_backed_index.rs
@@ -375,4 +375,8 @@ impl FileBackedIndex {
     pub(crate) fn add_source(&mut self, source: SourceConfig) -> MetastoreResult<bool> {
         self.metadata.add_source(source)
     }
+
+    pub(crate) fn delete_source(&mut self, source_id: &str) -> MetastoreResult<bool> {
+        self.metadata.delete_source(source_id)
+    }
 }

--- a/quickwit-metastore/src/metastore/file_backed_metastore/mod.rs
+++ b/quickwit-metastore/src/metastore/file_backed_metastore/mod.rs
@@ -351,6 +351,11 @@ impl Metastore for FileBackedMetastore {
             .await
     }
 
+    async fn delete_source(&self, index_id: &str, source_id: &str) -> MetastoreResult<()> {
+        self.mutate(index_id, |index| index.delete_source(source_id))
+            .await
+    }
+
     /// -------------------------------------------------------------------------------
     /// Read-only accessors
 

--- a/quickwit-metastore/src/metastore/file_backed_metastore/mod.rs
+++ b/quickwit-metastore/src/metastore/file_backed_metastore/mod.rs
@@ -31,6 +31,7 @@ use std::sync::{Arc, Weak};
 use std::time::Duration;
 
 use async_trait::async_trait;
+use quickwit_config::SourceConfig;
 use quickwit_index_config::tag_pruning::TagFilterAst;
 use quickwit_storage::Storage;
 use tokio::sync::{Mutex, OwnedMutexGuard, RwLock};
@@ -343,6 +344,11 @@ impl Metastore for FileBackedMetastore {
             Ok(true)
         })
         .await
+    }
+
+    async fn add_source(&self, index_id: &str, source: SourceConfig) -> MetastoreResult<()> {
+        self.mutate(index_id, |index| index.add_source(source))
+            .await
     }
 
     /// -------------------------------------------------------------------------------

--- a/quickwit-metastore/src/metastore/index_metadata.rs
+++ b/quickwit-metastore/src/metastore/index_metadata.rs
@@ -176,6 +176,15 @@ impl IndexMetadata {
         Ok(true)
     }
 
+    pub(crate) fn delete_source(&mut self, source_id: &str) -> MetastoreResult<bool> {
+        self.sources
+            .remove(source_id)
+            .ok_or_else(|| MetastoreError::SourceDoesNotExist {
+                source_id: source_id.to_string(),
+            })?;
+        Ok(true)
+    }
+
     /// Builds and returns the doc mapper associated with index.
     pub fn build_doc_mapper(&self) -> anyhow::Result<Arc<dyn DocMapper>> {
         let mut builder = DocMapperBuilder::new();

--- a/quickwit-metastore/src/metastore/mod.rs
+++ b/quickwit-metastore/src/metastore/mod.rs
@@ -157,6 +157,10 @@ pub trait Metastore: Send + Sync + 'static {
     /// same ID is already defined for the index.
     async fn add_source(&self, index_id: &str, source: SourceConfig) -> MetastoreResult<()>;
 
+    /// Deletes a source. Fails with [`MetastoreError::SourceDoesNotExist`] if the specified source
+    /// does not exist.
+    async fn delete_source(&self, index_id: &str, source_id: &str) -> MetastoreResult<()>;
+
     /// Returns the Metastore uri.
     fn uri(&self) -> String;
 }

--- a/quickwit-metastore/src/metastore/mod.rs
+++ b/quickwit-metastore/src/metastore/mod.rs
@@ -26,6 +26,7 @@ use std::ops::Range;
 
 use async_trait::async_trait;
 pub use index_metadata::IndexMetadata;
+use quickwit_config::SourceConfig;
 use quickwit_index_config::tag_pruning::TagFilterAst;
 
 use crate::checkpoint::CheckpointDelta;
@@ -151,6 +152,10 @@ pub trait Metastore: Send + Sync + 'static {
     /// storage.
     async fn delete_splits<'a>(&self, index_id: &str, split_ids: &[&'a str])
         -> MetastoreResult<()>;
+
+    /// Adds a new source. Fails with [`MetastoreError::SourceAlreadyExists`] if a source with the
+    /// same ID is already defined for the index.
+    async fn add_source(&self, index_id: &str, source: SourceConfig) -> MetastoreResult<()>;
 
     /// Returns the Metastore uri.
     fn uri(&self) -> String;

--- a/quickwit-metastore/src/metastore/postgresql_metastore.rs
+++ b/quickwit-metastore/src/metastore/postgresql_metastore.rs
@@ -742,6 +742,17 @@ impl Metastore for PostgresqlMetastore {
         Ok(())
     }
 
+    async fn delete_source(&self, index_id: &str, source_id: &str) -> MetastoreResult<()> {
+        let conn = self.get_conn()?;
+        conn.transaction::<_, MetastoreError, _>(|| {
+            let mut index_metadata = self.index_metadata_inner(&conn, index_id)?;
+            index_metadata.delete_source(source_id)?;
+            self.update_index(&conn, index_metadata)?;
+            Ok(())
+        })?;
+        Ok(())
+    }
+
     fn uri(&self) -> String {
         self.uri.clone()
     }


### PR DESCRIPTION
### Description
- Stores sources in hashmap rather than vector.
- Add and implement `add_source` and `delete_source` metastore APIs

### How was this PR tested?
- added unit tests
- ran `make test-all`
