### PR TITLE
Fix Rest API docs

### DIFF
--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -7,14 +7,6 @@ position: 9
 
 All the API endpoints start with the `api/v1/` prefix. `v1` indicates that we are currently using version 1 of the API.
 
-
-## Format
-
-The API uses **JSON** encoded as **UTF-8**. The body of POST and PUT requests must be a JSON object and their `Content-Type` header should be set to `application/json; charset=UTF-8`.
-
-The response for the /search endpoint is always a JSON object, and the content type is always `application/json; charset=UTF-8.`
-The response for the /search/stream endpoint is a HTTP stream. Depending on the client capability it is a HTTP1.1 [chunked transfer encoded stream](https://en.wikipedia.org/wiki/Chunked_transfer_encoding) or a HTTP2 stream.
-
 ### Parameters
 
 Parameters passed in the URL must be properly URL-encoded, using the UTF-8 encoding for non-ASCII characters.
@@ -40,7 +32,7 @@ Failed requests return a 4xx HTTP status code. The response body of failed reque
 ### Search in an index
 
 ```
-GET api/v1/indexes/<index id>/search
+GET api/v1/indexes/<index id>/search?query=searchterm
 ```
 
 Search for documents matching a query in the given index `<index id>`.
@@ -61,11 +53,13 @@ Search for documents matching a query in the given index `<index id>`.
 | **endTimestamp**           | `i64`       		    | If set, restrict search to documents with a `timestamp < end_timestamp`                                                            |                                                                                     |
 | **startOffset**            | `Integer`     	    | Number of documents to skip                                                                | `0`                                                                                             |
 | **maxHits**                | `Integer`          | Maximum number of hits to return (by default 20)                                                            | `20`                                                                                            |
-| **searchFields**           | `String`      		  | Fields to search on if no field name is specified in the query. Comma-separated list, e.g. "field1,field2" | index_config.search_settings.default_search_fields                                                                                             |
+| **searchField**           | `[String]`      		  | Fields to search on if no field name is specified in the query. Comma-separated list, e.g. "field1,field2" | index_config.search_settings.default_search_fields                                                                                             |
 | **format**                 | `Enum`           	| The output format. Allowed values are "json" or "prettyjson" 						 | `prettyjson`                                                                                            |
 
 
 #### Response
+
+The response for the is a JSON object, and the content type is `application/json; charset=UTF-8.`
 
 | Field                | Description                    |    Type    |
 | -------------------- | ------------------------------ | :--------: |
@@ -76,7 +70,7 @@ Search for documents matching a query in the given index `<index id>`.
 ### Search stream in an index
 
 ```
-GET api/v1/indexes/<index id>/search/stream
+GET api/v1/indexes/<index id>/search/stream?query=searchterm
 ```
 
 Streams field values from ALL documents matching a search query in the given index `<index id>`, in a specified output format among the following:
@@ -103,13 +97,14 @@ The endpoint will return 10 million values if 10 million documents match the que
 |----------|------|-------------|---------------|
 | **query** | `String` | Query text. See the [query language doc](query-language.md) (mandatory) | |
 | **fastField** | `String` | Name of a field to retrieve from documents. This field must be marked as "fast" in the index config. (mandatory)| |
-| **searchFields** | `[String]` | Fields to search on. Comma-separated list, e.g. "field1,field2" | index_config.search_settings.default_search_fields    |
+| **searchField** | `[String]` | Fields to search on. Comma-separated list, e.g. "field1,field2" | index_config.search_settings.default_search_fields    |
 | **startTimestamp** | `i64` | If set, restrict search to documents with a `timestamp >= start_timestamp` | |
-| **endTimestamp** | `i64` | If set, restrict search to documents with a `timestamp < end_timestamp`` | |
+| **endTimestamp** | `i64` | If set, restrict search to documents with a `timestamp < end_timestamp` | |
 | **outputFormat** | `String` | Response output format. `csv` or `clickHouseRowBinary`  | `csv` |
 
 
 #### Response
+
 The response is an HTTP stream. Depending on the client's capability, it is an HTTP1.1 [chunked transfer encoded stream](https://en.wikipedia.org/wiki/Chunked_transfer_encoding) or an HTTP2 stream.
 
 It returns a list of all the field values from documents matching the query. The field must be marked as "fast" in the index config for this to work. 


### PR DESCRIPTION
improve GET docs
Remove Format block with reference to POST/PUT, there are no POST/PUT
rename searchFields parameter to searchField

