### PR TITLE
Changing log line when index uri is missing.

### DIFF
--- a/quickwit-cli/src/index.rs
+++ b/quickwit-cli/src/index.rs
@@ -590,7 +590,10 @@ pub async fn create_index_cli(args: CreateIndexArgs) -> anyhow::Result<()> {
             "{}/{}",
             quickwit_config.default_index_root_uri, args.index_id
         );
-        info!("`index-uri` is not specified in the index configuration. Setting it to `{}`.", default_index_uri);
+        info!(
+            "`index-uri` is not specified in the index configuration. Setting it to `{}`.",
+            default_index_uri
+        );
         default_index_uri
     };
     let file_content = load_file(&args.index_config_uri).await?;

--- a/quickwit-cli/src/index.rs
+++ b/quickwit-cli/src/index.rs
@@ -590,7 +590,7 @@ pub async fn create_index_cli(args: CreateIndexArgs) -> anyhow::Result<()> {
             "{}/{}",
             quickwit_config.default_index_root_uri, args.index_id
         );
-        info!("`index-uri` is missing, set it to `{}`.", default_index_uri);
+        info!("`index-uri` is not specified in the index configuration. Setting it to `{}`.", default_index_uri);
         default_index_uri
     };
     let file_content = load_file(&args.index_config_uri).await?;


### PR DESCRIPTION
I was confused by the following output as I was running the clickhouse tutorial.

```
❯ quickwit index create --index gh-archive --index-config gh-archive-index-config.yaml
2021-12-30T15:33:56.635Z  INFO quickwit: version="0.1.0" commit="30eb30b"
2021-12-30T15:33:56.636Z  WARN quickwit_config::config: Peer seed list is empty.
2021-12-30T15:33:56.636Z  INFO quickwit_cli: Loaded Quickwit config. config_uri=file:///home/fulmicoton/git/clickhouse-test/datadir/config/quickwit.yaml config=QuickwitConfig { version: 0, node_id: "node-wispy-SV6b", metastore_uri: "file:///home/fulmicoton/git/clickhouse-test/datadir/qwdata/indexes", default_index_root_uri: "file:///home/fulmicoton/git/clickhouse-test/datadir/qwdata/indexes", data_dir_path: "./qwdata", indexer_config: IndexerConfig { rest_listen_address: "127.0.0.1", rest_listen_port: 7180, split_store_max_num_bytes: Byte(100000000000), split_store_max_num_splits: 1000 }, searcher_config: SearcherConfig { rest_listen_address: "127.0.0.1", rest_listen_port: 7280, peer_seeds: [], fast_field_cache_capacity: Byte(1000000000), split_footer_cache_capacity: Byte(500000000) }, storage_config: None }
2021-12-30T15:33:56.636Z  INFO quickwit_cli::index: `index-uri` is missing, set it to `file:///home/fulmicoton/git/clickhouse-test/datadir/qwdata/indexes/gh-archive`.
```

The confusing line:
```
2021-12-30T15:33:56.636Z  INFO quickwit_cli::index: `index-uri` is missing, set it to `file:///home/fulmicoton/git/clickhouse-test/datadir/qwdata/indexes/gh-archive`.
```

I thought the line was asking me to set index-uri to the value given.