### PR TITLE
Fixing the coverage CI.

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,7 +12,7 @@ on:
       - "quickwit-*/**"
 
 env:
-  QW_S3_ENDPOINT: "http://localstack:4566"
+  QW_S3_ENDPOINT: "http://localhost:4566" # Services are exposed as localhost because we are not running coverage in a container.
   AWS_DEFAULT_REGION  : "localhost"
   AWS_ACCESS_KEY_ID   : "placeholder"
   AWS_SECRET_ACCESS_KEY: "placeholder"
@@ -22,6 +22,8 @@ jobs:
   test:
     name: coverage
     runs-on: ubuntu-latest
+    # Setting a containing will require to fix the QW_S3_ENDPOINT to http://localstack:4566
+    # container: ---
     services:
       localstack:
         image: localstack/localstack:latest


### PR DESCRIPTION
This is a tricky problem.
In the current setting, localstack should be accessed via localhost,
not localstack.

This is because right now the CI tests are running on a host,
not in a dockerized environment.
(The services are running in containers)

I am not entirely sure how this is used to work.
