### PR TITLE
Adds support for custom s3 endpoint.

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,6 +12,7 @@ on:
       - "quickwit-*/**"
 
 env:
+  QW_S3_ENDPOINT: "http://localstack:4566"
   AWS_DEFAULT_REGION  : "localhost"
   AWS_ACCESS_KEY_ID   : "placeholder"
   AWS_SECRET_ACCESS_KEY: "placeholder"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ The process is simple and fast. Upon your first pull request, you will be prompt
 1. Install Docker (https://docs.docker.com/engine/install/) and Docker Compose (https://docs.docker.com/compose/install/)
 2. Install awslocal https://github.com/localstack/awscli-local
 3. Start the external services with `make docker-compose-up`
-5. Run `QW_ENV=LOCAL cargo test --all-features`
+5. Run `QW_S3_ENDPOINT=http://localhost:4566 cargo test --all-features`
 
 ## Running services such as Amazon Kinesis or S3, Kafka, or PostgreSQL locally.
 1. Ensure Docker and Docker Compose are correctly installed on your machine (see above)
@@ -48,8 +48,8 @@ The process is simple and fast. Upon your first pull request, you will be prompt
 ## Building binaries
 
 Currently, we use [cross](https://github.com/rust-embedded/cross) to build Quickwit binaries for different architectures.
-For this to work, we've had to customize the docker images cross uses. These customizations can be found in docker files located in `./cross-images` folder. To make cross take into account any change on those 
-docker files, you will need to build and push the images on dockerhub by running `make cross-images`. 
+For this to work, we've had to customize the docker images cross uses. These customizations can be found in docker files located in `./cross-images` folder. To make cross take into account any change on those
+docker files, you will need to build and push the images on dockerhub by running `make cross-images`.
 We also have nightly builds that are pushed to dockerhub. This helps continiously check our binaries are still built even with external dependency update. Successful builds let you accessed the artifacts for the next three days. Release builds always have their artifacts attached to the release.
 
 ## Testing release (alpha, beta, rc)

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ fmt:
 # `make test-all` starts the Docker services and runs all the tests.
 # `make -k test-all docker-compose-down`, tears down the Docker services after running all the tests.
 test-all: docker-compose-up
-	QW_ENV=local AWS_ACCESS_KEY_ID=ignored AWS_SECRET_ACCESS_KEY=ignored cargo test --all-features
+	QW_S3_ENDPOINT=http://localhost:4566 AWS_ACCESS_KEY_ID=ignored AWS_SECRET_ACCESS_KEY=ignored cargo test --all-features
 
 # This will build and push all custom cross images for cross-compilation.
 # You will need to login into Docker Hub with the `quickwit` account.
@@ -59,7 +59,7 @@ build:
 	esac
 
 # Usage:
-# `BINARY_FILE=path/to/quickwit/binary BINARY_VERSION=0.1.0 ARCHIVE_NAME=quickwit make archive` 
+# `BINARY_FILE=path/to/quickwit/binary BINARY_VERSION=0.1.0 ARCHIVE_NAME=quickwit make archive`
 # - BINARY_FILE: Path of the quickwit binary file.
 # - BINARY_VERSION: Version of the quickwit binary.
 # - ARCHIVE_NAME: Name of the resulting archive file (without extension).

--- a/docs/reference/storage-uri.md
+++ b/docs/reference/storage-uri.md
@@ -7,7 +7,7 @@ In Quickwit, Storage URIs refer to different kinds of storage.
 
 Generally speaking, you can use a storage URI or a regular file path wherever you would have expected a file path.
 
- 
+
 For instance
 
 - when configuring the index storage. (Passed as the `index_uri` in the index command line.)
@@ -26,7 +26,7 @@ The following are valid local file system URIs
 - /var/quickwit
 - file:///var/quickwit
 - /home/quickwit/data
-- ~/data 
+- ~/data
 - ./quickwit
 ```
 
@@ -64,13 +64,20 @@ Quickwit will detect the S3 credentials using the first successful method in thi
 
 ### Region
 
-The region will be detected using the first successful method in this list (order matters)
-
+The region or custom endpoint will be detected using the first successful method in this list (order matters)
 - `AWS_DEFAULT_REGION` environment variable
 - `AWS_REGION` environment variable
 - Amazon’s instance metadata API [https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)
 
-:::caution
-Custom endpoints are not supported yet.
+### S3-compatible Objective storage like Minio
 
-:::
+
+Quickwit can target other S3-compatible storage like MinIO.
+This is done by setting an endpoint url in the `QW_S3_ENDPOINT` environment variable.
+
+In this case, the region will be ignored.
+
+For instance:
+```bash
+export QW_S3_ENDPOINT=http://localhost:9000/
+```

--- a/quickwit-cli/tests/cli.rs
+++ b/quickwit-cli/tests/cli.rs
@@ -709,7 +709,7 @@ async fn test_all_local_index() -> Result<()> {
 #[tokio::test]
 #[serial]
 #[cfg_attr(not(feature = "ci-test"), ignore)]
-async fn test_all_with_s3_localstack_cli() -> Result<()> {
+async fn test_cmd_all_with_s3_localstack_cli() -> Result<()> {
     let index_id = append_random_suffix("test-all--cli-s3-localstack");
     let test_env = create_test_env(index_id, TestStorageType::S3)?;
     make_command(
@@ -723,11 +723,11 @@ async fn test_all_with_s3_localstack_cli() -> Result<()> {
     .assert()
     .success();
 
-    let index_metadata = test_env
+    test_env
         .metastore()
         .index_metadata(&test_env.index_id)
-        .await;
-    assert_eq!(index_metadata.is_ok(), true);
+        .await
+        .unwrap();
 
     ingest_docs(test_env.resource_files["logs"].as_path(), &test_env);
 
@@ -797,7 +797,7 @@ async fn test_all_with_s3_localstack_cli() -> Result<()> {
 #[tokio::test]
 #[serial]
 #[cfg_attr(not(feature = "ci-test"), ignore)]
-async fn test_all_with_s3_localstack_internal_api() -> Result<()> {
+async fn test_cmd_all_with_s3_localstack_internal_api() -> Result<()> {
     let index_id = append_random_suffix("test-all--cli-API");
     let test_env = create_test_env(index_id, TestStorageType::S3)?;
     let args = CreateIndexArgs {

--- a/quickwit-common/src/lib.rs
+++ b/quickwit-common/src/lib.rs
@@ -33,26 +33,6 @@ pub use checklist::{print_checklist, run_checklist, BLUE_COLOR, GREEN_COLOR, RED
 pub use coolid::new_coolid;
 use tracing::{error, info};
 
-#[derive(Debug, PartialEq, Eq)]
-pub enum QuickwitEnv {
-    UNSET,
-    LOCAL,
-}
-
-impl Default for QuickwitEnv {
-    fn default() -> Self {
-        Self::UNSET
-    }
-}
-
-pub fn get_quickwit_env() -> QuickwitEnv {
-    match std::env::var("QW_ENV") {
-        Ok(val) if val.to_lowercase().trim() == "local" => QuickwitEnv::LOCAL,
-        Ok(val) => panic!("QW_ENV value `{}` is not supported", val),
-        Err(_) => QuickwitEnv::UNSET,
-    }
-}
-
 pub fn chunk_range(range: Range<usize>, chunk_size: usize) -> impl Iterator<Item = Range<usize>> {
     range.clone().step_by(chunk_size).map(move |block_start| {
         let block_end = (block_start + chunk_size).min(range.end);

--- a/quickwit-metastore/src/metastore_resolver.rs
+++ b/quickwit-metastore/src/metastore_resolver.rs
@@ -71,12 +71,12 @@ pub fn quickwit_metastore_uri_resolver() -> &'static MetastoreUriResolver {
         let mut builder = MetastoreUriResolver::builder()
             .register("ram", FileBackedMetastoreFactory::default())
             .register("file", FileBackedMetastoreFactory::default())
-            .register("s3", FileBackedMetastoreFactory::default())
-            .register("s3+localstack", FileBackedMetastoreFactory::default());
+            .register("s3", FileBackedMetastoreFactory::default());
         #[cfg(feature = "postgres")]
         {
-            builder = builder.register("postgres", PostgresqlMetastoreFactory::default());
-            builder = builder.register("postgresql", PostgresqlMetastoreFactory::default());
+            builder = builder
+                .register("postgres", PostgresqlMetastoreFactory::default())
+                .register("postgresql", PostgresqlMetastoreFactory::default());
         }
 
         builder.build()
@@ -113,13 +113,9 @@ mod tests {
     use crate::quickwit_metastore_uri_resolver;
 
     #[tokio::test]
-    async fn test_metastore_resolver_should_not_raise_errors_on_file_and_s3() -> anyhow::Result<()>
-    {
+    async fn test_metastore_resolver_should_not_raise_errors_on_file() -> anyhow::Result<()> {
         let metastore_resolver = quickwit_metastore_uri_resolver();
         metastore_resolver.resolve("file://").await?;
-        metastore_resolver
-            .resolve("s3://bucket/path/to/object")
-            .await?;
         Ok(())
     }
 

--- a/quickwit-storage/src/error.rs
+++ b/quickwit-storage/src/error.rs
@@ -30,7 +30,7 @@ pub enum StorageErrorKind {
     DoesNotExist,
     /// The request credentials do not allow for this operation.
     Unauthorized,
-    /// A third-party service forbids this operation.
+    /// A third-party service forbids this operation, or is misconfigured.
     Service,
     /// Any generic internal error.
     InternalError,

--- a/quickwit-storage/src/lib.rs
+++ b/quickwit-storage/src/lib.rs
@@ -56,7 +56,7 @@ pub use self::bundle_storage::{BundleStorage, BundleStorageFileOffsets};
 pub use self::cache::MockCache;
 pub use self::local_file_storage::{LocalFileStorage, LocalFileStorageFactory};
 pub use self::object_storage::{
-    MultiPartPolicy, RegionProvider, S3CompatibleObjectStorage, S3CompatibleObjectStorageFactory,
+    MultiPartPolicy, S3CompatibleObjectStorage, S3CompatibleObjectStorageFactory,
 };
 pub use self::prefix_storage::add_prefix_to_storage;
 pub use self::ram_storage::{RamStorage, RamStorageBuilder};

--- a/quickwit-storage/src/object_storage/mod.rs
+++ b/quickwit-storage/src/object_storage/mod.rs
@@ -21,9 +21,7 @@ mod error;
 
 mod s3_compatible_storage;
 pub use self::s3_compatible_storage::S3CompatibleObjectStorage;
-pub use self::s3_compatible_storage_uri_resolver::{
-    RegionProvider, S3CompatibleObjectStorageFactory,
-};
+pub use self::s3_compatible_storage_uri_resolver::S3CompatibleObjectStorageFactory;
 
 mod policy;
 pub use crate::object_storage::policy::MultiPartPolicy;

--- a/quickwit-storage/src/object_storage/s3_compatible_storage.rs
+++ b/quickwit-storage/src/object_storage/s3_compatible_storage.rs
@@ -56,14 +56,14 @@ const POOL_IDLE_TIMEOUT: u64 = 10;
 
 /// Returns the region to use for the S3 object storage.
 ///
-/// This function test different methods in turn to get the region.
+/// This function tests different methods in turn to get the region.
 /// One of this method runs a GET request on an EC2 API Endpoint.
 /// If this endpoint is inaccessible, this can block for a few seconds.
 ///
 /// For this reason, this function needs to be called in a lazy manner.
 /// We cannot call it once when we create the
 /// `S3CompatibleObjectStorageFactory` for instance, as it would
-/// impact the start of quickwit in context where S3 is not used..
+/// impact the start of quickwit in a context where S3 is not used.
 ///
 /// This function caches its results.
 fn sniff_s3_region() -> anyhow::Result<Region> {
@@ -92,7 +92,7 @@ fn region_from_str(region_str: &str) -> anyhow::Result<Region> {
     // We require custom endpoints to explicitely state the http/https protocol`.
     if !region_str.starts_with("http") {
         anyhow::bail!(
-            "Invalid aws region. Quickwit expects an aws region code like `us-east-1` or a \
+            "Invalid AWS region. Quickwit expects an AWS region code like `us-east-1` or a \
              http:// endpoint"
         );
     }
@@ -108,7 +108,7 @@ fn s3_region_env_var() -> Option<String> {
             info!(
                 env_var_key = env_var_key,
                 env_var = env_var.as_str(),
-                "Found AWS Region from environment variable"
+                "Setting AWS Region from environment variable."
             );
             return Some(env_var);
         }
@@ -121,7 +121,7 @@ fn region_from_env_variable() -> anyhow::Result<Option<Region>> {
         match region_from_str(&region_str) {
             Ok(region) => Ok(Some(region)),
             Err(err) => {
-                error!(err=?err, "Failed to parse region set from env_var.");
+                error!(err=?err, "Failed to parse region set from environment variable.");
                 Err(err)
             }
         }
@@ -140,7 +140,7 @@ fn region_from_ec2_instance() -> anyhow::Result<Region> {
         .get()
         .context("Failed to get AWS instance metadata API.")?;
     Region::from_str(instance_metadata.region)
-        .context("Failed to parse Region fetched from AWS instance metadata API")
+        .context("Failed to parse region fetched from AWS instance metadata API")
 }
 
 /// S3 Compatible object storage implementation.

--- a/quickwit-storage/src/object_storage/s3_compatible_storage_uri_resolver.rs
+++ b/quickwit-storage/src/object_storage/s3_compatible_storage_uri_resolver.rs
@@ -17,129 +17,23 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use std::str::FromStr;
 use std::sync::Arc;
 
-use ec2_instance_metadata::{InstanceMetadata, InstanceMetadataClient};
-use once_cell::sync::OnceCell;
-use quickwit_common::{get_quickwit_env, QuickwitEnv};
 pub use rusoto_core::Region;
 
 use crate::{S3CompatibleObjectStorage, StorageFactory};
 
-/// The region provider lazily returns a region.
-///
-/// The "lazy" part was introduced following #478.
-/// Indeed, sniffing the Amazon S3 region that should be used
-/// requires performing a request on a URI with a timeout of 2s.
-///
-/// This call was making everything use of quickwit slower.
-/// By using this region provider, we only perform this call if
-/// the s3 protocol is actually used.
-#[derive(Debug)]
-pub enum RegionProvider {
-    /// Quickwit will try to sniff the right region for Amazon S3.
-    ///
-    /// It will try the following method in sequence to identify the one that should be used,
-    /// and stop as soon as a region is found.
-    /// - `AWS_DEFAULT_REGION` environment variable
-    /// - `AWS_REGION` environment variable
-    /// - region from ec2 instance metadata
-    /// - default to us-east-1
-    S3,
-    /// Target a local localstack instance, mocking Amazon S3.
-    /// This is mostly useful for integration tests.
-    ///
-    /// If the QW_ENV environment variable is set to LOCAL,
-    /// quickwit will try to connect to `localhost:4566`
-    /// otherwise, it will try to connect to `localstack:4566`.
-    Localstack,
-}
-
-/// Returns a localstack region (used for testing).
-fn localstack_region() -> Region {
-    let endpoint = if get_quickwit_env() == QuickwitEnv::LOCAL {
-        "http://localhost:4566".to_string()
-    } else {
-        "http://localstack:4566".to_string()
-    };
-    Region::Custom {
-        name: "localstack".to_string(),
-        endpoint,
-    }
-}
-
-fn sniff_s3_default_region() -> Region {
-    static CACHED_S3_DEFAULT_REGION: OnceCell<Region> = OnceCell::new();
-    CACHED_S3_DEFAULT_REGION
-        .get_or_init(|| {
-            region_from_env_variable()
-                .or_else(region_from_ec2_instance)
-                .unwrap_or_default()
-        })
-        .clone()
-}
-
-impl RegionProvider {
-    /// Returns the region to use for the S3 object storage.
-    pub fn get_region(&self) -> Region {
-        match self {
-            RegionProvider::S3 => sniff_s3_default_region(),
-            RegionProvider::Localstack => localstack_region(),
-        }
-    }
-}
-
 /// S3 Object storage Uri Resolver
-///
-/// The default implementation uses s3 as a protocol, and detects the region trying to us
-/// sequencially `AWS_DEFAULT_REGION` environment variable, `AWS_REGION` environment variable,
-/// region from ec2 instance metadata and lastly to default value `Region::UsEast1`.
-pub struct S3CompatibleObjectStorageFactory {
-    region_provider: RegionProvider,
-    protocol: &'static str,
-}
-
-impl S3CompatibleObjectStorageFactory {
-    /// Creates a new S3CompatibleObjetStorageFactory with the given AWS region.
-    pub fn new(region_provider: RegionProvider, protocol: &'static str) -> Self {
-        S3CompatibleObjectStorageFactory {
-            region_provider,
-            protocol,
-        }
-    }
-}
-
-fn region_from_env_variable() -> Option<Region> {
-    let region_str_from_env = std::env::var("AWS_DEFAULT_REGION")
-        .or_else(|_| std::env::var("AWS_REGION"))
-        .ok()?;
-    Region::from_str(&region_str_from_env).ok()
-}
-
-// Sniffes the EC2 region from the EC2 instance API.
-//
-// https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html
-fn region_from_ec2_instance() -> Option<Region> {
-    let instance_metadata_client: InstanceMetadataClient =
-        ec2_instance_metadata::InstanceMetadataClient::new();
-    let instance_metadata: InstanceMetadata = instance_metadata_client.get().ok()?;
-    Region::from_str(instance_metadata.region).ok()
-}
-
-impl Default for S3CompatibleObjectStorageFactory {
-    fn default() -> Self {
-        S3CompatibleObjectStorageFactory::new(RegionProvider::S3, "s3")
-    }
-}
+#[derive(Default)]
+pub struct S3CompatibleObjectStorageFactory;
 
 impl StorageFactory for S3CompatibleObjectStorageFactory {
     fn protocol(&self) -> String {
-        self.protocol.to_string()
+        "s3".to_string()
     }
 
     fn resolve(&self, uri: &str) -> crate::StorageResult<std::sync::Arc<dyn crate::Storage>> {
-        let storage = S3CompatibleObjectStorage::from_uri(self.region_provider.get_region(), uri)?;
+        let storage = S3CompatibleObjectStorage::from_uri(uri)?;
         Ok(Arc::new(storage))
     }
 }

--- a/quickwit-storage/src/storage_resolver.rs
+++ b/quickwit-storage/src/storage_resolver.rs
@@ -25,7 +25,7 @@ use once_cell::sync::OnceCell;
 
 use crate::local_file_storage::LocalFileStorageFactory;
 use crate::ram_storage::RamStorageFactory;
-use crate::{RegionProvider, S3CompatibleObjectStorageFactory, Storage, StorageResolverError};
+use crate::{S3CompatibleObjectStorageFactory, Storage, StorageResolverError};
 
 /// Quickwit supported storage resolvers.
 pub fn quickwit_storage_uri_resolver() -> &'static StorageUriResolver {
@@ -35,10 +35,6 @@ pub fn quickwit_storage_uri_resolver() -> &'static StorageUriResolver {
             .register(RamStorageFactory::default())
             .register(LocalFileStorageFactory::default())
             .register(S3CompatibleObjectStorageFactory::default())
-            .register(S3CompatibleObjectStorageFactory::new(
-                RegionProvider::Localstack,
-                "s3+localstack",
-            ))
             .build()
     })
 }
