### PR TITLE
Pleasing clippy after rust 1.58.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
   ci-passes:
     name: CI passes
     runs-on: ubuntu-latest
+    # See https://github.com/quickwit-inc/quickwit-builder
     container: public.ecr.aws/l6o9a3f9/quickwit-builder:latest
     needs:
       - lint

--- a/quickwit-cli/src/index.rs
+++ b/quickwit-cli/src/index.rs
@@ -543,12 +543,12 @@ fn print_descriptive_stats(values: &[usize]) {
     let min_val = values.iter().min().unwrap();
     let max_val = values.iter().max().unwrap();
     println!(
-        "{:<35} {} ± {} in [{} … {}]",
+        "{:<35} {:>2} ± {} in [{} … {}]",
         "Mean ± σ in [min … max]:".color(GREEN_COLOR),
-        format!("{:>2}", mean_val),
-        format!("{}", std_val),
-        format!("{}", min_val),
-        format!("{}", max_val),
+        mean_val,
+        std_val,
+        min_val,
+        max_val,
     );
     let q1 = percentile(values, 1);
     let q25 = percentile(values, 50);
@@ -558,11 +558,11 @@ fn print_descriptive_stats(values: &[usize]) {
     println!(
         "{:<35} [{}, {}, {}, {}, {}]",
         "Quantiles [1%, 25%, 50%, 75%, 99%]:".color(GREEN_COLOR),
-        format!("{}", q1),
-        format!("{}", q25),
-        format!("{}", q50),
-        format!("{}", q75),
-        format!("{}", q99),
+        q1,
+        q25,
+        q50,
+        q75,
+        q99,
     );
 }
 

--- a/quickwit-cli/src/split.rs
+++ b/quickwit-cli/src/split.rs
@@ -228,7 +228,7 @@ async fn list_split_cli(args: ListSplitArgs) -> anyhow::Result<()> {
     )?;
     let filtered_splits_table = make_list_splits_table(filtered_splits);
 
-    println!("{}", filtered_splits_table.to_string());
+    println!("{filtered_splits_table}");
 
     Ok(())
 }

--- a/quickwit-search/src/service.rs
+++ b/quickwit-search/src/service.rs
@@ -106,10 +106,7 @@ impl SearchServiceImpl {
 
 fn deserialize_doc_mapper(doc_mapper_str: &str) -> crate::Result<Arc<dyn DocMapper>> {
     let doc_mapper = serde_json::from_str::<Arc<dyn DocMapper>>(doc_mapper_str).map_err(|err| {
-        SearchError::InternalError(format!(
-            "Failed to deserialize doc mapper: `{}`",
-            err.to_string()
-        ))
+        SearchError::InternalError(format!("Failed to deserialize doc mapper: `{err}`"))
     })?;
     Ok(doc_mapper)
 }


### PR DESCRIPTION
Remove the use of a custom container.
Added clippy suggestion from rust 1.58
Added Makefile rules to refresh the quickwit-builder image used in CI.