### PR TITLE
Update demux maturity implementation with the new tag system.

### DIFF
--- a/quickwit-doc-mapper/src/tag_pruning.rs
+++ b/quickwit-doc-mapper/src/tag_pruning.rs
@@ -83,15 +83,14 @@ enum TermFilterAst {
 
 /// Records terms into a set of tags.
 ///
-/// If no terms are available for a given field, it is still
-/// beneficial to call this method with an empty array for values.
-///
-/// In that case, we will record a tag marking that the field has been
-/// processed, allowing for pruning of the split.
-pub fn append_to_tag_set(field: &str, values: &[String], tag_set: &mut BTreeSet<String>) {
-    tag_set.insert(field_tag(field));
+/// A special tag `{field_name}!` is always added to the tag set.
+/// It indicates that `{field_name}` is in the list of the
+/// `DocMapper` attribute `tag_fields`.
+/// See [`SplitMetadata`] for more details.
+pub fn append_to_tag_set(field_name: &str, values: &[String], tag_set: &mut BTreeSet<String>) {
+    tag_set.insert(field_tag(field_name));
     for value in values {
-        tag_set.insert(term_tag(field, value));
+        tag_set.insert(term_tag(field_name, value));
     }
 }
 
@@ -205,8 +204,10 @@ fn simplify_ast(ast: UnsimplifiedTagFilterAst) -> Option<TermFilterAst> {
     }
 }
 
-fn field_tag(field: &str) -> String {
-    format!("{}!", field)
+/// Special tag to indicate that a field is listed in the
+/// `DocMapper` `tag_fields` attribute.
+pub fn field_tag(field_name: &str) -> String {
+    format!("{}!", field_name)
 }
 
 fn term_tag(field: &str, value: &str) -> String {

--- a/quickwit-indexing/src/merge_policy.rs
+++ b/quickwit-indexing/src/merge_policy.rs
@@ -272,7 +272,7 @@ impl StableMultitenantWithTimestampMergePolicy {
         // strictly superior to [`MAX_VALUES_PER_TAG_FIELD`]. When inferior,
         // tags always contains the special tag `field_tag(demux_field_name)`.
         // This is why we have to check first if this special tag is present and then
-        // consider the split mature if we have less that one demux value.
+        // consider the split mature if we have less than two demux value.
         if split.tags.contains(&field_tag(demux_field_name))
             && split
                 .tags

--- a/quickwit-indexing/src/merge_policy.rs
+++ b/quickwit-indexing/src/merge_policy.rs
@@ -269,7 +269,7 @@ impl StableMultitenantWithTimestampMergePolicy {
         }
         let demux_field_name = self.demux_field_name.as_ref().unwrap();
         // Note: split metadata tags is empty when demux values have a cardinality
-        // is strictly superior to [`MAX_VALUES_PER_TAG_FIELD`]. When inferior,
+        // strictly superior to [`MAX_VALUES_PER_TAG_FIELD`]. When inferior,
         // tags always contains the special tag `field_tag(demux_field_name)`.
         // This is why we have to check first if this special tag is present and then
         // consider the split mature if we have less that one demux value.

--- a/quickwit-metastore/src/split_metadata.rs
+++ b/quickwit-metastore/src/split_metadata.rs
@@ -82,7 +82,7 @@ pub struct SplitMetadata {
     /// The set is filled at indexing with values from each field registered
     /// in the [`DocMapping`] `tag_fields` attribute and only when cardinality
     /// of a given field is less or equal to [`MAX_VALUES_PER_TAG_FIELD`].
-    /// A additional special tag of form `{field_name!}` is added to the set
+    /// An additional special tag of the form `{field_name}!` is added to the set
     /// to indicate that this field `field_name` was indeed registered in `tag_fields`.
     /// When cardinality is strictly higher than [`MAX_VALUES_PER_TAG_FIELD`],
     /// no field value is added to the set.

--- a/quickwit-metastore/src/split_metadata.rs
+++ b/quickwit-metastore/src/split_metadata.rs
@@ -78,7 +78,14 @@ pub struct SplitMetadata {
     #[serde(default = "utc_now_timestamp")]
     pub create_timestamp: i64,
 
-    /// A set of tags for categorizing and searching group of splits.
+    /// Set of unique tags values of form `{field_name}:{field_value}`.
+    /// The set is filled at indexing with values from each field registered
+    /// in the [`DocMapping`] `tag_fields` attribute and only when cardinality
+    /// of a given field is less or equal to [`MAX_VALUES_PER_TAG_FIELD`].
+    /// A additional special tag of form `{field_name!}` is added to the set
+    /// to indicate that this field `field_name` was indeed registered in `tag_fields`.
+    /// When cardinality is strictly higher than [`MAX_VALUES_PER_TAG_FIELD`],
+    /// no field value is added to the set.
     #[serde(default)]
     pub tags: BTreeSet<String>,
 

--- a/quickwit-search/src/lib.rs
+++ b/quickwit-search/src/lib.rs
@@ -134,7 +134,6 @@ async fn list_relevant_splits(
 ) -> crate::Result<Vec<SplitMetadata>> {
     let time_range_opt =
         extract_time_range(search_request.start_timestamp, search_request.end_timestamp);
-    // TODO: will be removed after #issues/823 is solved
     let tags_filter = extract_tags_from_query(&search_request.query)?;
     let split_metas = metastore
         .list_splits(


### PR DESCRIPTION
I update the merge policy so that we can correctly identify the splits to demux.

Few notes:
I was very surprised by the usage of the special tag `tag_field!` which indicates that, for a given split, the field is registered as `tagged`, I was expecting a special tag like "indicates that there are no tags in a split" like described in #887 examples. It's working well and I understand why this is like this, it was just me that did not understand correctly the usage.
Just to be clear, I will rewrite the example I wrote in #887:

`split_1`: no tag values => metadata contains `tag_field!`
`split_2`: contains one value `tag_field:value` => metadata contains `tag_field:value` and `tag_field!`
`split_3`: too many tag values => metadata tags is empty
`split_4`: `tag_field` was not configured as a tag field at that point. metadata does not contain `tag_field!`.


@fulmicoton can you confirm that this is the implementation you have in mind when you open issue #887?

I added some documentation as it's not super easy to understand.