@@ -95,10 +91,7 @@ impl StorageUriResolver {
         StorageUriResolver::builder()
             .register(RamStorageFactory::default())
             .register(LocalFileStorageFactory::default())
-            .register(S3CompatibleObjectStorageFactory::new(
-                RegionProvider::Localstack,
-                "s3+localstack",
-            ))
+            .register(S3CompatibleObjectStorageFactory::default())
             .build()
     }
 

--- a/quickwit-storage/tests/s3_storage.rs
+++ b/quickwit-storage/tests/s3_storage.rs
@@ -22,15 +22,13 @@
 
 use std::path::Path;
 
-use quickwit_storage::{MultiPartPolicy, RegionProvider, S3CompatibleObjectStorage, Storage};
+use quickwit_storage::{MultiPartPolicy, S3CompatibleObjectStorage, Storage};
 
 #[tokio::test]
 #[cfg_attr(not(feature = "ci-test"), ignore)]
 async fn test_upload_single_part_file() -> anyhow::Result<()> {
     let _ = tracing_subscriber::fmt::try_init();
-    let localstack_region = RegionProvider::Localstack.get_region();
-    let object_storage =
-        S3CompatibleObjectStorage::new(localstack_region, "quickwit-integration-tests")?;
+    let object_storage = S3CompatibleObjectStorage::from_uri("s3://quickwit-integration-tests")?;
     object_storage
         .put(
             Path::new("test-s3-compatible-storage/hello_small.txt"),
@@ -44,9 +42,8 @@ async fn test_upload_single_part_file() -> anyhow::Result<()> {
 #[cfg_attr(not(feature = "ci-test"), ignore)]
 async fn test_upload_multiple_part_file() -> anyhow::Result<()> {
     let _ = tracing_subscriber::fmt::try_init();
-    let localstack_region = RegionProvider::Localstack.get_region();
     let mut object_storage =
-        S3CompatibleObjectStorage::new(localstack_region, "quickwit-integration-tests")?;
+        S3CompatibleObjectStorage::from_uri("s3://quickwit-integration-tests")?;
     object_storage.set_policy(MultiPartPolicy {
         target_part_num_bytes: 5 * 1_024 * 1_024, //< the minimum on S3 is 5MB.
         max_num_parts: 10_000,
@@ -70,9 +67,8 @@ async fn test_upload_multiple_part_file() -> anyhow::Result<()> {
 // Weirdly this does not work for localstack. The error messages seem off.
 async fn test_suite_on_s3_storage() -> anyhow::Result<()> {
     let _ = tracing_subscriber::fmt::try_init();
-    let localstack_region = RegionProvider::Localstack.get_region();
     let mut object_storage =
-        S3CompatibleObjectStorage::new(localstack_region, "quickwit-integration-tests")?;
+        S3CompatibleObjectStorage::from_uri("s3://quickwit-integration-tests")?;
     quickwit_storage::storage_test_suite(&mut object_storage).await?;
     Ok(())
 }


### PR DESCRIPTION
This removes our trickery to use localstack,
and replaces it by a way to set a specific
endpoint via an environment variable:
`QW_S3_REGION`.

Closes #1037
