### PR TITLE
improve rest api error formatting

### DIFF
--- a/quickwit-doc-mapper/src/error.rs
+++ b/quickwit-doc-mapper/src/error.rs
@@ -21,10 +21,9 @@ use thiserror::Error;
 
 // TODO improve me and my error messages :)
 
-#[derive(Error, Debug)]
-#[error("Invalid query syntax: `{0}`")]
-
 /// Failed to parse query.
+#[derive(Error, Debug)]
+#[error("{0}")]
 pub struct QueryParserError(#[from] anyhow::Error);
 
 impl From<tantivy::query::QueryParserError> for QueryParserError {

--- a/quickwit-proto/src/lib.rs
+++ b/quickwit-proto/src/lib.rs
@@ -23,6 +23,8 @@ mod quickwit;
 #[macro_use]
 extern crate serde;
 
+use std::fmt::{self, Display};
+
 pub use cluster::*;
 pub use quickwit::*;
 
@@ -39,5 +41,11 @@ impl From<SearchStreamRequest> for SearchRequest {
             sort_by_field: None,
             sort_order: None,
         }
+    }
+}
+
+impl Display for SplitSearchError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "({}, split_id: {})", self.error, self.split_id)
     }
 }

--- a/quickwit-search/src/leaf.rs
+++ b/quickwit-search/src/leaf.rs
@@ -278,7 +278,7 @@ pub async fn leaf_search(
         .failed_splits
         .extend(errors.iter().map(|(split_id, err)| SplitSearchError {
             split_id: split_id.to_string(),
-            error: format!("{:?}", err),
+            error: format!("{}", err),
             retryable_error: true,
         }));
     Ok(merged_search_response)

--- a/quickwit-search/src/root.rs
+++ b/quickwit-search/src/root.rs
@@ -103,10 +103,13 @@ pub async fn root_search(
 
     if !leaf_search_response.failed_splits.is_empty() {
         error!(failed_splits = ?leaf_search_response.failed_splits, "Leaf search response contains at least one failed split.");
-        return Err(SearchError::InternalError(format!(
-            "{:?}",
-            leaf_search_response.failed_splits
-        )));
+        let errors: String = leaf_search_response
+            .failed_splits
+            .iter()
+            .map(|splits| format!("{}", splits))
+            .collect::<Vec<_>>()
+            .join(", ");
+        return Err(SearchError::InternalError(errors));
     }
 
     // Create a hash map of PartialHit with split as a key.

--- a/quickwit-serve/src/error.rs
+++ b/quickwit-serve/src/error.rs
@@ -28,11 +28,11 @@ use warp::hyper::StatusCode;
 pub enum ApiError {
     #[error("InvalidArgument: {0}.")]
     InvalidArgument(String),
-    // TODO rely on some an error serialization in the messsage
+    // TODO rely on some an error serialization in the message
     // to rebuild a structured SearchError, (the tonic Code is pretty useless)
     // and build a meaningful ApiError instead of this
     // silly wrapping.
-    #[error("Search error. {0}.")]
+    #[error("Search error. {0}")]
     SearchError(#[from] SearchError),
     #[error("Cluster error. {0}.")]
     ClusterError(#[from] ClusterError),


### PR DESCRIPTION
before
```
"error": "Search error. Internal error: `[SplitSearchError { error: \"InvalidQuery(\\\"Invalid query syntax: `Field does not exists: '\\\\\\\"asdf\\\\\\\"'`\\\")\", split_id: \"01FS4C5YHK92E1VB1AHSQ26B7X\", retryable_error: true }]`.."
```
after
```
"error": "Search error. Internal error: `(Invalid query: Field does not exists: '\"asdf\"', split_id: 01FS4C5YHK92E1VB1AHSQ26B7X)`."
```
