### PR TITLE
ISSUE-1086 Check and validate the query against the last schema before dispatching

### DIFF
--- a/quickwit-search/src/root.rs
+++ b/quickwit-search/src/root.rs
@@ -153,9 +153,8 @@ pub async fn root_search(
 
     // Merge the fetched docs.
     let hits = fetch_docs_responses
-        .iter()
-        .map(|response| response.hits.clone())
-        .flatten()
+        .into_iter()
+        .flat_map(|response| response.hits)
         .sorted_by(|hit1, hit2| {
             let value1 = if let Some(partial_hit) = &hit1.partial_hit {
                 partial_hit.sorting_field_value
@@ -220,9 +219,8 @@ fn jobs_to_leaf_request(
         search_request: Some(request_with_offset_0),
         split_metadata: jobs
             .iter()
-            .map(|job| {
-                extract_split_and_footer_offsets(split_metadata_map.get(&job.split_id).unwrap())
-            })
+            .filter_map(|job| split_metadata_map.get(&job.split_id))
+            .map(extract_split_and_footer_offsets)
             .collect(),
         doc_mapper: doc_mapper_str.to_string(),
         index_uri: index_uri.to_string(),
@@ -238,12 +236,12 @@ fn jobs_to_fetch_docs_request(
 ) -> FetchDocsRequest {
     let partial_hits = jobs
         .iter()
-        .map(|job| partial_hits_map.remove(&job.split_id).unwrap())
+        .filter_map(|job| partial_hits_map.remove(&job.split_id))
         .flatten()
         .collect_vec();
     let splits_footer_and_offsets = jobs
         .iter()
-        .map(|job| split_metadata_map.get(&job.split_id).unwrap())
+        .filter_map(|job| split_metadata_map.get(&job.split_id))
         .map(extract_split_and_footer_offsets)
         .collect_vec();
 

--- a/quickwit-search/src/root.rs
+++ b/quickwit-search/src/root.rs
@@ -215,13 +215,18 @@ fn jobs_to_leaf_request(
     request_with_offset_0.start_offset = 0;
     request_with_offset_0.max_hits += request.start_offset;
 
+    // collect split_id and footer offsets
+    let split_metadata: Vec<_> = jobs
+        .iter()
+        .filter_map(|job| split_metadata_map.get(&job.split_id))
+        .map(extract_split_and_footer_offsets)
+        .collect();
+    // we expect job's metadata existence (thus metadata_map does not miss any split_id)
+    debug_assert_eq!(jobs.len(), split_metadata.len());
+
     LeafSearchRequest {
         search_request: Some(request_with_offset_0),
-        split_metadata: jobs
-            .iter()
-            .filter_map(|job| split_metadata_map.get(&job.split_id))
-            .map(extract_split_and_footer_offsets)
-            .collect(),
+        split_metadata,
         doc_mapper: doc_mapper_str.to_string(),
         index_uri: index_uri.to_string(),
     }
@@ -234,16 +239,21 @@ fn jobs_to_fetch_docs_request(
     partial_hits_map: &mut HashMap<String, Vec<PartialHit>>,
     jobs: &[Job],
 ) -> FetchDocsRequest {
+    let partial_hits_map_size = partial_hits_map.len();
     let partial_hits = jobs
         .iter()
         .filter_map(|job| partial_hits_map.remove(&job.split_id))
         .flatten()
         .collect_vec();
+    debug_assert_eq!(partial_hits_map_size - partial_hits_map.len(), jobs.len());
+
     let splits_footer_and_offsets = jobs
         .iter()
         .filter_map(|job| split_metadata_map.get(&job.split_id))
         .map(extract_split_and_footer_offsets)
         .collect_vec();
+    // we expect job's metadata existence (thus metadata_map does not miss any split_id)
+    debug_assert_eq!(jobs.len(), splits_footer_and_offsets.len());
 
     FetchDocsRequest {
         partial_hits,

--- a/quickwit-search/src/root.rs
+++ b/quickwit-search/src/root.rs
@@ -1051,7 +1051,7 @@ mod tests {
         assert!(root_search(
             &quickwit_proto::SearchRequest {
                 index_id: "test-idx".to_string(),
-                query: "invalid_body:\"test\"".to_string(),
+                query: r#"invalid_body:"test""#.to_string(),
                 search_fields: vec!["body".to_string()],
                 start_timestamp: None,
                 end_timestamp: None,


### PR DESCRIPTION
This PR is first attempt to fix issue-1086 where query should be validated against current/last schema before dispatching to leaf node. It also tries to refactor/optimize code a bit to be (a bit) safer and faster.

What is not covered:
- Stream API (I think it's better to make it in another PR)