### PR TITLE
Put index-uri and index-id in IndexConfig, update --id to --source fo…

### DIFF
--- a/quickwit-cli/src/cli.yaml
+++ b/quickwit-cli/src/cli.yaml
@@ -12,20 +12,11 @@ subcommands:
                 about: Creates an index.
                 display_order: 1
                 args:
-                    - index:
-                        about: ID of the target index.
-                        long: index
-                        value_name: INDEX
-                        required: true
                     - index-config:
                         about: Location of the index config file.
                         long: index-config
                         value_name: INDEX CONFIG
                         required: true
-                    - index-uri:
-                        about: Index data (or splits) storage URI.
-                        long: index-uri
-                        value_name: INDEX URI
                     - config:
                         about: Quickwit config file.
                         long: config
@@ -372,9 +363,9 @@ subcommands:
                         long: index
                         value_name: INDEX
                         required: true
-                    - id:
+                    - source:
                         about: ID of the source.
-                        long: id
+                        long: source
                         value_name: SOURCE ID
                         required: true
                     - type:

--- a/quickwit-cli/src/main.rs
+++ b/quickwit-cli/src/main.rs
@@ -168,10 +168,6 @@ mod tests {
         let matches = app.try_get_matches_from(vec![
             "index",
             "create",
-            "--index",
-            "wikipedia",
-            "--index-uri",
-            "s3://quickwit-bucket/indexes/wikipedia",
             "--index-config",
             "index-conf.yaml",
             "--config",
@@ -184,8 +180,6 @@ mod tests {
         ))
         .unwrap();
         let expected_cmd = CliCommand::Index(IndexCliCommand::Create(CreateIndexArgs {
-            index_id: "wikipedia".to_string(),
-            index_uri: Some(Uri::try_new("s3://quickwit-bucket/indexes/wikipedia").unwrap()),
             config_uri: Uri::try_new("file:///config.yaml").unwrap(),
             index_config_uri: expected_index_config_uri.clone(),
             overwrite: false,
@@ -197,8 +191,6 @@ mod tests {
         let matches = app.try_get_matches_from(vec![
             "index",
             "create",
-            "--index",
-            "wikipedia",
             "--index-config",
             "index-conf.yaml",
             "--config",
@@ -207,8 +199,6 @@ mod tests {
         ])?;
         let command = CliCommand::parse_cli_args(&matches)?;
         let expected_cmd = CliCommand::Index(IndexCliCommand::Create(CreateIndexArgs {
-            index_id: "wikipedia".to_string(),
-            index_uri: None,
             config_uri: Uri::try_new("file:///config.yaml").unwrap(),
             index_config_uri: expected_index_config_uri,
             overwrite: true,

--- a/quickwit-cli/src/source.rs
+++ b/quickwit-cli/src/source.rs
@@ -102,9 +102,9 @@ impl SourceCliCommand {
             .map(String::from)
             .expect("`index` is a required arg.");
         let source_id = matches
-            .value_of("id")
+            .value_of("source")
             .map(String::from)
-            .expect("`id` is a required arg.");
+            .expect("`source` is a required arg.");
         let source_type = matches
             .value_of("type")
             .map(String::from)
@@ -424,7 +424,7 @@ mod tests {
                 "add",
                 "--index",
                 "hdfs-logs",
-                "--id",
+                "--source",
                 "hdfs-logs-source",
                 "--type",
                 "kafka",

--- a/quickwit-cli/tests/cli.rs
+++ b/quickwit-cli/tests/cli.rs
@@ -40,9 +40,7 @@ use crate::helpers::{create_test_env, make_command, spawn_command};
 fn create_logs_index(test_env: &TestEnv) {
     make_command(
         format!(
-            "index create --index {} --index-uri {} --index-config {} --config {}",
-            test_env.index_id,
-            test_env.index_uri(),
+            "index create --index-config {} --config {}",
             test_env.resource_files["index_config"].display(),
             test_env.resource_files["config"].display(),
         )
@@ -97,9 +95,8 @@ async fn test_cmd_create() -> Result<()> {
     let test_env = create_test_env(index_id, TestStorageType::LocalFileSystem)?;
     make_command(
         format!(
-            "index create --index {} --index-config {} --config {}",
-            test_env.index_id,
-            test_env.resource_files["index_config"].display(),
+            "index create --index-config {} --config {}",
+            test_env.resource_files["index_config_without_uri"].display(),
             test_env.resource_files["config"].display(),
         )
         .as_str(),
@@ -135,8 +132,7 @@ fn test_cmd_create_on_existing_index() -> Result<()> {
 
     make_command(
         format!(
-            "index create --index {} --index-config {} --config {}",
-            test_env.index_id,
+            "index create --index-config {} --config {}",
             test_env.resource_files["index_config"].display(),
             test_env.resource_files["config"].display(),
         )
@@ -575,9 +571,7 @@ async fn test_cmd_dry_run_delete_on_s3_localstack() -> Result<()> {
     let test_env = create_test_env(index_id, TestStorageType::S3)?;
     make_command(
         format!(
-            "index create --index {} --index-uri {} --config {} --index-config {}",
-            test_env.index_id,
-            test_env.index_uri(),
+            "index create --config {} --index-config {}",
             test_env.resource_files["config"].display(),
             test_env.resource_files["index_config"].display()
         )
@@ -639,9 +633,7 @@ async fn test_all_local_index() -> Result<()> {
     let test_env = create_test_env(index_id, TestStorageType::LocalFileSystem)?;
     make_command(
         format!(
-            "index create --index {} --index-uri {} --index-config {} --config {}",
-            test_env.index_id,
-            test_env.index_uri(),
+            "index create --index-config {} --config {}",
             test_env.resource_files["index_config"].display(),
             test_env.resource_files["config"].display()
         )
@@ -721,9 +713,7 @@ async fn test_all_with_s3_localstack_cli() -> Result<()> {
     let test_env = create_test_env(index_id, TestStorageType::S3)?;
     make_command(
         format!(
-            "index create --index {} --index-uri {} --index-config {} --config {}",
-            test_env.index_id,
-            test_env.index_uri(),
+            "index create --index-config {} --config {}",
             test_env.resource_files["index_config"].display(),
             test_env.resource_files["config"].display()
         )
@@ -810,8 +800,6 @@ async fn test_all_with_s3_localstack_internal_api() -> Result<()> {
     let index_id = append_random_suffix("test-all--cli-API");
     let test_env = create_test_env(index_id, TestStorageType::S3)?;
     let args = CreateIndexArgs {
-        index_id: test_env.index_id.clone(),
-        index_uri: Some(test_env.index_uri()),
         index_config_uri: Uri::try_new(test_env.resource_files["index_config"].to_str().unwrap())
             .unwrap(),
         config_uri: Uri::try_new(&test_env.resource_files["config"].display().to_string()).unwrap(),

--- a/quickwit-cli/tests/helpers.rs
+++ b/quickwit-cli/tests/helpers.rs
@@ -73,7 +73,7 @@ const DEFAULT_INDEX_CONFIG: &str = r#"
 const DEFAULT_QUICKWIT_CONFIG: &str = r#"
     version: 0
     metastore_uri: #metastore_uri
-    data_dir_path: #data_dir_path
+    data_dir: #data_dir
     rest_listen_port: #rest_listen_port
 "#;
 
@@ -143,6 +143,7 @@ pub struct TestEnv {
     pub metastore_uri: String,
     /// The index ID.
     pub index_id: String,
+    pub index_uri: Uri,
     pub rest_listen_port: u16,
     pub storage: Arc<dyn Storage>,
 }
@@ -151,10 +152,6 @@ impl TestEnv {
     // For cache reason, it's safer to always create an instance and then make your assertions.
     pub fn metastore(&self) -> FileBackedMetastore {
         FileBackedMetastore::new(self.storage.clone())
-    }
-
-    pub fn index_uri(&self) -> Uri {
-        Uri::try_new(&format!("{}/{}", self.metastore_uri, self.index_id)).unwrap()
     }
 }
 
@@ -190,8 +187,21 @@ pub fn create_test_env(index_id: String, storage_type: TestStorageType) -> anyho
             (metastore_uri.to_string(), storage)
         }
     };
+    let index_uri = Uri::try_new(&format!("{}/{}", metastore_uri, index_id))?;
     let index_config_path = resources_dir_path.join("index_config.yaml");
-    fs::write(&index_config_path, DEFAULT_INDEX_CONFIG)?;
+    fs::write(
+        &index_config_path,
+        DEFAULT_INDEX_CONFIG
+            .replace("#index_id", &index_id)
+            .replace("#index_uri", &index_uri.to_string()),
+    )?;
+    let index_config_without_uri_path = resources_dir_path.join("index_config_without_uri.yaml");
+    fs::write(
+        &index_config_without_uri_path,
+        DEFAULT_INDEX_CONFIG
+            .replace("#index_id", &index_id)
+            .replace("index_uri: #index_uri\n", ""),
+    )?;
     let quickwit_config_path = resources_dir_path.join("config.yaml");
     let rest_listen_port = find_available_port()?;
     fs::write(
@@ -199,10 +209,7 @@ pub fn create_test_env(index_id: String, storage_type: TestStorageType) -> anyho
         // A poor's man templating engine reloaded...
         DEFAULT_QUICKWIT_CONFIG
             .replace("#metastore_uri", &metastore_uri)
-            .replace(
-                "#data_dir_path",
-                &data_dir_path.to_str().unwrap().to_string(),
-            )
+            .replace("#data_dir", &data_dir_path.to_str().unwrap().to_string())
             .replace("#rest_listen_port", &rest_listen_port.to_string()),
     )?;
     let log_docs_path = resources_dir_path.join("logs.json");
@@ -213,6 +220,7 @@ pub fn create_test_env(index_id: String, storage_type: TestStorageType) -> anyho
     let mut resource_files = HashMap::new();
     resource_files.insert("config", quickwit_config_path);
     resource_files.insert("index_config", index_config_path);
+    resource_files.insert("index_config_without_uri", index_config_without_uri_path);
     resource_files.insert("logs", log_docs_path);
     resource_files.insert("wiki", wikipedia_docs_path);
 
@@ -223,6 +231,7 @@ pub fn create_test_env(index_id: String, storage_type: TestStorageType) -> anyho
         resource_files,
         metastore_uri,
         index_id,
+        index_uri,
         rest_listen_port,
         storage,
     })

--- a/quickwit-config/resources/tests/config/quickwit.json
+++ b/quickwit-config/resources/tests/config/quickwit.json
@@ -3,7 +3,7 @@
     "version": 0,
     "node_id": "my-unique-node-id",
     "metastore_uri": "postgres://username:password@host:port/db",
-    "data_dir_path": "/opt/quickwit/data",
+    "data_dir": "/opt/quickwit/data",
     "listen_address": "0.0.0.0",
     "rest_listen_port": 1111,
     "peer_seeds": [

--- a/quickwit-config/resources/tests/config/quickwit.toml
+++ b/quickwit-config/resources/tests/config/quickwit.toml
@@ -4,7 +4,7 @@ listen_address = "0.0.0.0"
 rest_listen_port = 1111
 peer_seeds = [ "quickwit-searcher-0.local", "quickwit-searcher-1.local" ]
 metastore_uri = "postgres://username:password@host:port/db"
-data_dir_path = "/opt/quickwit/data"
+data_dir = "/opt/quickwit/data"
 
 [indexer]
 split_store_max_num_bytes = "1T"

--- a/quickwit-config/resources/tests/config/quickwit.yaml
+++ b/quickwit-config/resources/tests/config/quickwit.yaml
@@ -6,7 +6,7 @@ peer_seeds:
   - quickwit-searcher-0.local
   - quickwit-searcher-1.local
 metastore_uri: postgres://username:password@host:port/db
-data_dir_path: /opt/quickwit/data
+data_dir: /opt/quickwit/data
 indexer:
   split_store_max_num_bytes: 1T
   split_store_max_num_splits: 10000

--- a/quickwit-config/resources/tests/index_config/hdfs-logs.json
+++ b/quickwit-config/resources/tests/index_config/hdfs-logs.json
@@ -1,6 +1,8 @@
 # Comments are supported.
 {
     "version": 0,
+    "index_id": "hdfs-logs",
+    "index_uri": "s3://quickwit-indexes/hdfs-logs",
     "doc_mapping": {
         "field_mappings": [
             {

--- a/quickwit-config/resources/tests/index_config/hdfs-logs.toml
+++ b/quickwit-config/resources/tests/index_config/hdfs-logs.toml
@@ -1,4 +1,6 @@
 version = 0
+index_id = "hdfs-logs"
+index_uri = "s3://quickwit-indexes/hdfs-logs"
 
 [doc_mapping]
 field_mappings = [

--- a/quickwit-config/resources/tests/index_config/hdfs-logs.yaml
+++ b/quickwit-config/resources/tests/index_config/hdfs-logs.yaml
@@ -1,4 +1,6 @@
 version: 0
+index_id: hdfs-logs
+index_uri: s3://quickwit-indexes/hdfs-logs
 
 doc_mapping:
   field_mappings:

--- a/quickwit-config/resources/tests/index_config/minimal-hdfs-logs.yaml
+++ b/quickwit-config/resources/tests/index_config/minimal-hdfs-logs.yaml
@@ -1,5 +1,8 @@
 version: 0
 
+index_id: hdfs-logs
+index_uri: s3://quickwit-indexes/hdfs-logs
+
 doc_mapping:
   field_mappings:
     - name: body

--- a/quickwit-config/resources/tests/index_config/partial-hdfs-logs.yaml
+++ b/quickwit-config/resources/tests/index_config/partial-hdfs-logs.yaml
@@ -1,5 +1,8 @@
 version: 0
 
+index_id: hdfs-logs
+index_uri: s3://quickwit-indexes/hdfs-logs
+
 doc_mapping:
   field_mappings:
     - name: body

--- a/quickwit-config/src/config.rs
+++ b/quickwit-config/src/config.rs
@@ -167,6 +167,7 @@ pub struct QuickwitConfig {
     #[serde(default = "default_metastore_and_index_root_uri")]
     pub default_index_root_uri: String,
     #[serde(default = "default_data_dir_path")]
+    #[serde(rename = "data_dir")]
     pub data_dir_path: PathBuf,
     #[serde(rename = "indexer")]
     #[serde(default)]
@@ -418,7 +419,7 @@ mod tests {
             let config_yaml = r#"
             version: 0
             metastore_uri: postgres://username:password@host:port/db
-            data_dir_path: /opt/quickwit/data
+            data_dir: /opt/quickwit/data
         "#;
             let config = serde_yaml::from_str::<QuickwitConfig>(config_yaml).unwrap();
             assert_eq!(config.version, 0);

--- a/quickwit-config/src/index_config.rs
+++ b/quickwit-config/src/index_config.rs
@@ -210,6 +210,8 @@ pub struct SourceConfig {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct IndexConfig {
     pub version: usize,
+    pub index_id: String,
+    pub index_uri: Option<String>,
     pub doc_mapping: DocMapping,
     #[serde(default)]
     pub indexing_settings: IndexingSettings,
@@ -272,6 +274,7 @@ impl IndexConfig {
         if self.sources.len() > self.sources().len() {
             bail!("Index config contains duplicate sources.")
         }
+
         // Validation is made by building the doc mapper.
         // Note: this needs a deep refactoring to separate the doc mapping configuration,
         // and doc mapper implementations.
@@ -440,6 +443,11 @@ mod tests {
                 .await
                 .unwrap();
 
+            assert_eq!(index_config.index_id, "hdfs-logs");
+            assert_eq!(
+                index_config.index_uri,
+                Some("s3://quickwit-indexes/hdfs-logs".to_string())
+            );
             assert_eq!(index_config.doc_mapping.field_mappings.len(), 1);
             assert_eq!(index_config.doc_mapping.field_mappings[0].name, "body");
             assert!(!index_config.doc_mapping.store_source);
@@ -463,6 +471,11 @@ mod tests {
                 .unwrap();
 
             assert_eq!(index_config.version, 0);
+            assert_eq!(index_config.index_id, "hdfs-logs");
+            assert_eq!(
+                index_config.index_uri,
+                Some("s3://quickwit-indexes/hdfs-logs".to_string())
+            );
             assert_eq!(index_config.doc_mapping.field_mappings.len(), 2);
             assert_eq!(index_config.doc_mapping.field_mappings[0].name, "body");
             assert_eq!(index_config.doc_mapping.field_mappings[1].name, "timestamp");


### PR DESCRIPTION
…r source add CLI, use data_dir in config.

This PR fixes:
- [x] #1041 
- [x] #1046 

It does not fix the docs, it's on purpose and it will be done in #1029 

Notes:
1. I finally put the `index_id` in the config as it would be easier to introduce an `apply` command
2. I put `index_uri` as an Option in `IndexConfig` to be able to parse the index config file valid even without `index_uri` and if absent, resolve the index URI to the default root URI + index id. I'm not satisfied by this choice as... an `IndexConfig` should always have an `index-uri`. But I did not find a simple solution to avoid this option unless having a dedicated struct for creation only or by implementing a custom deserializer.
