### PR TITLE
check SocketAddr when node joins cluster

### DIFF
--- a/quickwit-cli/src/generate_markdown.rs
+++ b/quickwit-cli/src/generate_markdown.rs
@@ -62,17 +62,14 @@ fn markdown_for_subcommand(
         }
         val_opt
     };
-    let long_about_opt: Option<&str> = subcommand_ext
-        .map(|el| el.get("long_about").map(|el| el.as_str()).flatten())
-        .flatten();
+    let long_about_opt: Option<&str> =
+        subcommand_ext.and_then(|el| el.get("long_about").and_then(|el| el.as_str()));
 
-    let note: Option<&str> = subcommand_ext
-        .map(|el| el.get("note").map(|el| el.as_str()).flatten())
-        .flatten();
+    let note: Option<&str> =
+        subcommand_ext.and_then(|el| el.get("note").and_then(|el| el.as_str()));
 
-    let examples_opt: Option<&Vec<Value>> = subcommand_ext
-        .map(|el| el.get("examples").map(|el| el.as_array()).flatten())
-        .flatten();
+    let examples_opt: Option<&Vec<Value>> =
+        subcommand_ext.and_then(|el| el.get("examples").and_then(|el| el.as_array()));
 
     if let Some(about) = long_about_opt {
         if !about.trim().is_empty() {

--- a/quickwit-swim/src/member.rs
+++ b/quickwit-swim/src/member.rs
@@ -29,7 +29,7 @@ pub struct ArtilleryMember {
     #[serde(rename = "r")]
     remote_host: Option<SocketAddr>,
     #[serde(rename = "i")]
-    incarnation_number: u64,
+    pub incarnation_number: u64,
     #[serde(rename = "m")]
     member_state: ArtilleryMemberState,
     #[serde(rename = "t", skip, default = "Instant::now")]
@@ -73,6 +73,10 @@ impl ArtilleryMember {
 
     pub fn remote_host(&self) -> Option<SocketAddr> {
         self.remote_host
+    }
+
+    pub fn set_remote_host(&mut self, addr: SocketAddr) {
+        self.remote_host = Some(addr);
     }
 
     pub fn is_remote(&self) -> bool {

--- a/quickwit-swim/src/member.rs
+++ b/quickwit-swim/src/member.rs
@@ -25,7 +25,7 @@ pub enum ArtilleryMemberState {
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct ArtilleryMember {
     #[serde(rename = "h")]
-    node_id: String,
+    pub node_id: String,
     #[serde(rename = "r")]
     remote_host: Option<SocketAddr>,
     #[serde(rename = "i")]
@@ -164,13 +164,7 @@ impl Debug for ArtilleryMember {
                 "drift_time_ms",
                 &self.last_state_change.elapsed().as_millis(),
             )
-            .field(
-                "remote_host",
-                &self
-                    .remote_host
-                    .map_or(String::from("(current)"), |r| format!("{}", r))
-                    .as_str(),
-            )
+            .field("remote_host", &self.remote_host)
             .finish()
     }
 }

--- a/quickwit-swim/src/membership.rs
+++ b/quickwit-swim/src/membership.rs
@@ -5,6 +5,7 @@ use std::net::SocketAddr;
 use std::time::Duration;
 
 use rand::prelude::SliceRandom;
+use tracing::info;
 
 use crate::member::{self, ArtilleryMember, ArtilleryMemberState, ArtilleryStateChange};
 
@@ -200,8 +201,11 @@ impl ArtilleryMemberList {
                     .unwrap();
                 let update_member = update_member.member_by_changing_host(new_host);
 
-                if update_member.state() != existing_member.state() {
+                if existing_member.node_id != member_change.node_id() {
+                    info!(old_node_id=?existing_member.node_id(), new_node_id=?member_change.node_id(), "updating node id from state change.");
                     existing_member.node_id = member_change.node_id();
+                }
+                if update_member.state() != existing_member.state() {
                     existing_member.set_state(update_member.state());
                     existing_member.incarnation_number = update_member.incarnation_number;
                     if let Some(host) = update_member.remote_host() {

--- a/quickwit-swim/src/state.rs
+++ b/quickwit-swim/src/state.rs
@@ -446,6 +446,9 @@ impl ArtilleryEpidemic {
     }
 
     fn ensure_node_is_member(&mut self, src_addr: SocketAddr, node_id: String) {
+        if node_id == self.host_id {
+            return;
+        }
         if self.members.has_member(&src_addr) {
             return;
         }

--- a/quickwit-swim/src/state.rs
+++ b/quickwit-swim/src/state.rs
@@ -329,10 +329,15 @@ impl ArtilleryEpidemic {
         use Request::*;
 
         if message.cluster_key == self.config.cluster_key {
-            // We want to abort if a new member has the same node_id of an existing member.  
+            // We want to abort if a new member has the same node_id of an existing member.
             // A new member is detected according to its socket address.
-            if !self.members.has_member(&src_addr) && self.members.get_member(&message.sender).is_some() {
-                error!("Cannot add a member with a node-id `{}` already present in the cluster.", message.sender);
+            if !self.members.has_member(&src_addr)
+                && self.members.get_member(&message.sender).is_some()
+            {
+                error!(
+                    "Cannot add a member with a node-id `{}` already present in the cluster.",
+                    message.sender
+                );
                 return;
             }
 


### PR DESCRIPTION
Check SocketAddr when node joins cluster to avoid duplicates when node-id changes

Fixes #1018

### Description
Describe the proposed changes made in this PR.

### How was this PR tested?
Describe how you tested this PR.
