### PR TITLE
Use an enum rather than JSON value for storing source params

### DIFF
--- a/quickwit-cli/src/index.rs
+++ b/quickwit-cli/src/index.rs
@@ -31,7 +31,7 @@ use itertools::Itertools;
 use quickwit_actors::{ActorHandle, ObservationType};
 use quickwit_common::uri::Uri;
 use quickwit_common::{run_checklist, GREEN_COLOR};
-use quickwit_config::{IndexConfig, IndexerConfig, SourceConfig, SourceType};
+use quickwit_config::{IndexConfig, IndexerConfig, SourceConfig, SourceParams};
 use quickwit_core::{create_index, delete_index, garbage_collect_index, reset_index};
 use quickwit_doc_mapper::tag_pruning::match_tag_field_name;
 use quickwit_indexing::actors::{IndexingPipeline, IndexingServer};
@@ -625,14 +625,14 @@ pub async fn ingest_docs_cli(args: IngestDocsArgs) -> anyhow::Result<()> {
 
     let config = load_quickwit_config(args.config_uri, args.data_dir).await?;
 
-    let source_type = if let Some(filepath) = args.input_path_opt.as_ref() {
-        SourceType::file(filepath)
+    let source_params = if let Some(filepath) = args.input_path_opt.as_ref() {
+        SourceParams::file(filepath)
     } else {
-        SourceType::stdin()
+        SourceParams::stdin()
     };
     let source = SourceConfig {
         source_id: INGEST_SOURCE_ID.to_string(),
-        source_type,
+        source_params,
     };
     run_index_checklist(&config.metastore_uri, &args.index_id, Some(&source)).await?;
     let metastore_uri_resolver = quickwit_metastore_uri_resolver();

--- a/quickwit-cli/src/source.rs
+++ b/quickwit-cli/src/source.rs
@@ -188,15 +188,11 @@ async fn add_source_cli(args: AddSourceArgs) -> anyhow::Result<()> {
     source_params_json.insert("source_type".to_string(), Value::String(args.source_type));
     source_params_json.insert("params".to_string(), Value::Object(params));
     let source_params: SourceParams = serde_json::from_value(Value::Object(source_params_json))?;
-    if let SourceParams::File(file_source_params) = &source_params {
-        if file_source_params.filepath.is_none() {
-            bail!("Source of type `file` must contain a `filepath`")
-        }
-    }
     let source = SourceConfig {
         source_id: args.source_id.clone(),
         source_params,
     };
+    source.validate()?;
     check_source_connectivity(&source).await?;
 
     metastore.add_source(&args.index_id, source).await?;

--- a/quickwit-cli/tests/cli.rs
+++ b/quickwit-cli/tests/cli.rs
@@ -214,6 +214,7 @@ fn test_cmd_ingest_simple() -> Result<()> {
     .stdout(predicate::str::contains("Indexed"))
     .stdout(predicate::str::contains("documents in"))
     .stdout(predicate::str::contains("Now, you can query the index"));
+    println!("piped input");
     Ok(())
 }
 

--- a/quickwit-cli/update_on_config.md
+++ b/quickwit-cli/update_on_config.md
@@ -1,0 +1,1 @@
+This does not directly reflect the overall memory usage of `quickwit index ingest`, but doubling this value should give a fair approximation.

--- a/quickwit-config/resources/tests/index_config/hdfs-logs.json
+++ b/quickwit-config/resources/tests/index_config/hdfs-logs.json
@@ -66,8 +66,10 @@
             "source_id": "hdfs-logs-kafka-source",
             "source_type": "kafka",
             "params": {
-                "bootstrap.servers": "host:9092",
-                "topic": "cloudera-cluster-logs"
+                "topic": "cloudera-cluster-logs",
+                "client_params": {
+                    "bootstrap.servers": "host:9092"
+                }
             }
         },
         {

--- a/quickwit-config/resources/tests/index_config/hdfs-logs.toml
+++ b/quickwit-config/resources/tests/index_config/hdfs-logs.toml
@@ -36,7 +36,7 @@ default_search_fields = [ "severity_text", "body" ]
 [[sources]]
 source_id = "hdfs-logs-kafka-source"
 source_type = "kafka"
-params = { "bootstrap.servers" = "host:9092", "topic" = "cloudera-cluster-logs" }
+params = { "topic" = "cloudera-cluster-logs", "client_params" = { "bootstrap.servers" = "host:9092" } }
 
 [[sources]]
 source_id = "hdfs-logs-kinesis-source"

--- a/quickwit-config/resources/tests/index_config/hdfs-logs.yaml
+++ b/quickwit-config/resources/tests/index_config/hdfs-logs.yaml
@@ -48,8 +48,9 @@ sources:
   - source_id: hdfs-logs-kafka-source
     source_type: kafka
     params:
-      bootstrap.servers: host:9092
       topic: cloudera-cluster-logs
+      client_params:
+        bootstrap.servers: host:9092
 
   - source_id: hdfs-logs-kinesis-source
     source_type: kinesis

--- a/quickwit-config/src/index_config.rs
+++ b/quickwit-config/src/index_config.rs
@@ -33,7 +33,7 @@ use quickwit_doc_mapper::{
 use serde::{Deserialize, Serialize};
 
 use crate::source_config::SourceConfig;
-use crate::SourceType;
+use crate::SourceParams;
 
 // Note(fmassot): `DocMapping` is a struct only used for
 // serialization/deserialization of `DocMapper` parameters.
@@ -279,7 +279,7 @@ impl IndexConfig {
 
         // We want to forbid file source with no filepath.
         for source in self.sources.iter() {
-            if let SourceType::File(file_source_params) = &source.source_type {
+            if let SourceParams::File(file_source_params) = &source.source_params {
                 if file_source_params.filepath.is_none() {
                     bail!(
                         "Source `{}` of type `file` must contain a `filepath`",
@@ -335,7 +335,7 @@ pub fn build_doc_mapper(
 mod tests {
 
     use super::*;
-    use crate::{FileSourceParams, SourceType};
+    use crate::{FileSourceParams, SourceParams};
 
     fn get_resource_path(resource_filename: &str) -> String {
         format!(
@@ -429,12 +429,12 @@ mod tests {
                 {
                     let source = &index_config.sources[0];
                     assert_eq!(source.source_id, "hdfs-logs-kafka-source");
-                    assert!(matches!(source.source_type, SourceType::Kafka(_)));
+                    assert!(matches!(source.source_type, SourceParams::Kafka(_)));
                 }
                 {
                     let source = &index_config.sources[1];
                     assert_eq!(source.source_id, "hdfs-logs-kinesis-source");
-                    assert!(matches!(source.source_type, SourceType::Kinesis(_)));
+                    assert!(matches!(source.source_type, SourceParams::Kinesis(_)));
                 }
                 Ok(())
             }
@@ -551,11 +551,11 @@ mod tests {
             invalid_index_config.sources = vec![
                 SourceConfig {
                     source_id: "void_1".to_string(),
-                    source_type: SourceType::void(),
+                    source_params: SourceParams::void(),
                 },
                 SourceConfig {
                     source_id: "void_1".to_string(),
-                    source_type: SourceType::void(),
+                    source_params: SourceParams::void(),
                 },
             ];
             assert!(invalid_index_config.validate().is_err());
@@ -570,7 +570,7 @@ mod tests {
             let mut invalid_index_config = index_config.clone();
             invalid_index_config.sources = vec![SourceConfig {
                 source_id: "file_params_1".to_string(),
-                source_type: SourceType::File(FileSourceParams { filepath: None }),
+                source_params: SourceParams::File(FileSourceParams { filepath: None }),
             }];
             assert!(invalid_index_config.validate().is_err());
             assert!(invalid_index_config

--- a/quickwit-config/src/lib.rs
+++ b/quickwit-config/src/lib.rs
@@ -30,6 +30,6 @@ pub use index_config::{
     SearchSettings,
 };
 pub use source_config::{
-    FileSourceParams, KafkaSourceParams, SourceConfig, SourceType, VecSourceParams,
+    FileSourceParams, KafkaSourceParams, SourceConfig, SourceParams, VecSourceParams,
     VoidSourceParams,
 };

--- a/quickwit-config/src/lib.rs
+++ b/quickwit-config/src/lib.rs
@@ -19,6 +19,7 @@
 
 mod config;
 mod index_config;
+mod source_config;
 
 pub use config::{
     get_searcher_config_instance, IndexerConfig, QuickwitConfig, SearcherConfig,
@@ -26,5 +27,9 @@ pub use config::{
 };
 pub use index_config::{
     build_doc_mapper, DocMapping, IndexConfig, IndexingResources, IndexingSettings, MergePolicy,
-    SearchSettings, SourceConfig,
+    SearchSettings,
+};
+pub use source_config::{
+    FileSourceParams, KafkaSourceParams, SourceConfig, SourceType, VecSourceParams,
+    VoidSourceParams,
 };

--- a/quickwit-config/src/source_config.rs
+++ b/quickwit-config/src/source_config.rs
@@ -27,28 +27,28 @@ use serde::{Deserialize, Deserializer, Serialize};
 pub struct SourceConfig {
     pub source_id: String,
     #[serde(flatten)]
-    pub source_type: SourceType,
+    pub source_params: SourceParams,
 }
 
 impl SourceConfig {
     pub fn source_type(&self) -> &str {
-        match self.source_type {
-            SourceType::File(_) => "file",
-            SourceType::Kafka(_) => "kafka",
-            SourceType::Kinesis(_) => "kinesis",
-            SourceType::Vec(_) => "vec",
-            SourceType::Void(_) => "void",
+        match self.source_params {
+            SourceParams::File(_) => "file",
+            SourceParams::Kafka(_) => "kafka",
+            SourceParams::Kinesis(_) => "kinesis",
+            SourceParams::Vec(_) => "vec",
+            SourceParams::Void(_) => "void",
         }
     }
 
     // TODO: Remove after source factory refactor.
     pub fn params(&self) -> serde_json::Value {
-        match &self.source_type {
-            SourceType::File(params) => serde_json::to_value(params),
-            SourceType::Kafka(params) => serde_json::to_value(params),
-            SourceType::Kinesis(params) => serde_json::to_value(params),
-            SourceType::Vec(params) => serde_json::to_value(params),
-            SourceType::Void(params) => serde_json::to_value(params),
+        match &self.source_params {
+            SourceParams::File(params) => serde_json::to_value(params),
+            SourceParams::Kafka(params) => serde_json::to_value(params),
+            SourceParams::Kinesis(params) => serde_json::to_value(params),
+            SourceParams::Vec(params) => serde_json::to_value(params),
+            SourceParams::Void(params) => serde_json::to_value(params),
         }
         .unwrap()
     }
@@ -56,7 +56,7 @@ impl SourceConfig {
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "source_type", content = "params")]
-pub enum SourceType {
+pub enum SourceParams {
     #[serde(rename = "file")]
     File(FileSourceParams),
     #[serde(rename = "kafka")]
@@ -70,7 +70,7 @@ pub enum SourceType {
     Void(VoidSourceParams),
 }
 
-impl SourceType {
+impl SourceParams {
     pub fn file<P: AsRef<Path>>(filepath: P) -> Self {
         Self::File(FileSourceParams::file(filepath))
     }

--- a/quickwit-config/src/source_config.rs
+++ b/quickwit-config/src/source_config.rs
@@ -1,0 +1,140 @@
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use std::io;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct SourceConfig {
+    pub source_id: String,
+    #[serde(flatten)]
+    pub source_type: SourceType,
+}
+
+impl SourceConfig {
+    pub fn source_type(&self) -> &str {
+        match self.source_type {
+            SourceType::File(_) => "file",
+            SourceType::Kafka(_) => "kafka",
+            SourceType::Kinesis(_) => "kinesis",
+            SourceType::Vec(_) => "vec",
+            SourceType::Void(_) => "void",
+        }
+    }
+
+    // TODO: Remove after source factory refactor.
+    pub fn params(&self) -> serde_json::Value {
+        let params = match &self.source_type {
+            SourceType::File(params) => serde_json::to_value(params),
+            SourceType::Kafka(params) => serde_json::to_value(params),
+            SourceType::Kinesis(params) => serde_json::to_value(params),
+            SourceType::Vec(params) => serde_json::to_value(params),
+            SourceType::Void(params) => serde_json::to_value(params),
+        }
+        .unwrap();
+        params
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "source_type", content = "params")]
+pub enum SourceType {
+    #[serde(rename = "file")]
+    File(FileSourceParams),
+    #[serde(rename = "kafka")]
+    Kafka(KafkaSourceParams),
+    #[doc(hidden)]
+    #[serde(rename = "kinesis")]
+    Kinesis(KinesisSourceParams),
+    #[serde(rename = "vec")]
+    Vec(VecSourceParams),
+    #[serde(rename = "void")]
+    Void(VoidSourceParams),
+}
+
+impl SourceType {
+    pub fn file<P: AsRef<Path>>(filepath: P) -> Self {
+        Self::File(FileSourceParams::file(filepath))
+    }
+
+    pub fn stdin() -> Self {
+        Self::File(FileSourceParams::stdin())
+    }
+
+    pub fn void() -> Self {
+        Self::Void(VoidSourceParams)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct FileSourceParams {
+    /// Path of the file to read. Assume stdin if None.
+    pub filepath: Option<PathBuf>, //< If None read from stdin.
+}
+
+impl FileSourceParams {
+    pub fn file<P: AsRef<Path>>(filepath: P) -> Self {
+        FileSourceParams {
+            filepath: Some(filepath.as_ref().to_path_buf()),
+        }
+    }
+
+    pub fn stdin() -> Self {
+        FileSourceParams { filepath: None }
+    }
+
+    pub fn canonical_filepath(&self) -> io::Result<Option<PathBuf>> {
+        match &self.filepath {
+            Some(filepath) => {
+                let canonical_filepath = filepath.canonicalize()?;
+                Ok(Some(canonical_filepath))
+            }
+            None => Ok(None),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct KafkaSourceParams {
+    /// Name of the topic that the source consumes.
+    pub topic: String,
+    /// Kafka client log level. Possible values are `debug`, `info`, `warn`, and `error`.
+    pub client_log_level: Option<String>,
+    /// Kafka client configuration parameters.
+    pub client_params: serde_json::Value,
+}
+
+#[doc(hidden)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct KinesisSourceParams {
+    stream_name: String
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct VecSourceParams {
+    pub items: Vec<String>,
+    pub batch_num_docs: usize,
+    #[serde(default)]
+    pub partition: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct VoidSourceParams;

--- a/quickwit-indexing/src/actors/indexing_pipeline.rs
+++ b/quickwit-indexing/src/actors/indexing_pipeline.rs
@@ -590,10 +590,10 @@ mod tests {
     use std::sync::Arc;
 
     use quickwit_actors::Universe;
+    use quickwit_config::{IndexingSettings, SourceType};
     use quickwit_doc_mapper::default_doc_mapper_for_tests;
     use quickwit_metastore::{IndexMetadata, MetastoreError, MockMetastore};
     use quickwit_storage::RamStorage;
-    use serde_json::json;
 
     use super::{IndexingPipeline, *};
     use crate::models::IndexingDirectory;
@@ -673,8 +673,7 @@ mod tests {
         let universe = Universe::new();
         let source_config = SourceConfig {
             source_id: "test-source".to_string(),
-            source_type: "file".to_string(),
-            params: json!({ "filepath": PathBuf::from("data/test_corpus.json") }),
+            source_type: SourceType::file(PathBuf::from("data/test_corpus.json")),
         };
         let indexing_pipeline_params = IndexingPipelineParams {
             index_id: index_id.to_string(),
@@ -755,8 +754,7 @@ mod tests {
         let universe = Universe::new();
         let source = SourceConfig {
             source_id: "test-source".to_string(),
-            source_type: "file".to_string(),
-            params: json!({ "filepath": PathBuf::from("data/test_corpus.json") }),
+            source_type: SourceType::file(PathBuf::from("data/test_corpus.json")),
         };
         let pipeline_params = IndexingPipelineParams {
             index_id: "test-index".to_string(),

--- a/quickwit-indexing/src/actors/indexing_pipeline.rs
+++ b/quickwit-indexing/src/actors/indexing_pipeline.rs
@@ -590,7 +590,7 @@ mod tests {
     use std::sync::Arc;
 
     use quickwit_actors::Universe;
-    use quickwit_config::{IndexingSettings, SourceType};
+    use quickwit_config::{IndexingSettings, SourceParams};
     use quickwit_doc_mapper::default_doc_mapper_for_tests;
     use quickwit_metastore::{IndexMetadata, MetastoreError, MockMetastore};
     use quickwit_storage::RamStorage;
@@ -673,7 +673,7 @@ mod tests {
         let universe = Universe::new();
         let source_config = SourceConfig {
             source_id: "test-source".to_string(),
-            source_type: SourceType::file(PathBuf::from("data/test_corpus.json")),
+            source_params: SourceParams::file(PathBuf::from("data/test_corpus.json")),
         };
         let indexing_pipeline_params = IndexingPipelineParams {
             index_id: index_id.to_string(),
@@ -754,7 +754,7 @@ mod tests {
         let universe = Universe::new();
         let source = SourceConfig {
             source_id: "test-source".to_string(),
-            source_type: SourceType::file(PathBuf::from("data/test_corpus.json")),
+            source_params: SourceParams::file(PathBuf::from("data/test_corpus.json")),
         };
         let pipeline_params = IndexingPipelineParams {
             index_id: "test-index".to_string(),

--- a/quickwit-indexing/src/actors/indexing_server.rs
+++ b/quickwit-indexing/src/actors/indexing_server.rs
@@ -27,7 +27,7 @@ use quickwit_actors::{
     Actor, ActorContext, ActorExitStatus, ActorHandle, AsyncActor, Health, Mailbox, Observation,
     Supervisable, Universe,
 };
-use quickwit_config::{IndexerConfig, SourceConfig, SourceType, VecSourceParams};
+use quickwit_config::{IndexerConfig, SourceConfig, SourceParams, VecSourceParams};
 use quickwit_metastore::{IndexMetadata, Metastore};
 use quickwit_storage::StorageUriResolver;
 use serde::Serialize;
@@ -327,7 +327,7 @@ impl IndexingServer {
 
         let source = SourceConfig {
             source_id: pipeline_id.source_id.clone(),
-            source_type: SourceType::Vec(VecSourceParams::default()),
+            source_params: SourceParams::Vec(VecSourceParams::default()),
         };
         self.spawn_pipeline_inner(ctx, pipeline_id.clone(), index_metadata, source)
             .await?;
@@ -505,7 +505,7 @@ mod tests {
         // Test `spawn_pipeline`.
         let source_1 = SourceConfig {
             source_id: "test-indexing-server--source-1".to_string(),
-            source_type: SourceType::void(),
+            source_params: SourceParams::void(),
         };
         let pipeline_id1 = client
             .spawn_pipeline(index_id.clone(), source_1.clone())
@@ -534,7 +534,7 @@ mod tests {
 
         let source_2 = SourceConfig {
             source_id: "test-indexing-server--source-2".to_string(),
-            source_type: SourceType::void(),
+            source_params: SourceParams::void(),
         };
         metastore.add_source(&index_id, source_2).await.unwrap();
         client.spawn_pipelines(index_id.clone()).await.unwrap();
@@ -553,7 +553,7 @@ mod tests {
         // Test `supervise_pipelines`
         let source_3 = SourceConfig {
             source_id: "test-indexing-server--source-3".to_string(),
-            source_type: SourceType::Vec(VecSourceParams {
+            source_params: SourceParams::Vec(VecSourceParams {
                 items: Vec::new(),
                 batch_num_docs: 10,
                 partition: "0".to_string(),

--- a/quickwit-indexing/src/actors/indexing_server.rs
+++ b/quickwit-indexing/src/actors/indexing_server.rs
@@ -27,14 +27,13 @@ use quickwit_actors::{
     Actor, ActorContext, ActorExitStatus, ActorHandle, AsyncActor, Health, Mailbox, Observation,
     Supervisable, Universe,
 };
-use quickwit_config::{IndexerConfig, SourceConfig};
+use quickwit_config::{IndexerConfig, SourceConfig, SourceType, VecSourceParams};
 use quickwit_metastore::{IndexMetadata, Metastore};
 use quickwit_storage::StorageUriResolver;
 use serde::Serialize;
 use tokio::sync::oneshot;
 use tracing::{error, info};
 
-use crate::source::VecSourceParams;
 use crate::{IndexingPipeline, IndexingPipelineParams, IndexingStatistics};
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
@@ -328,8 +327,7 @@ impl IndexingServer {
 
         let source = SourceConfig {
             source_id: pipeline_id.source_id.clone(),
-            source_type: "vec".to_string(),
-            params: serde_json::to_value(VecSourceParams::default()).unwrap(),
+            source_type: SourceType::Vec(VecSourceParams::default()),
         };
         self.spawn_pipeline_inner(ctx, pipeline_id.clone(), index_metadata, source)
             .await?;
@@ -469,10 +467,10 @@ mod tests {
 
     use quickwit_actors::ObservationType;
     use quickwit_common::rand::append_random_suffix;
+    use quickwit_config::VecSourceParams;
     use quickwit_metastore::quickwit_metastore_uri_resolver;
 
     use super::*;
-    use crate::source::VecSourceParams;
 
     const METASTORE_URI: &str = "ram:///qwdata/indexes";
 
@@ -507,8 +505,7 @@ mod tests {
         // Test `spawn_pipeline`.
         let source_1 = SourceConfig {
             source_id: "test-indexing-server--source-1".to_string(),
-            source_type: "void".to_string(),
-            params: serde_json::json!(null),
+            source_type: SourceType::void(),
         };
         let pipeline_id1 = client
             .spawn_pipeline(index_id.clone(), source_1.clone())
@@ -537,8 +534,7 @@ mod tests {
 
         let source_2 = SourceConfig {
             source_id: "test-indexing-server--source-2".to_string(),
-            source_type: "void".to_string(),
-            params: serde_json::json!(null),
+            source_type: SourceType::void(),
         };
         metastore.add_source(&index_id, source_2).await.unwrap();
         client.spawn_pipelines(index_id.clone()).await.unwrap();
@@ -557,8 +553,11 @@ mod tests {
         // Test `supervise_pipelines`
         let source_3 = SourceConfig {
             source_id: "test-indexing-server--source-3".to_string(),
-            source_type: "vec".to_string(),
-            params: serde_json::to_value(VecSourceParams::default()).unwrap(),
+            source_type: SourceType::Vec(VecSourceParams {
+                items: Vec::new(),
+                batch_num_docs: 10,
+                partition: "0".to_string(),
+            }),
         };
         client
             .spawn_pipeline(index_id.clone(), source_3)

--- a/quickwit-indexing/src/source/kafka_source.rs
+++ b/quickwit-indexing/src/source/kafka_source.rs
@@ -28,6 +28,7 @@ use backoff::ExponentialBackoff;
 use futures::{StreamExt, TryFutureExt};
 use itertools::Itertools;
 use quickwit_actors::{ActorExitStatus, Mailbox};
+use quickwit_config::KafkaSourceParams;
 use quickwit_metastore::checkpoint::{CheckpointDelta, PartitionId, Position, SourceCheckpoint};
 use rdkafka::config::{ClientConfig, RDKafkaLogLevel};
 use rdkafka::consumer::stream_consumer::StreamConsumer;
@@ -38,7 +39,6 @@ use rdkafka::topic_partition_list::TopicPartitionList;
 use rdkafka::types::RDKafkaErrorCode;
 use rdkafka::util::Timeout;
 use rdkafka::{ClientContext, Message, Offset};
-use serde::{Deserialize, Serialize};
 use serde_json::json;
 use tokio::task::spawn_blocking;
 use tracing::{debug, info, warn};
@@ -56,17 +56,6 @@ use crate::source::{IndexerMessage, Source, SourceContext, TypedSourceFactory};
 ///
 /// 5MB seems like a good one size fits all value.
 const TARGET_BATCH_NUM_BYTES: u64 = 5_000_000;
-
-/// Required parameters for instantiating a `KafkaSource`.
-#[derive(Clone, Deserialize, Serialize)]
-pub struct KafkaSourceParams {
-    /// Name of the topic that the source consumes.
-    pub topic: String,
-    /// Kafka client log level. Valid values are `debug`, `info`, `warn`, and `error`.
-    pub client_log_level: Option<String>,
-    /// Kafka client configuration parameters.
-    pub client_params: serde_json::Value,
-}
 
 /// Factory for instantiating a `KafkaSource`.
 pub struct KafkaSourceFactory;

--- a/quickwit-indexing/src/source/mod.rs
+++ b/quickwit-indexing/src/source/mod.rs
@@ -186,6 +186,7 @@ pub async fn check_source_connectivity(source_config: &SourceConfig) -> anyhow::
             }
             Ok(())
         }
+        #[allow(unused_variables)]
         SourceType::Kafka(params) => {
             #[cfg(not(feature = "kafka"))]
             bail!("Quickwit binary was not compiled with the `kafka` feature.");

--- a/quickwit-indexing/src/source/mod.rs
+++ b/quickwit-indexing/src/source/mod.rs
@@ -31,15 +31,15 @@ use std::path::Path;
 
 use anyhow::bail;
 use async_trait::async_trait;
-pub use file_source::{FileSource, FileSourceFactory, FileSourceParams};
+pub use file_source::{FileSource, FileSourceFactory};
 #[cfg(feature = "kafka")]
-pub use kafka_source::{KafkaSource, KafkaSourceFactory, KafkaSourceParams};
+pub use kafka_source::{KafkaSource, KafkaSourceFactory};
 use once_cell::sync::OnceCell;
 use quickwit_actors::{Actor, ActorContext, ActorExitStatus, AsyncActor, Mailbox};
-use quickwit_config::SourceConfig;
+use quickwit_config::{SourceConfig, SourceType};
 pub use source_factory::{SourceFactory, SourceLoader, TypedSourceFactory};
-pub use vec_source::{VecSource, VecSourceFactory, VecSourceParams};
-pub use void_source::{VoidSource, VoidSourceFactory, VoidSourceParams};
+pub use vec_source::{VecSource, VecSourceFactory};
+pub use void_source::{VoidSource, VoidSourceFactory};
 
 use crate::models::IndexerMessage;
 
@@ -177,58 +177,32 @@ pub fn quickwit_supported_sources() -> &'static SourceLoader {
 }
 
 pub async fn check_source_connectivity(source_config: &SourceConfig) -> anyhow::Result<()> {
-    match source_config.source_type.as_ref() {
-        "file" => {
-            match source_config.params.get("filepath") {
-                Some(serde_json::Value::String(path)) => {
-                    if Path::new(&path).exists() {
-                        Ok(())
-                    } else {
-                        bail!("File `{}` does not exist.", path)
-                    }
-                }
-                None | Some(serde_json::Value::Null) => {
-                    if source_config.source_id == INGEST_SOURCE_ID {
-                        // We are indexing stdin using the ingest source.
-                        return Ok(());
-                    }
-                    bail!("Failed to parse source config params: property `filepath` is missing.")
-                }
-                Some(_) => {
-                    bail!(
-                        "Failed to parse source config params: property `filepath` is not a \
-                         string."
-                    )
+    match &source_config.source_type {
+        SourceType::File(params) => {
+            if let Some(filepath) = &params.filepath {
+                if !Path::new(filepath).exists() {
+                    bail!("File `{}` does not exist.", filepath.display())
                 }
             }
+            Ok(())
         }
-        "kafka" => {
+        SourceType::Kafka(params) => {
             #[cfg(not(feature = "kafka"))]
-            bail!("Quickwit binary was not compiled with the Kafka source feature.");
+            bail!("Quickwit binary was not compiled with the `kafka` feature.");
 
             #[cfg(feature = "kafka")]
             {
-                let kafka_source_params: KafkaSourceParams =
-                    serde_json::from_value(source_config.params.clone())?;
-                kafka_source::check_connectivity(kafka_source_params).await?;
+                kafka_source::check_connectivity(params.clone()).await?;
                 Ok(())
             }
         }
-        "vec" => Ok(()),
-        "void" => Ok(()),
-        unrecognized_source_type => {
-            bail!(
-                "Unknown source type `{}` or connectivity check not implemented for this source \
-                 type.",
-                unrecognized_source_type
-            );
-        }
+        _ => Ok(()),
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use serde_json::json;
+    use quickwit_config::VecSourceParams;
 
     use super::*;
 
@@ -237,36 +211,28 @@ mod tests {
         {
             let source_config = SourceConfig {
                 source_id: "void".to_string(),
-                source_type: "void".to_string(),
-                params: json!(null),
+                source_type: SourceType::void(),
             };
             check_source_connectivity(&source_config).await?;
         }
         {
             let source_config = SourceConfig {
                 source_id: "vec".to_string(),
-                source_type: "vec".to_string(),
-                params: json!(null),
+                source_type: SourceType::Vec(VecSourceParams::default()),
             };
             check_source_connectivity(&source_config).await?;
         }
         {
             let source_config = SourceConfig {
                 source_id: "file".to_string(),
-                source_type: "file".to_string(),
-                params: json!({
-                    "filepath": "non-existing-file.json"
-                }),
+                source_type: SourceType::file("file-does-not-exist.json"),
             };
             assert!(check_source_connectivity(&source_config).await.is_err());
         }
         {
             let source_config = SourceConfig {
                 source_id: "file".to_string(),
-                source_type: "file".to_string(),
-                params: json!({
-                    "filepath": "data/test_corpus.json"
-                }),
+                source_type: SourceType::file("data/test_corpus.json"),
             };
             assert!(check_source_connectivity(&source_config).await.is_ok());
         }

--- a/quickwit-indexing/src/source/source_factory.rs
+++ b/quickwit-indexing/src/source/source_factory.rs
@@ -115,7 +115,7 @@ impl SourceLoader {
 #[cfg(test)]
 mod tests {
 
-    use quickwit_config::SourceType;
+    use quickwit_config::SourceParams;
 
     use super::*;
     use crate::source::quickwit_supported_sources;
@@ -125,7 +125,7 @@ mod tests {
         let source_loader = quickwit_supported_sources();
         let source_config = SourceConfig {
             source_id: "test-source".to_string(),
-            source_type: SourceType::void(),
+            source_params: SourceParams::void(),
         };
         source_loader
             .load_source(source_config, SourceCheckpoint::default())

--- a/quickwit-indexing/src/source/vec_source.rs
+++ b/quickwit-indexing/src/source/vec_source.rs
@@ -19,20 +19,12 @@
 
 use async_trait::async_trait;
 use quickwit_actors::{ActorExitStatus, Mailbox};
+use quickwit_config::VecSourceParams;
 use quickwit_metastore::checkpoint::{CheckpointDelta, PartitionId, Position, SourceCheckpoint};
-use serde::{Deserialize, Serialize};
 use tracing::info;
 
 use crate::models::{IndexerMessage, RawDocBatch};
 use crate::source::{Source, SourceContext, TypedSourceFactory};
-
-#[derive(Debug, Default, Deserialize, Serialize)]
-pub struct VecSourceParams {
-    pub items: Vec<String>,
-    pub batch_num_docs: usize,
-    #[serde(default)]
-    pub partition: String,
-}
 
 pub struct VecSource {
     next_item_idx: usize,

--- a/quickwit-indexing/src/source/void_source.rs
+++ b/quickwit-indexing/src/source/void_source.rs
@@ -19,7 +19,7 @@
 
 use async_trait::async_trait;
 use quickwit_actors::{ActorExitStatus, Mailbox, HEARTBEAT};
-use serde::{Deserialize, Serialize};
+use quickwit_config::VoidSourceParams;
 
 use crate::models::IndexerMessage;
 use crate::source::{Source, SourceContext, TypedSourceFactory};
@@ -46,9 +46,6 @@ impl Source for VoidSource {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug)]
-pub struct VoidSourceParams;
-
 pub struct VoidSourceFactory;
 
 #[async_trait]
@@ -68,6 +65,7 @@ impl TypedSourceFactory for VoidSourceFactory {
 #[cfg(test)]
 mod tests {
     use quickwit_actors::{create_test_mailbox, Health, Supervisable, Universe};
+    use quickwit_config::SourceType;
     use quickwit_metastore::checkpoint::SourceCheckpoint;
     use serde_json::json;
 
@@ -78,8 +76,7 @@ mod tests {
     async fn test_void_source_loading() -> anyhow::Result<()> {
         let source_config = SourceConfig {
             source_id: "void-test-source".to_string(),
-            source_type: "void".to_string(),
-            params: json!(null),
+            source_type: SourceType::void(),
         };
         let source_loader = quickwit_supported_sources();
         let _ = source_loader

--- a/quickwit-indexing/src/source/void_source.rs
+++ b/quickwit-indexing/src/source/void_source.rs
@@ -65,7 +65,7 @@ impl TypedSourceFactory for VoidSourceFactory {
 #[cfg(test)]
 mod tests {
     use quickwit_actors::{create_test_mailbox, Health, Supervisable, Universe};
-    use quickwit_config::SourceType;
+    use quickwit_config::SourceParams;
     use quickwit_metastore::checkpoint::SourceCheckpoint;
     use serde_json::json;
 
@@ -76,7 +76,7 @@ mod tests {
     async fn test_void_source_loading() -> anyhow::Result<()> {
         let source_config = SourceConfig {
             source_id: "void-test-source".to_string(),
-            source_type: SourceType::void(),
+            source_params: SourceParams::void(),
         };
         let source_loader = quickwit_supported_sources();
         let _ = source_loader

--- a/quickwit-indexing/src/test_utils.rs
+++ b/quickwit-indexing/src/test_utils.rs
@@ -20,7 +20,7 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
-use quickwit_config::{build_doc_mapper, IndexerConfig, SourceConfig, SourceType, VecSourceParams};
+use quickwit_config::{build_doc_mapper, IndexerConfig, SourceConfig, SourceParams, VecSourceParams};
 use quickwit_doc_mapper::DocMapper;
 use quickwit_metastore::{
     quickwit_metastore_uri_resolver, IndexMetadata, Metastore, Split, SplitMetadata, SplitState,
@@ -114,7 +114,7 @@ impl TestSandbox {
         let add_docs_id = self.add_docs_id.fetch_add(1, Ordering::SeqCst);
         let source = SourceConfig {
             source_id: self.index_id.clone(),
-            source_type: SourceType::Vec(VecSourceParams {
+            source_params: SourceParams::Vec(VecSourceParams {
                 items: docs,
                 batch_num_docs: 10,
                 partition: format!("add-docs-{}", add_docs_id),

--- a/quickwit-indexing/src/test_utils.rs
+++ b/quickwit-indexing/src/test_utils.rs
@@ -20,7 +20,7 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
-use quickwit_config::{build_doc_mapper, IndexerConfig, SourceConfig};
+use quickwit_config::{build_doc_mapper, IndexerConfig, SourceConfig, SourceType, VecSourceParams};
 use quickwit_doc_mapper::DocMapper;
 use quickwit_metastore::{
     quickwit_metastore_uri_resolver, IndexMetadata, Metastore, Split, SplitMetadata, SplitState,
@@ -29,7 +29,6 @@ use quickwit_storage::{Storage, StorageUriResolver};
 
 use crate::actors::{IndexingServer, IndexingServerClient};
 use crate::models::IndexingStatistics;
-use crate::source::VecSourceParams;
 
 /// Creates a Test environment.
 ///
@@ -115,12 +114,11 @@ impl TestSandbox {
         let add_docs_id = self.add_docs_id.fetch_add(1, Ordering::SeqCst);
         let source = SourceConfig {
             source_id: self.index_id.clone(),
-            source_type: "vec".to_string(),
-            params: serde_json::to_value(VecSourceParams {
+            source_type: SourceType::Vec(VecSourceParams {
                 items: docs,
                 batch_num_docs: 10,
                 partition: format!("add-docs-{}", add_docs_id),
-            })?,
+            }),
         };
         let pipeline_id = self
             .client

--- a/quickwit-indexing/src/test_utils.rs
+++ b/quickwit-indexing/src/test_utils.rs
@@ -20,7 +20,9 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
-use quickwit_config::{build_doc_mapper, IndexerConfig, SourceConfig, SourceParams, VecSourceParams};
+use quickwit_config::{
+    build_doc_mapper, IndexerConfig, SourceConfig, SourceParams, VecSourceParams,
+};
 use quickwit_doc_mapper::DocMapper;
 use quickwit_metastore::{
     quickwit_metastore_uri_resolver, IndexMetadata, Metastore, Split, SplitMetadata, SplitState,

--- a/quickwit-metastore/src/backward_compatibility_tests/index_metadata.rs
+++ b/quickwit-metastore/src/backward_compatibility_tests/index_metadata.rs
@@ -22,7 +22,7 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 use byte_unit::Byte;
 use quickwit_config::{
     DocMapping, IndexingResources, IndexingSettings, KafkaSourceParams, MergePolicy,
-    SearchSettings, SourceConfig, SourceType,
+    SearchSettings, SourceConfig, SourceParams,
 };
 use quickwit_doc_mapper::SortOrder;
 
@@ -166,7 +166,7 @@ pub(crate) fn sample_index_metadata_for_regression() -> IndexMetadata {
     };
     let kafka_source = SourceConfig {
         source_id: "kafka-source".to_string(),
-        source_type: SourceType::Kafka(KafkaSourceParams {
+        source_params: SourceParams::Kafka(KafkaSourceParams {
             topic: "kafka-topic".to_string(),
             client_log_level: None,
             client_params: serde_json::json!({}),

--- a/quickwit-metastore/src/backward_compatibility_tests/index_metadata.rs
+++ b/quickwit-metastore/src/backward_compatibility_tests/index_metadata.rs
@@ -21,7 +21,8 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use byte_unit::Byte;
 use quickwit_config::{
-    DocMapping, IndexingResources, IndexingSettings, MergePolicy, SearchSettings, SourceConfig,
+    DocMapping, IndexingResources, IndexingSettings, KafkaSourceParams, MergePolicy,
+    SearchSettings, SourceConfig, SourceType,
 };
 use quickwit_doc_mapper::SortOrder;
 
@@ -165,8 +166,11 @@ pub(crate) fn sample_index_metadata_for_regression() -> IndexMetadata {
     };
     let kafka_source = SourceConfig {
         source_id: "kafka-source".to_string(),
-        source_type: "kafka".to_string(),
-        params: serde_json::json!({}),
+        source_type: SourceType::Kafka(KafkaSourceParams {
+            topic: "kafka-topic".to_string(),
+            client_log_level: None,
+            client_params: serde_json::json!({}),
+        }),
     };
     let mut sources = HashMap::default();
     sources.insert("kafka-source".to_string(), kafka_source);

--- a/quickwit-metastore/src/metastore/index_metadata.rs
+++ b/quickwit-metastore/src/metastore/index_metadata.rs
@@ -157,7 +157,7 @@ impl IndexMetadata {
         if let Entry::Occupied(_) = entry {
             return Err(MetastoreError::SourceAlreadyExists {
                 source_id: source_id.clone(),
-                source_type: source.source_type,
+                source_type: source.source_type().to_string(),
             });
         }
         entry.or_insert(source);

--- a/quickwit-metastore/src/tests.rs
+++ b/quickwit-metastore/src/tests.rs
@@ -24,7 +24,7 @@ pub mod test_suite {
 
     use async_trait::async_trait;
     use chrono::Utc;
-    use quickwit_config::{SourceConfig, SourceType};
+    use quickwit_config::{SourceConfig, SourceParams};
     use quickwit_doc_mapper::tag_pruning::{no_tag, tag, TagFilterAst};
     use tokio::time::{sleep, Duration};
 
@@ -86,7 +86,7 @@ pub mod test_suite {
 
         let source = SourceConfig {
             source_id: source_id.to_string(),
-            source_type: SourceType::void(),
+            source_params: SourceParams::void(),
         };
 
         assert_eq!(
@@ -139,7 +139,7 @@ pub mod test_suite {
 
         let source = SourceConfig {
             source_id: source_id.to_string(),
-            source_type: SourceType::void(),
+            source_params: SourceParams::void(),
         };
 
         let mut index_metadata = IndexMetadata::for_test(index_id, index_uri);

--- a/quickwit-metastore/src/tests.rs
+++ b/quickwit-metastore/src/tests.rs
@@ -24,7 +24,7 @@ pub mod test_suite {
 
     use async_trait::async_trait;
     use chrono::Utc;
-    use quickwit_config::SourceConfig;
+    use quickwit_config::{SourceConfig, SourceType};
     use quickwit_doc_mapper::tag_pruning::{no_tag, tag, TagFilterAst};
     use tokio::time::{sleep, Duration};
 
@@ -86,8 +86,7 @@ pub mod test_suite {
 
         let source = SourceConfig {
             source_id: source_id.to_string(),
-            source_type: "void".to_string(),
-            params: serde_json::json!({}),
+            source_type: SourceType::void(),
         };
 
         assert_eq!(
@@ -112,7 +111,7 @@ pub mod test_suite {
         assert_eq!(sources.len(), 1);
         assert!(sources.contains_key(source_id));
         assert_eq!(sources.get(source_id).unwrap().source_id, source_id);
-        assert_eq!(sources.get(source_id).unwrap().source_type, "void");
+        assert_eq!(sources.get(source_id).unwrap().source_type(), "void");
 
         assert!(matches!(
             metastore
@@ -140,8 +139,7 @@ pub mod test_suite {
 
         let source = SourceConfig {
             source_id: source_id.to_string(),
-            source_type: "void".to_string(),
-            params: serde_json::json!({}),
+            source_type: SourceType::void(),
         };
 
         let mut index_metadata = IndexMetadata::for_test(index_id, index_uri);

--- a/quickwit-metastore/test-data/file-backed-index/v0-9e6b2f93986378154c2ced8692b1c82b.expected.json
+++ b/quickwit-metastore/test-data/file-backed-index/v0-9e6b2f93986378154c2ced8692b1c82b.expected.json
@@ -73,7 +73,10 @@
     },
     "sources": [
       {
-        "params": {},
+        "params": {
+          "client_params": {},
+          "topic": "kafka-topic"
+        },
         "source_id": "kafka-source",
         "source_type": "kafka"
       }

--- a/quickwit-metastore/test-data/file-backed-index/v0-9e6b2f93986378154c2ced8692b1c82b.json
+++ b/quickwit-metastore/test-data/file-backed-index/v0-9e6b2f93986378154c2ced8692b1c82b.json
@@ -1,7 +1,9 @@
 {
   "index": {
     "checkpoint": {
-      "0000000000": "0000000042"
+      "kafka-source": {
+        "0000000000": "0000000042"
+      }
     },
     "create_timestamp": 1789,
     "doc_mapping": {
@@ -71,13 +73,16 @@
     },
     "sources": [
       {
-        "params": {},
+        "params": {
+          "client_params": {},
+          "topic": "kafka-topic"
+        },
         "source_id": "kafka-source",
         "source_type": "kafka"
       }
     ],
     "update_timestamp": 1789,
-    "version": "0"
+    "version": "1"
   },
   "splits": [
     {

--- a/quickwit-metastore/test-data/file-backed-index/v0-abe75eb4eab7af5fd6a01237efebe352.expected.json
+++ b/quickwit-metastore/test-data/file-backed-index/v0-abe75eb4eab7af5fd6a01237efebe352.expected.json
@@ -73,7 +73,9 @@
     },
     "sources": [
       {
-        "params": {},
+        "params": {
+          "topic": "kafka-topic"
+        },
         "source_id": "kafka-source",
         "source_type": "kafka"
       }

--- a/quickwit-metastore/test-data/file-backed-index/v0-abe75eb4eab7af5fd6a01237efebe352.json
+++ b/quickwit-metastore/test-data/file-backed-index/v0-abe75eb4eab7af5fd6a01237efebe352.json
@@ -73,7 +73,9 @@
     },
     "sources": [
       {
-        "params": {},
+        "params": {
+          "topic": "kafka-topic"
+        },
         "source_id": "kafka-source",
         "source_type": "kafka"
       }

--- a/quickwit-metastore/test-data/index-metadata/v0-082493da53735bc58ec35c1648a4f14c.expected.json
+++ b/quickwit-metastore/test-data/index-metadata/v0-082493da53735bc58ec35c1648a4f14c.expected.json
@@ -72,7 +72,9 @@
   },
   "sources": [
     {
-      "params": {},
+      "params": {
+        "topic": "kafka-topic"
+      },
       "source_id": "kafka-source",
       "source_type": "kafka"
     }

--- a/quickwit-metastore/test-data/index-metadata/v0-082493da53735bc58ec35c1648a4f14c.json
+++ b/quickwit-metastore/test-data/index-metadata/v0-082493da53735bc58ec35c1648a4f14c.json
@@ -70,7 +70,9 @@
   },
   "sources": [
     {
-      "params": {},
+      "params": {
+        "topic": "kafka-topic"
+      },
       "source_id": "kafka-source",
       "source_type": "kafka"
     }

--- a/quickwit-metastore/test-data/index-metadata/v0-4a463f5078aa6acf314c95936336fa68.expected.json
+++ b/quickwit-metastore/test-data/index-metadata/v0-4a463f5078aa6acf314c95936336fa68.expected.json
@@ -72,7 +72,9 @@
   },
   "sources": [
     {
-      "params": {},
+      "params": {
+        "topic": "kafka-topic"
+      },
       "source_id": "kafka-source",
       "source_type": "kafka"
     }

--- a/quickwit-metastore/test-data/index-metadata/v0-4a463f5078aa6acf314c95936336fa68.json
+++ b/quickwit-metastore/test-data/index-metadata/v0-4a463f5078aa6acf314c95936336fa68.json
@@ -70,7 +70,9 @@
   },
   "sources": [
     {
-      "params": {},
+      "params": {
+        "topic": "kafka-topic"
+      },
       "source_id": "kafka-source",
       "source_type": "kafka"
     }

--- a/quickwit-metastore/test-data/index-metadata/v0-cb4b352caf8990d0e7a54582a4478cd5.expected.json
+++ b/quickwit-metastore/test-data/index-metadata/v0-cb4b352caf8990d0e7a54582a4478cd5.expected.json
@@ -72,7 +72,9 @@
   },
   "sources": [
     {
-      "params": {},
+      "params": {
+        "topic": "kafka-topic"
+      },
       "source_id": "kafka-source",
       "source_type": "kafka"
     }

--- a/quickwit-metastore/test-data/index-metadata/v0-cb4b352caf8990d0e7a54582a4478cd5.json
+++ b/quickwit-metastore/test-data/index-metadata/v0-cb4b352caf8990d0e7a54582a4478cd5.json
@@ -70,7 +70,9 @@
   },
   "sources": [
     {
-      "params": {},
+      "params": {
+        "topic": "kafka-topic"
+      },
       "source_id": "kafka-source",
       "source_type": "kafka"
     }

--- a/quickwit-metastore/test-data/index-metadata/v1-9538b1b7051ec08b3b442298cd7ba362.expected.json
+++ b/quickwit-metastore/test-data/index-metadata/v1-9538b1b7051ec08b3b442298cd7ba362.expected.json
@@ -72,7 +72,10 @@
   },
   "sources": [
     {
-      "params": {},
+      "params": {
+        "client_params": {},
+        "topic": "kafka-topic"
+      },
       "source_id": "kafka-source",
       "source_type": "kafka"
     }

--- a/quickwit-metastore/test-data/index-metadata/v1-9538b1b7051ec08b3b442298cd7ba362.json
+++ b/quickwit-metastore/test-data/index-metadata/v1-9538b1b7051ec08b3b442298cd7ba362.json
@@ -72,7 +72,10 @@
   },
   "sources": [
     {
-      "params": {},
+      "params": {
+        "client_params": {},
+        "topic": "kafka-topic"
+      },
       "source_id": "kafka-source",
       "source_type": "kafka"
     }


### PR DESCRIPTION
### Description
Use an enum rather than JSON value for storing source params, which indirectly validates the content of the params provided by the user. To get this PR out in a few hours for the release, I took a few shortcuts :/

### How was this PR tested?
In progress
